### PR TITLE
History downloading is not supported with the Sanitas SBF-70 + new address prefix

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
@@ -135,7 +135,13 @@ public class BluetoothSanitasSbf70 extends BluetoothCommunication {
         return false;
     }
 
+    @Override
     public boolean initSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean historySupported() {
         return false;
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
@@ -116,6 +116,7 @@ public class BluetoothSanitasSbf70 extends BluetoothCommunication {
         ArrayList hwAddresses = new ArrayList();
         hwAddresses.add("C4BE84");
         hwAddresses.add("209148");
+        hwAddresses.add("F4B85E");
 
         return hwAddresses;
     }


### PR DESCRIPTION
- History downloading is not supported with the Sanitas SBF-70
- Sanitas SBF-70: Add BT address prefix reported by @nykroy