### PR TITLE
Add support for non-binary gender

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSbf70.java
@@ -184,7 +184,7 @@ public class BluetoothSanitasSbf70 extends BluetoothCommunication {
                             (byte) selectedUser.birthday.getMonth(),
                             (byte) selectedUser.birthday.getDate(),
                             (byte) selectedUser.body_height,
-                            (byte) (((1 - selectedUser.gender) << 7) | activity)
+                            (byte) (((selectedUser.isMale() ? 1 : 0) << 7) | activity)
                     });
                 } else {
                     // Get existing user information

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFDeurenberg.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFDeurenberg.java
@@ -26,10 +26,22 @@ public class BFDeurenberg extends EstimatedFatMetric {
 
     @Override
     public float getFat(ScaleUser user, ScaleData data) {
+        float genderVal = 0.0f;
+        switch (user.gender) {
+            case ScaleUser.MALE:
+                genderVal = 1.0f;
+                break;
+            case ScaleUser.FEMALE:
+                genderVal = 0.0f;
+                break;
+            default:
+                genderVal = 0.5;
+                break;
+        }
         if (user.getAge(data.getDateTime()) >= 16) {
-            return (1.2f * data.getBMI(user.body_height)) + (0.23f*user.getAge(data.getDateTime())) - (10.8f*(1-user.gender)) - 5.4f;
+            return (1.2f * data.getBMI(user.body_height)) + (0.23f*user.getAge(data.getDateTime())) - (10.8f*genderVal) - 5.4f;
         }
 
-        return (1.294f * data.getBMI(user.body_height)) + (0.20f*user.getAge(data.getDateTime())) - (11.4f*(1-user.gender)) - 8.0f;
+        return (1.294f * data.getBMI(user.body_height)) + (0.20f*user.getAge(data.getDateTime())) - (11.4f*genderVal) - 8.0f;
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFDeurenbergII.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFDeurenbergII.java
@@ -26,10 +26,9 @@ public class BFDeurenbergII extends EstimatedFatMetric {
 
     @Override
     public float getFat(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return (data.getBMI(user.body_height) * 1.2f) + (user.getAge(data.getDateTime()) * 0.23f) - 16.2f;
-        }
+        float maleFat = (data.getBMI(user.body_height) * 1.2f) + (user.getAge(data.getDateTime()) * 0.23f) - 16.2f;
+        float femaleFat = (data.getBMI(user.body_height) * 1.2f) + (user.getAge(data.getDateTime()) * 0.23f) - 5.4f;
 
-        return (data.getBMI(user.body_height) * 1.2f) + (user.getAge(data.getDateTime()) * 0.23f) - 5.4f;
+        return Utils.genderizeMetric(user, maleFat, femaleFat);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFEddy.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFEddy.java
@@ -26,10 +26,9 @@ public class BFEddy extends EstimatedFatMetric {
 
     @Override
     public float getFat(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return (1.281f* data.getBMI(user.body_height)) - 10.13f;
-        }
+        float maleFat = (1.281f* data.getBMI(user.body_height)) - 10.13f;
+        float femaleFat = (1.48f* data.getBMI(user.body_height)) - 7.0f;
 
-        return (1.48f* data.getBMI(user.body_height)) - 7.0f;
+        return Utils.genderizeMetric(user, maleFat, femaleFat);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFGallagher.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFGallagher.java
@@ -26,12 +26,12 @@ public class BFGallagher extends EstimatedFatMetric {
 
     @Override
     public float getFat(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            // non-asian male
-            return 64.5f - 848.0f * (1.0f / data.getBMI(user.body_height)) + 0.079f * user.getAge(data.getDateTime()) - 16.4f + 0.05f * user.getAge(data.getDateTime()) + 39.0f * (1.0f / data.getBMI(user.body_height));
-        }
+        // non-asian male
+        float maleFat = 64.5f - 848.0f * (1.0f / data.getBMI(user.body_height)) + 0.079f * user.getAge(data.getDateTime()) - 16.4f + 0.05f * user.getAge(data.getDateTime()) + 39.0f * (1.0f / data.getBMI(user.body_height));
 
         // non-asian female
-        return 64.5f - 848.0f * (1.0f / data.getBMI(user.body_height)) + 0.079f * user.getAge(data.getDateTime());
+        float femaleFat = 64.5f - 848.0f * (1.0f / data.getBMI(user.body_height)) + 0.079f * user.getAge(data.getDateTime());
+
+        return Utils.genderizeMetric(user, maleFat, femaleFat);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFGallagherAsian.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/BFGallagherAsian.java
@@ -26,12 +26,12 @@ public class BFGallagherAsian extends EstimatedFatMetric {
 
     @Override
     public float getFat(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            // asian male
-            return 51.9f - 740.0f * (1.0f / data.getBMI(user.body_height)) + 0.029f * user.getAge(data.getDateTime());
-        }
+        // asian male
+        float maleFat = 51.9f - 740.0f * (1.0f / data.getBMI(user.body_height)) + 0.029f * user.getAge(data.getDateTime());
 
         // asian female
-        return 64.8f - 752.0f * (1.0f / data.getBMI(user.body_height)) + 0.016f * user.getAge(data.getDateTime());
+        float femaleFat = 64.8f - 752.0f * (1.0f / data.getBMI(user.body_height)) + 0.016f * user.getAge(data.getDateTime());
+
+        return Utils.genderizeMetric(user, maleFat, femaleFat);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/LBWBoer.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/LBWBoer.java
@@ -27,10 +27,9 @@ public class LBWBoer extends EstimatedLBWMetric {
 
     @Override
     public float getLBW(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return (0.4071f * data.getWeight()) + (0.267f * user.body_height) - 19.2f;
-        }
+        maleLBW = (0.4071f * data.getWeight()) + (0.267f * user.body_height) - 19.2f;
+        femaleLBW = (0.252f * data.getWeight()) + (0.473f * user.body_height) - 48.3f;
 
-        return (0.252f * data.getWeight()) + (0.473f * user.body_height) - 48.3f;
+        return Utils.genderizeMetric(user, maleLBW, femaleLBW);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/LBWHume.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/LBWHume.java
@@ -27,10 +27,9 @@ public class LBWHume extends EstimatedLBWMetric {
 
     @Override
     public float getLBW(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return (0.32810f * data.getWeight()) + (0.33929f * user.body_height) - 29.5336f;
-        }
+        float maleLBW = (0.32810f * data.getWeight()) + (0.33929f * user.body_height) - 29.5336f;
+        float femaleLBW = (0.29569f * data.getWeight()) + (0.41813f * user.body_height) - 43.2933f;
 
-        return (0.29569f * data.getWeight()) + (0.41813f * user.body_height) - 43.2933f;
+        return Utils.genderizeMetric(user, maleLBW, femaleLBW);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/TBWBehnke.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/TBWBehnke.java
@@ -26,10 +26,9 @@ public class TBWBehnke extends EstimatedWaterMetric {
 
     @Override
     public float getWater(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return 0.72f * (0.204f * user.body_height * user.body_height) / 100.0f;
-        }
+        float maleWater = 0.72f * (0.204f * user.body_height * user.body_height) / 100.0f;
+        float femaleWater = 0.72f * (0.18f * user.body_height * user.body_height) / 100.0f;
 
-        return 0.72f * (0.18f * user.body_height * user.body_height) / 100.0f;
+        return Utils.genderizeMetric(user, maleWater, femaleWater);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/TBWLeeSongKim.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/TBWLeeSongKim.java
@@ -26,10 +26,9 @@ public class TBWLeeSongKim extends EstimatedWaterMetric {
 
     @Override
     public float getWater(ScaleUser user, ScaleData data) {
-        if (user.isMale()) {
-            return -28.3497f + (0.243057f * user.body_height) + (0.366248f * data.getWeight());
-        }
+        float maleWater = -28.3497f + (0.243057f * user.body_height) + (0.366248f * data.getWeight());
+        float femaleWater = -26.6224f + (0.262513f * user.body_height) + (0.232948f * data.getWeight());
 
-        return -26.6224f + (0.262513f * user.body_height) + (0.232948f * data.getWeight());
+        return Utils.genderizeMetric(user, maleWater, femaleWater);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bodymetric/Utils.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bodymetric/Utils.java
@@ -15,20 +15,17 @@
 */
 package com.health.openscale.core.bodymetric;
 
-import com.health.openscale.core.datatypes.ScaleData;
 import com.health.openscale.core.datatypes.ScaleUser;
 
-public class TBWHumeWeyers extends EstimatedWaterMetric {
-    @Override
-    public String getName() {
-        return "Hume & Weyers (1971)";
-    }
-
-    @Override
-    public float getWater(ScaleUser user, ScaleData data) {
-        float maleWater = (0.194786f * user.body_height) + (0.296785f * data.getWeight()) - 14.012934f;
-        float femaleWater = (0.34454f * user.body_height) + (0.183809f * data.getWeight()) - 35.270121f;
-
-        return Utils.genderizeMetric(user, maleWater, femaleWater);
+public class Utils {
+    public static float genderizeMetric(ScaleUser user, float maleValue, float femaleValue) {
+        switch (user.gender) {
+            case ScaleUser.MALE:
+                return maleValue;
+            case ScaleUser.FEMALE:
+                return femaleValue;
+            default:
+                return (maleValue + femaleValue) / 2.0f;
+        }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleData.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleData.java
@@ -184,11 +184,21 @@ public class ScaleData {
         float bmr = 0.0f;
 
         // BMR formula by Mifflin, St Jeor et al: A new predictive equation for resting energy expenditure in healthy individuals
-        if (scaleUser.isMale()) {
-            bmr = 10.0f * weight + 6.25f * scaleUser.body_height - 5.0f * scaleUser.getAge(date_time) + 5.0f;
-        } else {
-            bmr = 10.0f * weight + 6.25f * scaleUser.body_height - 5.0f * scaleUser.getAge(date_time) - 161.0f;
+        float MALE_CONST = 5.0f;
+        float FEMALE_CONST = -161.0f;
+        float genderConst = 0.0f;
+        switch (scaleUser.gender) {
+            case ScaleUser.MALE:
+                genderConst = MALE_CONST;
+                break;
+            case ScaleUser.FEMALE:
+                genderConst = FEMALE_CONST;
+                break;
+            default:
+                genderConst = (MALE_CONST + FEMALE_CONST) / 2.0f;
+                break;
         }
+        bmr = 10.0f * weight + 6.25f * scaleUser.body_height - 5.0f * scaleUser.getAge(date_time) + genderConst;
 
         return bmr; // kCal / day
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleUser.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleUser.java
@@ -20,6 +20,10 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class ScaleUser {
+    public static int MALE = 0;
+    public static int FEMALE = 1;
+    public static int NONBINARY = 2;
+
     public static final String[] UNIT_STRING = new String[] {"kg", "lb", "st"};
     private static float KG_LB = 2.20462f;
     private static float KG_ST = 0.157473f;
@@ -40,7 +44,7 @@ public class ScaleUser {
         birthday = new Date();
         body_height = -1;
         scale_unit = 0;
-        gender = 0;
+        gender = NONBINARY;
         initial_weight = -1;
         goal_weight = -1;
         goal_date = new Date();
@@ -48,7 +52,7 @@ public class ScaleUser {
 
     public boolean isMale()
     {
-        if (gender == 0)
+        if (gender == MALE)
             return true;
 
         return false;

--- a/android_app/app/src/main/java/com/health/openscale/core/evaluation/EvaluationSheet.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/evaluation/EvaluationSheet.java
@@ -164,18 +164,24 @@ public class EvaluationSheet {
         whrEvaluateSheet_Woman.add(new sheetEntry(18, 90, 0.7f, 0.8f));
     }
 
-
     public EvaluationResult evaluateWeight(float weight) {
         float body_height_squared = (evalUser.body_height / 100.0f) * (evalUser.body_height / 100.0f);
         float lowLimit = 0.0f;
         float highLimit = 0.0f;
 
-        if (evalUser.isMale()) {
-            lowLimit = body_height_squared * 20.0f;
-            highLimit = body_height_squared * 25.0f;
-        } else {
-            lowLimit = body_height_squared * 19.0f;
-            highLimit = body_height_squared * 24.0f;
+        switch (evalUser.gender) {
+            case ScaleUser.MALE:
+                lowLimit = body_height_squared * 20.0f;
+                highLimit = body_height_squared * 25.0f;
+                break;
+            case ScaleUser.FEMALE:
+                lowLimit = body_height_squared * 19.0f;
+                highLimit = body_height_squared * 24.0f;
+                break;
+            default:
+                lowLimit = body_height_squared * 19.0f;
+                highLimit = body_height_squared * 25.0f;
+                break;
         }
 
         if (weight < lowLimit) { // low
@@ -191,63 +197,33 @@ public class EvaluationSheet {
 
 
     public EvaluationResult evaluateBodyFat(float fat) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet = fatEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = fatEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(fat, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(fat, fatEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(fat, fatEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     public EvaluationResult evaluateBodyWater(float water) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet = waterEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = waterEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(water, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(water, waterEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(water, waterEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     public EvaluationResult evaluateBodyMuscle(float muscle) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet = muscleEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = muscleEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(muscle, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(muscle, muscleEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(muscle, muscleEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     public EvaluationResult evaluateBMI(float bmi) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet =  bmiEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = bmiEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(bmi, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(bmi, bmiEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(bmi, bmiEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     public EvaluationResult evaluateWaist(float waist) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet =  waistEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = waistEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(waist, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(waist, waistEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(waist, waistEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     public EvaluationResult evaluateWHtR(float whrt) {
@@ -255,15 +231,9 @@ public class EvaluationSheet {
     }
 
     public EvaluationResult evaluateWHR(float whr) {
-        List<sheetEntry> bodyEvaluateSheet;
-
-        if (evalUser.isMale()) {
-            bodyEvaluateSheet =  whrEvaluateSheet_Man;
-        } else {
-            bodyEvaluateSheet = whrEvaluateSheet_Woman;
-        }
-
-        return evaluateSheet(whr, bodyEvaluateSheet);
+        EvaluationResult maleResult = evaluateSheet(whr, whrEvaluateSheet_Man);
+        EvaluationResult femaleResult = evaluateSheet(whr, whrEvaluateSheet_Woman);
+        return genderizeEvaluation(maleResult, femaleResult);
     }
 
     private EvaluationResult evaluateSheet(float value, List<sheetEntry> sheet) {
@@ -282,5 +252,29 @@ public class EvaluationSheet {
         }
 
         return new EvaluationResult(0, -1, -1, EvaluationResult.EVAL_STATE.UNDEFINED);
+    }
+
+    private EvaluationResult genderizeEvaluation(EvaluationResult maleResult, EvaluationResult femaleResult) {
+        switch (evalUser.gender) {
+            case ScaleUser.MALE:
+                return maleResult;
+            case ScaleUser.FEMALE:
+                return femaleResult;
+            default:
+                if (maleResult == femaleResult) {
+                    return femaleResult;
+                }
+                if (maleResult == EvaluationResult.UNDEFINED) {
+                    return femaleResult;
+                }
+                if (femaleResult == EvaluationResult.UNDEFINED) {
+                    return maleResult;
+                }
+                // If the results disagree and neither is undefined, then
+                // we aren't above the maximum for humans overall and we
+                // aren't below the minimum for humans overall, so we're
+                // "normal"
+                return EvaluationResult.EVAL_STATE.NORMAL;
+        }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
@@ -160,11 +160,14 @@ public class UserSettingsActivity extends Activity {
 
         switch (scaleUser.gender)
         {
-            case 0:
+            case ScaleUser.MALE:
                 radioGender.check(R.id.btnRadioMale);
                 break;
-            case 1:
+            case ScaleUser.FEMALE:
                 radioGender.check(R.id.btnRadioWoman);
+                break;
+            case ScaleUser.NONBINARY:
+                radioGender.check(R.id.btnRadioNonbinary);
                 break;
         }
     }
@@ -293,10 +296,13 @@ public class UserSettingsActivity extends Activity {
 
                     switch (checkedGenderId) {
                         case R.id.btnRadioMale:
-                            gender = 0;
+                            gender = ScaleUser.MALE;
                             break;
                         case R.id.btnRadioWoman:
-                            gender = 1;
+                            gender = ScaleUser.FEMALE;
+                            break;
+                        case R.id.btnRadioNonbinary:
+                            gender = ScaleUser.NONBINARY;
                             break;
                     }
 

--- a/android_app/app/src/main/res/layout/activity_usersettings.xml
+++ b/android_app/app/src/main/res/layout/activity_usersettings.xml
@@ -88,14 +88,20 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/label_male"
-                            android:id="@+id/btnRadioMale"
-                            android:checked="true" />
+                            android:id="@+id/btnRadioMale" />
 
                         <RadioButton
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/label_woman"
                             android:id="@+id/btnRadioWoman" />
+
+                        <RadioButton
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/label_nonbinary"
+                            android:id="@+id/btnRadioNonbinary"
+                            android:checked="true" />
 
                     </RadioGroup>
 

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -55,6 +55,7 @@
     <string name="label_measures">Messungen</string>
     <string name="label_muscle">Muskelanteil</string>
     <string name="label_no">Nein</string>
+    <string name="label_nonbinary">Nichtbinär</string>
     <string name="label_ok">OK</string>
     <string name="label_scale_unit">Einheit</string>
     <string name="label_time">Zeit</string>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -55,6 +55,7 @@
     <string name="label_gender">Género</string>
     <string name="label_male">Hombre</string>
     <string name="label_woman">Mujer</string>
+    <string name="label_nonbinary">No-binario</string>
     <string name="label_goal_weight">Peso objetivo</string>
     <string name="label_goal_date">Fecha objetivo</string>
 

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -50,6 +50,7 @@
     <string name="label_gender">Sexe</string>
     <string name="label_male">Homme</string>
     <string name="label_woman">Femme</string>
+    <string name="label_nonbinary">Non-binaire</string>
     <string name="label_goal_weight">Objectif de poids</string>
     <string name="label_goal_date">Date de l\'objectif</string>
 

--- a/android_app/app/src/main/res/values-ja/strings.xml
+++ b/android_app/app/src/main/res/values-ja/strings.xml
@@ -7,6 +7,7 @@
     <string name="title_overview">概説</string>
     <string name="label_yes">はい</string>
     <string name="label_woman">女性</string>
+    <string name="label_nonbinary">Xジェンダー</string>
     <string name="label_user_name">高名</string>
     <string name="label_time">時刻</string>
     <string name="label_ok">OK</string>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -53,6 +53,7 @@
     <string name="label_gender">Płęć</string>
     <string name="label_male">Mężczyzna</string>
     <string name="label_woman">Kobieta</string>
+    <string name="label_nonbinary">Niebinarny</string>
     <string name="label_goal_weight">Docelowa waga</string>
     <string name="label_goal_date">Data celu</string>
 

--- a/android_app/app/src/main/res/values-pt/strings.xml
+++ b/android_app/app/src/main/res/values-pt/strings.xml
@@ -98,6 +98,7 @@
     <string name="label_measures">medidas</string>
     <string name="label_muscle">Porcentagem de massa muscular</string>
     <string name="label_no">Não</string>
+    <string name="label_nonbinary">Não-binário</string>
     <string name="label_ok">OK</string>
     <string name="label_not_found">não encontrado</string>
     <string name="label_regression_line">Linha de tendência de peso</string>

--- a/android_app/app/src/main/res/values-sk/strings.xml
+++ b/android_app/app/src/main/res/values-sk/strings.xml
@@ -47,6 +47,7 @@
   <string name="label_gender">Pohlavie</string>
   <string name="label_male">Muž</string>
   <string name="label_woman">Žena</string>
+  <string name="label_nonbinary">Non-binary</string>
   <string name="label_goal_weight">Cieľová hmotnosť</string>
   <string name="label_goal_date">Cieľový dátum</string>
   <string name="label_title_user">používateľ</string>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -46,6 +46,7 @@
     <string name="label_gender">Kön</string>
     <string name="label_male">Man</string>
     <string name="label_woman">Kvinna</string>
+    <string name="label_nonbinary">Icke-binär</string>
     <string name="label_goal_weight">Målvikt</string>
     <string name="label_goal_date">Måldatum</string>
     <string name="label_title_user">användare</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="label_gender">Gender</string>
     <string name="label_male">Male</string>
     <string name="label_woman">Woman</string>
+    <string name="label_nonbinary">Non-binary</string>
     <string name="label_goal_weight">Goal weight</string>
     <string name="label_goal_date">Goal date</string>
 


### PR DESCRIPTION
The `ScaleUser.gender` variable can now be set to 2 to indicate a non-binary gender, and a corresponding radio button has been added to the UI.  For evaluation sheets, we evaluate a non-binary user as `NORMAL` if their body metrics are within the combined `NORMAL` ranges for male and female metrics.  For body metrics that depend on biological sex, we return the average of the male and female values for a non-binary user.  For communicating with bluetooth scales, we largely stick to the existing code pattern, designating all non-male users as female.

This is kind of terrible, but I don't have any better ideas for how to make this app as gender-inclusive as possible while relying on data from non-inclusive research papers and interfacing with non-inclusive external devices.