### PR TITLE
Show days since current date in overview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ after_success:
  - chmod +x ./upload_apk.sh
  - ./upload_apk.sh
 
-script: cd android_app && ./gradlew -i testDebugUnitTest assembleDebug
+script: cd android_app && ./gradlew testDebug assembleDebug

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ after_success:
  - chmod +x ./upload_apk.sh
  - ./upload_apk.sh
 
-script: cd android_app && ./gradlew assembleDebug
+script: cd android_app && ./gradlew -i testDebugUnitTest assembleDebug

--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -31,4 +31,6 @@ dependencies {
     compile "com.android.support:support-v4:${supportLibVersion}"
     compile "com.android.support:appcompat-v7:${supportLibVersion}"
     compile 'com.github.lecho:hellocharts-library:1.5.8@aar'
+
+    testCompile 'junit:junit:4.12'
 }

--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -34,3 +34,11 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
 }
+
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/utils/DateTimeHelpers.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/DateTimeHelpers.java
@@ -1,0 +1,42 @@
+/* Copyright (C) 2017 Erik Johansson <erik@ejohansson.se>
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package com.health.openscale.core.utils;
+
+import java.util.Calendar;
+
+public final class DateTimeHelpers {
+    static public int daysBetween(Calendar start, Calendar end) {
+        if (start.after(end)) {
+            return -daysBetween(end, start);
+        }
+
+        int days = 0;
+
+        Calendar current = (Calendar)start.clone();
+        while (current.get(Calendar.YEAR) < end.get(Calendar.YEAR)) {
+            final int daysInYear =
+                current.getActualMaximum(Calendar.DAY_OF_YEAR)
+                - current.get(Calendar.DAY_OF_YEAR) + 1;
+            days += daysInYear;
+            current.add(Calendar.DAY_OF_YEAR, daysInYear);
+        }
+
+        days += end.get(Calendar.DAY_OF_YEAR) - current.get(Calendar.DAY_OF_YEAR);
+
+        return days;
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -37,6 +37,7 @@ import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleData;
 import com.health.openscale.core.datatypes.ScaleUser;
+import com.health.openscale.core.utils.DateTimeHelpers;
 import com.health.openscale.gui.activities.DataEntryActivity;
 import com.health.openscale.gui.views.BMIMeasurementView;
 import com.health.openscale.gui.views.BMRMeasurementView;
@@ -54,6 +55,7 @@ import com.health.openscale.gui.views.WeightMeasurementView;
 
 import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -255,7 +257,8 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             max_i = scaleDataList.size();
         }
 
-        Date now = new Date();
+        final Calendar now = Calendar.getInstance();
+        Calendar histCalendar = Calendar.getInstance();
 
         scaleDataLastDays = new ArrayList<ScaleData>();
 
@@ -280,7 +283,8 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             if (histData.getBone() != 0.0f)
                 valuesBone.add(new PointValue(i, histData.getBone()));
 
-            int days = daysBetween(now, histData.getDateTime());
+            histCalendar.setTime(histData.getDateTime());
+            int days = DateTimeHelpers.daysBetween(now, histCalendar);
             String label = getResources().getQuantityString(R.plurals.label_days, Math.abs(days), days);
             axisValues.add(new AxisValue(i, label.toCharArray()));
         }
@@ -419,11 +423,6 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         }
 
         pieChartLast.setPieChartData(pieChartData);
-    }
-
-    private int daysBetween(Date startDate, Date endDate) {
-        final float msPerDay = 24 * 60 * 60 * 1000;
-        return Math.round((endDate.getTime() - startDate.getTime()) / msPerDay);
     }
 
     public void btnOnClickInsertData()

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -54,7 +54,7 @@ import com.health.openscale.gui.views.WeightMeasurementView;
 
 import java.text.DateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import lecho.lib.hellocharts.formatter.SimpleLineChartValueFormatter;
@@ -255,12 +255,7 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             max_i = scaleDataList.size();
         }
 
-        Calendar histDate = Calendar.getInstance();
-        Calendar lastDate = Calendar.getInstance();
-
-        if (!scaleDataList.isEmpty()) {
-            lastDate.setTime(scaleDataList.get(0).getDateTime());
-        }
+        Date now = new Date();
 
         scaleDataLastDays = new ArrayList<ScaleData>();
 
@@ -285,11 +280,9 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             if (histData.getBone() != 0.0f)
                 valuesBone.add(new PointValue(i, histData.getBone()));
 
-            histDate.setTime(histData.getDateTime());
-
-            long days = 0 - daysBetween(lastDate, histDate);
-
-            axisValues.add(new AxisValue(i, String.format("%d " + getResources().getString(R.string.label_days), days).toCharArray()));
+            int days = daysBetween(now, histData.getDateTime());
+            String label = getResources().getQuantityString(R.plurals.label_days, Math.abs(days), days);
+            axisValues.add(new AxisValue(i, label.toCharArray()));
         }
 
         Line lineWeight = new Line(valuesWeight).
@@ -428,8 +421,9 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         pieChartLast.setPieChartData(pieChartData);
     }
 
-    private long daysBetween(Calendar startDate, Calendar endDate) {
-        return startDate.get(Calendar.DAY_OF_YEAR) - endDate.get(Calendar.DAY_OF_YEAR);
+    private int daysBetween(Date startDate, Date endDate) {
+        final float msPerDay = 24 * 60 * 60 * 1000;
+        return Math.round((endDate.getTime() - startDate.getTime()) / msPerDay);
     }
 
     public void btnOnClickInsertData()

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
@@ -30,6 +30,7 @@ import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleData;
 import com.health.openscale.core.datatypes.ScaleUser;
+import com.health.openscale.core.utils.DateTimeHelpers;
 
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -114,7 +115,9 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
         double weight_diff = goalScaleData.getConvertedWeight(currentScaleUser.scale_unit) - lastScaleData.getConvertedWeight(currentScaleUser.scale_unit);
         txtGoalDiff.setText(String.format("%.1f " + ScaleUser.UNIT_STRING[currentScaleUser.scale_unit], weight_diff));
 
-        int days = Math.max(0, daysBetween(new Date(), currentScaleUser.goal_date));
+        Calendar goalCalendar = Calendar.getInstance();
+        goalCalendar.setTime(currentScaleUser.goal_date);
+        int days = Math.max(0, DateTimeHelpers.daysBetween(Calendar.getInstance(), goalCalendar));
         txtGoalDayLeft.setText(getResources().getQuantityString(R.plurals.label_days, days, days));
 
         lastScaleData.setUserId(currentScaleUser.id);
@@ -329,10 +332,5 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
 
         txtAvgWeek.setText(weekSize + " " + getResources().getString(R.string.label_measures));
         txtAvgMonth.setText(monthSize + " " + getResources().getString(R.string.label_measures));
-    }
-
-    private int daysBetween(Date startDate, Date endDate) {
-        final float msPerDay = 24 * 60 * 60 * 1000;
-        return (int)Math.ceil((endDate.getTime() - startDate.getTime()) / msPerDay);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
@@ -34,7 +34,7 @@ import com.health.openscale.core.datatypes.ScaleUser;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.concurrent.TimeUnit;
+import java.util.Date;
 
 public class StatisticsFragment extends Fragment implements FragmentUpdateListener {
 
@@ -99,7 +99,7 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
         txtTitleStatistics.setText(getResources().getString(R.string.label_title_statistics).toUpperCase());
 
         prefs = PreferenceManager.getDefaultSharedPreferences(statisticsView.getContext());
-        currentScaleUser =  OpenScale.getInstance(getContext()).getSelectedScaleUser();
+        currentScaleUser = OpenScale.getInstance(getContext()).getSelectedScaleUser();
 
         updateStatistics(scaleDataList);
         updateGoal(scaleDataList);
@@ -114,12 +114,8 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
         double weight_diff = goalScaleData.getConvertedWeight(currentScaleUser.scale_unit) - lastScaleData.getConvertedWeight(currentScaleUser.scale_unit);
         txtGoalDiff.setText(String.format("%.1f " + ScaleUser.UNIT_STRING[currentScaleUser.scale_unit], weight_diff));
 
-        Calendar goalDate = Calendar.getInstance();
-        Calendar curDate = Calendar.getInstance();
-        goalDate.setTime(currentScaleUser.goal_date);
-
-        long days = daysBetween(curDate, goalDate);
-        txtGoalDayLeft.setText(days + " " + getResources().getString(R.string.label_days));
+        int days = Math.max(0, daysBetween(new Date(), currentScaleUser.goal_date));
+        txtGoalDayLeft.setText(getResources().getQuantityString(R.plurals.label_days, days, days));
 
         lastScaleData.setUserId(currentScaleUser.id);
 
@@ -335,9 +331,8 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
         txtAvgMonth.setText(monthSize + " " + getResources().getString(R.string.label_measures));
     }
 
-    private long daysBetween(Calendar startDate, Calendar endDate) {
-        long end = endDate.getTimeInMillis();
-        long start = startDate.getTimeInMillis();
-        return TimeUnit.MILLISECONDS.toDays(Math.abs(end - start));
+    private int daysBetween(Date startDate, Date endDate) {
+        final float msPerDay = 24 * 60 * 60 * 1000;
+        return (int)Math.ceil((endDate.getTime() - startDate.getTime()) / msPerDay);
     }
 }

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -36,7 +36,10 @@
     <string name="label_body_height">Körpergröße</string>
     <string name="label_comment">Kommentar</string>
     <string name="label_date">Datum</string>
-    <string name="label_days">Tage</string>
+    <plurals name="label_days">
+        <item quantity="one">%d Tag</item>
+        <item quantity="other">%d Tage</item>
+    </plurals>
     <string name="label_days_left">Tage übrig</string>
     <string name="label_delete">Löschen</string>
     <string name="label_delete_all">Alles löschen</string>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -38,7 +38,10 @@
     <string name="label_bone">Masa ósea</string>
     <string name="label_smartUserAssign">Asignación inteligente de usuario</string>
 
-    <string name="label_days">días</string>
+    <plurals name="label_days">
+        <item quantity="one">%d día</item>
+        <item quantity="other">%d días</item>
+    </plurals>
     <string name="label_measures">medidas</string>
     <string name="label_last_week">Últimos 7 días</string>
     <string name="label_last_month">Últimos 30 días</string>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -33,7 +33,10 @@
     <string name="label_whr">Rapport taille-hanches</string>
     <string name="label_smartUserAssign">Affectation intelligente de l\'Utilisateur</string>
 
-    <string name="label_days">jours</string>
+    <plurals name="label_days">
+        <item quantity="one">%d jour</item>
+        <item quantity="other">%d jours</item>
+    </plurals>
     <string name="label_measures">mesures</string>
     <string name="label_last_week">7 derniers jours</string>
     <string name="label_last_month">30 derniers jours</string>

--- a/android_app/app/src/main/res/values-ja/strings.xml
+++ b/android_app/app/src/main/res/values-ja/strings.xml
@@ -23,7 +23,9 @@
     <string name="label_body_height">身長</string>
     <string name="label_cancel">キャンセル</string>
     <string name="label_comment">コメント</string>
-    <string name="label_days">日</string>
+    <plurals name="label_days">
+        <item quantity="other">%d 日</item>
+    </plurals>
     <string name="label_date">期日</string>
     <string name="label_delete">デリート</string>
     <string name="label_export">レコードのエクスポート</string>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -36,7 +36,9 @@
     <string name="label_bone">Masa kostna</string>
     <string name="label_smartUserAssign">Inteligente przypisywanie użytkowników</string>
 
-    <string name="label_days">dni</string>
+    <plurals name="label_days">
+        <item quantity="other">%d dni</item>
+    </plurals>
     <string name="label_measures">pomiarów</string>
     <string name="label_last_week">Ostatnie 7 dni</string>
     <string name="label_last_month">Ostatnie 30 dni</string>

--- a/android_app/app/src/main/res/values-pt/strings.xml
+++ b/android_app/app/src/main/res/values-pt/strings.xml
@@ -69,7 +69,9 @@
     <string name="label_cancel">Cancelar</string>
     <string name="label_comment">Comentário</string>
     <string name="label_date">Data</string>
-    <string name="label_days">dias</string>
+    <plurals name="label_days">
+        <item quantity="other">%d dias</item>
+    </plurals>
     <string name="label_days_left">Dias restantes</string>
     <string name="label_delete">Deletar</string>
     <string name="label_delete_all">Deletar tudo</string>

--- a/android_app/app/src/main/res/values-sk/strings.xml
+++ b/android_app/app/src/main/res/values-sk/strings.xml
@@ -31,7 +31,9 @@
   <string name="label_whr">Pomer pásu a bokov</string>
   <string name="label_bone">Hmotnosť kostí</string>
   <string name="label_smartUserAssign">Chytré priradenie používateľa</string>
-  <string name="label_days">dni</string>
+  <plurals name="label_days">
+        <item quantity="other">%d dni</item>
+    </plurals>
   <string name="label_measures">merania</string>
   <string name="label_last_week">Posledných 7 dní</string>
   <string name="label_last_month">Posledných 30 dní</string>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -60,7 +60,10 @@
     <string name="label_days_left">Dagar kvar</string>
     <string name="label_goal_date_is">Måldatum är</string>
     <string name="label_weight_difference">Viktskillnad</string>
-    <string name="label_days">dagar</string>
+    <plurals name="label_days">
+        <item quantity="one">%d dag</item>
+        <item quantity="other">%d dagar</item>
+    </plurals>
     <string name="label_measures">mätningar</string>
     <string name="label_last_week">Senast 7 dagarna</string>
     <string name="label_last_month">Senast 30 dagarna</string>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -37,7 +37,9 @@
     <string name="label_bone">Kemik kütlesi</string>
     <string name="label_smartUserAssign">Akýllý kullanýcý atamasý</string>
 
-    <string name="label_days">Günler</string>
+    <plurals name="label_days">
+        <item quantity="other">%d Günler</item>
+    </plurals>
     <string name="label_measures">Ölçüler</string>
     <string name="label_last_week">Son 7 Gün</string>
     <string name="label_last_month">Son 30 Gün</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -38,7 +38,10 @@
     <string name="label_bone">Bone mass</string>
     <string name="label_smartUserAssign">Smart User assignment</string>
 
-    <string name="label_days">days</string>
+    <plurals name="label_days">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
     <string name="label_measures">measures</string>
     <string name="label_last_week">Last 7 days</string>
     <string name="label_last_month">Last 30 days</string>

--- a/android_app/app/src/test/java/com/health/openscale/core/utils/DateTimeHelpersTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/core/utils/DateTimeHelpersTest.java
@@ -1,0 +1,78 @@
+/* Copyright (C) 2017 Erik Johansson <erik@ejohansson.se>
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package com.health.openscale.core.utils;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.*;
+
+public class DateTimeHelpersTest {
+    Calendar getDate(int year, int month, int day, int hour, int minute, int second, int ms) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month - 1, day, hour, minute, second);
+        cal.set(Calendar.MILLISECOND, ms);
+        return cal;
+    }
+    Calendar getDate(int year, int month, int day) {
+        return getDate(year, month, day, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void daysBetween() throws Exception {
+        assertEquals(0,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 1),
+                getDate(2017, 1, 1)));
+
+        assertEquals(0,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 1, 12, 10, 10, 0),
+                getDate(2017, 1, 1, 12, 9, 0, 0)));
+
+        assertEquals(0,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 1, 23, 59, 59, 999),
+                getDate(2017, 1, 1)));
+
+        assertEquals(1,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 1),
+                getDate(2017, 1, 2)));
+
+        assertEquals(-1,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 2),
+                getDate(2017, 1, 1)));
+
+        assertEquals(1,
+            DateTimeHelpers.daysBetween(
+                getDate(2017, 1, 1, 23, 59, 59, 999),
+                getDate(2017, 1, 2)));
+
+        assertEquals(29 - 10 + 4 * 30 + 6 * 31 + 2,
+            DateTimeHelpers.daysBetween(
+                getDate(2016, 2, 10, 1, 2, 3, 10),
+                getDate(2017, 1, 2)));
+
+        assertEquals(1 + 365 + 366,
+            DateTimeHelpers.daysBetween(
+                getDate(2014, 12, 31),
+                getDate(2017, 1, 1)));
+    }
+}


### PR DESCRIPTION
I find it more logical to see how long ago a measurement was done,
instead of how long ago since the last measurement was a measurement
done.

Fix a bug where the days since a measurement was calculated
incorrectly if the measurement was done in the previous year.

Convert the days label to plurals so that "day" is used when the
measurement was done yesterday.