### PR TITLE
Graphs: Ignore 0 values

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -214,12 +214,16 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             calDB.setTime(scaleEntry.getDateTime());
 
             valuesWeight.add(new PointValue(calDB.get(field)-1, scaleEntry.getConvertedWeight(openScale.getSelectedScaleUser().scale_unit)));
-            valuesFat.add(new PointValue(calDB.get(field)-1, scaleEntry.getFat()));
-            valuesWater.add(new PointValue(calDB.get(field)-1, scaleEntry.getWater()));
-            valuesMuscle.add(new PointValue(calDB.get(field)-1, scaleEntry.getMuscle()));
-            valuesWaist.add(new PointValue(calDB.get(field)-1, scaleEntry.getWaist()));
-            valuesHip.add(new PointValue(calDB.get(field)-1, scaleEntry.getHip()));
-
+            if (scaleEntry.getFat() != 0.0f)
+                valuesFat.add(new PointValue(calDB.get(field)-1, scaleEntry.getFat()));
+            if (scaleEntry.getWater() != 0.0f)
+                valuesWater.add(new PointValue(calDB.get(field)-1, scaleEntry.getWater()));
+            if (scaleEntry.getMuscle() != 0.0f)
+                valuesMuscle.add(new PointValue(calDB.get(field)-1, scaleEntry.getMuscle()));
+            if (scaleEntry.getWaist() != 0.0f)
+                valuesWaist.add(new PointValue(calDB.get(field)-1, scaleEntry.getWaist()));
+            if (scaleEntry.getHip() != 0.0f)
+                valuesHip.add(new PointValue(calDB.get(field)-1, scaleEntry.getHip()));
         }
 
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -267,11 +267,16 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             scaleDataLastDays.add(histData);
 
             valuesWeight.add(new PointValue(i, histData.getConvertedWeight(currentScaleUser.scale_unit)));
-            valuesFat.add(new PointValue(i, histData.getFat()));
-            valuesWater.add(new PointValue(i, histData.getWater()));
-            valuesMuscle.add(new PointValue(i, histData.getMuscle()));
-            valuesWaist.add(new PointValue(i, histData.getWaist()));
-            valuesHip.add(new PointValue(i, histData.getHip()));
+            if (histData.getFat() != 0.0f)
+                valuesFat.add(new PointValue(i, histData.getFat()));
+            if (histData.getWater() != 0.0f)
+                valuesWater.add(new PointValue(i, histData.getWater()));
+            if (histData.getMuscle() != 0.0f)
+                valuesMuscle.add(new PointValue(i, histData.getMuscle()));
+            if (histData.getWaist() != 0.0f)
+                valuesWaist.add(new PointValue(i, histData.getWaist()));
+            if (histData.getHip() != 0.0f)
+                valuesHip.add(new PointValue(i, histData.getHip()));
 
             histDate.setTime(histData.getDateTime());
 


### PR DESCRIPTION
Graphs: Ignore 0 values. They are meaningless and just indicate a lack of data.
They also force the graph Y axis to go down to 0.

Signed-off-by: Jerome Flesch <jflesch@kwain.net>