### PR TITLE
Refactor measurement views

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -23,6 +23,7 @@ import android.os.AsyncTask;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
+import android.text.format.DateFormat;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -48,6 +49,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -215,7 +217,15 @@ public class OpenScale {
         if (measurementDAO.insert(scaleMeasurement) != -1) {
             ScaleUser scaleUser = getScaleUser(scaleMeasurement.getUserId());
 
-            String infoText = String.format(context.getString(R.string.info_new_data_added), scaleMeasurement.getConvertedWeight(scaleUser.getScaleUnit()), scaleUser.UNIT_STRING[scaleUser.getScaleUnit()], dateTimeFormat.format(scaleMeasurement.getDateTime()), scaleUser.getUserName());
+            final java.text.DateFormat dateFormat = DateFormat.getDateFormat(context);
+            final java.text.DateFormat timeFormat = DateFormat.getTimeFormat(context);
+            final Date dateTime = scaleMeasurement.getDateTime();
+
+            String infoText = String.format(context.getString(R.string.info_new_data_added),
+                    scaleMeasurement.getConvertedWeight(scaleUser.getScaleUnit()),
+                    scaleUser.UNIT_STRING[scaleUser.getScaleUnit()],
+                    dateFormat.format(dateTime) + " " + timeFormat.format(dateTime),
+                    scaleUser.getUserName());
             Toast.makeText(context, infoText, Toast.LENGTH_LONG).show();
             alarmHandler.entryChanged(context, scaleMeasurement);
             updateScaleData();

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
@@ -141,7 +141,6 @@ public class ScaleMeasurement {
 
     public void setWeight(float weight) {
         this.weight = weight;
-
     }
 
     public void setConvertedWeight(float weight, int scale_unit) {

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
@@ -26,7 +26,7 @@ import com.j256.simplecsv.common.CsvColumn;
 import java.util.Date;
 
 @Entity(tableName = "scaleMeasurements", indices = {@Index(value = {"datetime"}, unique = true)})
-public class ScaleMeasurement {
+public class ScaleMeasurement implements Cloneable {
     private static float KG_LB = 2.20462f;
     private static float KG_ST = 0.157473f;
 
@@ -83,6 +83,19 @@ public class ScaleMeasurement {
         waist = 0.0f;
         hip = 0.0f;
         comment = new String();
+    }
+
+    @Override
+    public ScaleMeasurement clone() {
+        ScaleMeasurement clone;
+        try {
+            clone = (ScaleMeasurement) super.clone();
+        }
+        catch (CloneNotSupportedException e) {
+            throw new RuntimeException("failed to clone ScaleMeasurement", e);
+        }
+        clone.dateTime = (Date) dateTime.clone();
+        return clone;
     }
 
     public int getId() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -65,22 +65,6 @@ public class DataEntryActivity extends Activity {
     private ArrayList<MeasurementView> dataEntryMeasurements;
     private TableLayout tableLayoutDataEntry;
 
-    private WeightMeasurementView weightMeasurement;
-    private BMIMeasurementView bmiMeasurementView;
-    private WaterMeasurementView waterMeasurement;
-    private MuscleMeasurementView muscleMeasurement;
-    private LBWMeasurementView lbwMeasurement;
-    private FatMeasurementView fatMeasurement;
-    private WaistMeasurementView waistMeasurement;
-    private WHtRMeasurementView wHtRMeasurementView;
-    private HipMeasurementView hipMeasurement;
-    private WHRMeasurementView whrMeasurementView;
-    private BMRMeasurementView bmrMeasurementView;
-    private BoneMeasurementView boneMeasurementView;
-    private CommentMeasurementView commentMeasurement;
-    private DateMeasurementView dateMeasurement;
-    private TimeMeasurementView timeMeasurement;
-
     private TextView txtDataNr;
     private Button btnAdd;
     private Button btnOk;
@@ -91,7 +75,9 @@ public class DataEntryActivity extends Activity {
     private FloatingActionButton switchEditMode;
     private FloatingActionButton expandButton;
 
-    private int id;
+    private ScaleMeasurement scaleMeasurement;
+    private ScaleMeasurement previousMeasurement;
+    private boolean isDirty;
 
     private Context context;
 
@@ -105,41 +91,27 @@ public class DataEntryActivity extends Activity {
 
         tableLayoutDataEntry = (TableLayout) findViewById(R.id.tableLayoutDataEntry);
 
-        weightMeasurement = new WeightMeasurementView(context);
-        bmiMeasurementView = new BMIMeasurementView(context);
-        waterMeasurement = new WaterMeasurementView(context);
-        muscleMeasurement = new MuscleMeasurementView(context);
-        lbwMeasurement = new LBWMeasurementView(context);
-        fatMeasurement = new FatMeasurementView(context);
-        boneMeasurementView = new BoneMeasurementView(context);
-        waistMeasurement = new WaistMeasurementView(context);
-        wHtRMeasurementView = new WHtRMeasurementView(context);
-        hipMeasurement = new HipMeasurementView(context);
-        whrMeasurementView = new WHRMeasurementView(context);
-        bmrMeasurementView = new BMRMeasurementView(context);
-        commentMeasurement = new CommentMeasurementView(context);
-        dateMeasurement = new DateMeasurementView(context);
-        timeMeasurement = new TimeMeasurementView(context);
-
         dataEntryMeasurements = new ArrayList<>();
-        dataEntryMeasurements.add(weightMeasurement);
-        dataEntryMeasurements.add(bmiMeasurementView);
-        dataEntryMeasurements.add(waterMeasurement);
-        dataEntryMeasurements.add(muscleMeasurement);
-        dataEntryMeasurements.add(lbwMeasurement);
-        dataEntryMeasurements.add(fatMeasurement);
-        dataEntryMeasurements.add(boneMeasurementView);
-        dataEntryMeasurements.add(waistMeasurement);
-        dataEntryMeasurements.add(wHtRMeasurementView);
-        dataEntryMeasurements.add(hipMeasurement);
-        dataEntryMeasurements.add(whrMeasurementView);
-        dataEntryMeasurements.add(bmrMeasurementView);
-        dataEntryMeasurements.add(commentMeasurement);
-        dataEntryMeasurements.add(dateMeasurement);
-        dataEntryMeasurements.add(timeMeasurement);
+        dataEntryMeasurements.add(new WeightMeasurementView(context));
+        dataEntryMeasurements.add(new BMIMeasurementView(context));
+        dataEntryMeasurements.add(new WaterMeasurementView(context));
+        dataEntryMeasurements.add(new MuscleMeasurementView(context));
+        dataEntryMeasurements.add(new LBWMeasurementView(context));
+        dataEntryMeasurements.add(new FatMeasurementView(context));
+        dataEntryMeasurements.add(new BoneMeasurementView(context));
+        dataEntryMeasurements.add(new WaistMeasurementView(context));
+        dataEntryMeasurements.add(new WHtRMeasurementView(context));
+        dataEntryMeasurements.add(new HipMeasurementView(context));
+        dataEntryMeasurements.add(new WHRMeasurementView(context));
+        dataEntryMeasurements.add(new BMRMeasurementView(context));
+        dataEntryMeasurements.add(new CommentMeasurementView(context));
+        dataEntryMeasurements.add(new DateMeasurementView(context));
+        dataEntryMeasurements.add(new TimeMeasurementView(context));
 
+        onMeasurementViewUpdateListener updateListener = new onMeasurementViewUpdateListener();
         for (MeasurementView measurement : dataEntryMeasurements) {
             tableLayoutDataEntry.addView(measurement);
+            measurement.setOnUpdateListener(updateListener);
         }
 
         txtDataNr = (TextView) findViewById(R.id.txtDataNr);
@@ -165,22 +137,28 @@ public class DataEntryActivity extends Activity {
         updateOnView();
     }
 
-
     private void updateOnView()
     {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
         for (MeasurementView measurement : dataEntryMeasurements) {
-            measurement.setOnUpdateListener(null);
             measurement.updatePreferences(prefs);
         }
 
+        int id = 0;
         if (getIntent().hasExtra("id")) {
             id = getIntent().getExtras().getInt("id");
         }
 
-        ScaleMeasurement scaleMeasurement;
+        if (scaleMeasurement == null || scaleMeasurement.getId() != id) {
+            isDirty = false;
+        }
+
+        scaleMeasurement = null;
+        previousMeasurement = null;
+
         OpenScale openScale = OpenScale.getInstance(context);
+        boolean doExpand = false;
 
         if (id > 0) {
             // keep edit mode state if we are moving to left or right
@@ -192,27 +170,17 @@ public class DataEntryActivity extends Activity {
                 switchEditMode.setBackgroundTintList(ColorStateList.valueOf(Color.parseColor("#D3D3D3")));
             }
 
-            final boolean doExpand = prefs.getBoolean(String.valueOf(expandButton.getId()), false);
+            doExpand = prefs.getBoolean(String.valueOf(expandButton.getId()), false);
             if (doExpand) {
                 expandButton.setBackgroundTintList(ColorStateList.valueOf(ChartUtils.COLOR_ORANGE));
             } else {
                 expandButton.setBackgroundTintList(ColorStateList.valueOf(Color.parseColor("#D3D3D3")));
             }
 
+            // Show selected scale data
             ScaleMeasurement[] tupleScaleData = openScale.getTupleScaleData(id);
-            ScaleMeasurement prevScaleMeasurement = tupleScaleData[0];
-            scaleMeasurement = tupleScaleData[1];
-
-            if (prevScaleMeasurement == null) {
-                prevScaleMeasurement = new ScaleMeasurement();
-            }
-
-            // show selected scale data
-            for (MeasurementView measurement : dataEntryMeasurements) {
-                measurement.updateValue(scaleMeasurement);
-                measurement.updateDiff(scaleMeasurement, prevScaleMeasurement);
-                measurement.setExpand(doExpand);
-            }
+            previousMeasurement = tupleScaleData[0];
+            scaleMeasurement = tupleScaleData[1].clone();
         } else {
             setViewMode(MeasurementView.MeasurementViewMode.ADD);
 
@@ -223,27 +191,26 @@ public class DataEntryActivity extends Activity {
             }
             else {
                 // Show the last scale data as default
-                scaleMeasurement = openScale.getScaleMeasurementList().get(0);
+                scaleMeasurement = openScale.getScaleMeasurementList().get(0).clone();
+                scaleMeasurement.setId(0);
                 scaleMeasurement.setDateTime(new Date());
                 scaleMeasurement.setComment("");
             }
+        }
 
-            for (MeasurementView measurement : dataEntryMeasurements) {
-                measurement.updateValue(scaleMeasurement);
-            }
+        for (MeasurementView measurement : dataEntryMeasurements) {
+            measurement.loadFrom(scaleMeasurement, previousMeasurement);
+            measurement.setExpand(doExpand);
         }
 
         txtDataNr.setText(DateFormat.getDateTimeInstance(
             DateFormat.LONG, DateFormat.SHORT).format(scaleMeasurement.getDateTime()));
-
-        onMeasurementViewUpdateListener updateListener = new onMeasurementViewUpdateListener();
-        for (MeasurementView measurement : dataEntryMeasurements) {
-            measurement.setOnUpdateListener(updateListener);
-        }
     }
 
     private void setViewMode(MeasurementView.MeasurementViewMode viewMode)
     {
+        int dateTimeVisibility = View.VISIBLE;
+
         switch (viewMode) {
             case VIEW:
                 btnOk.setVisibility(View.VISIBLE);
@@ -253,8 +220,7 @@ public class DataEntryActivity extends Activity {
                 btnRight.setVisibility(View.VISIBLE);
                 expandButton.setVisibility(View.VISIBLE);
                 switchEditMode.setVisibility(View.VISIBLE);
-                dateMeasurement.setVisibility(View.GONE);
-                timeMeasurement.setVisibility(View.GONE);
+                dateTimeVisibility = View.GONE;
                 break;
             case EDIT:
                 btnOk.setVisibility(View.VISIBLE);
@@ -264,8 +230,6 @@ public class DataEntryActivity extends Activity {
                 btnRight.setVisibility(View.VISIBLE);
                 expandButton.setVisibility(View.VISIBLE);
                 switchEditMode.setVisibility(View.VISIBLE);
-                dateMeasurement.setVisibility(View.VISIBLE);
-                timeMeasurement.setVisibility(View.VISIBLE);
                 break;
             case ADD:
                 btnOk.setVisibility(View.GONE);
@@ -275,63 +239,29 @@ public class DataEntryActivity extends Activity {
                 btnRight.setVisibility(View.GONE);
                 expandButton.setVisibility(View.GONE);
                 switchEditMode.setVisibility(View.GONE);
-                dateMeasurement.setVisibility(View.VISIBLE);
-                timeMeasurement.setVisibility(View.VISIBLE);
                 break;
         }
 
         for (MeasurementView measurement : dataEntryMeasurements) {
+            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
+                measurement.setVisibility(dateTimeVisibility);
+            }
             measurement.setEditMode(viewMode);
         }
     }
 
-    private ScaleMeasurement createScaleDataFromMeasurement() {
-        OpenScale openScale = OpenScale.getInstance(getApplicationContext());
-        ScaleUser user = openScale.getSelectedScaleUser();
-
-        Calendar time = Calendar.getInstance();
-        time.setTime(timeMeasurement.getDateTime());
-
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(dateMeasurement.getDateTime());
-        cal.set(Calendar.HOUR_OF_DAY, time.get(Calendar.HOUR_OF_DAY));
-        cal.set(Calendar.MINUTE, time.get(Calendar.MINUTE));
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-
-        ScaleMeasurement scaleMeasurement = new ScaleMeasurement();
-
-        scaleMeasurement.setUserId(user.getId());
-        scaleMeasurement.setDateTime(cal.getTime());
-        scaleMeasurement.setConvertedWeight(weightMeasurement.getValue(), user.getScaleUnit());
-        scaleMeasurement.setFat(fatMeasurement.getValue());
-        scaleMeasurement.setWater(waterMeasurement.getValue());
-        scaleMeasurement.setMuscle(muscleMeasurement.getValue());
-        scaleMeasurement.setLbw(lbwMeasurement.getValue());
-        scaleMeasurement.setWaist(waistMeasurement.getValue());
-        scaleMeasurement.setHip(hipMeasurement.getValue());
-        scaleMeasurement.setBone(boneMeasurementView.getValue());
-        scaleMeasurement.setComment(commentMeasurement.getValueAsString());
-
-        return scaleMeasurement;
-    }
-
     private void saveScaleData() {
-        ScaleMeasurement scaleMeasurement = createScaleDataFromMeasurement();
-
-        scaleMeasurement.setId(id);
-
-        OpenScale openScale = OpenScale.getInstance(getApplicationContext());
-        openScale.updateScaleData(scaleMeasurement);
+        if (isDirty) {
+            OpenScale openScale = OpenScale.getInstance(getApplicationContext());
+            openScale.updateScaleData(scaleMeasurement);
+            isDirty = false;
+        }
     }
 
     private boolean moveLeft() {
-        ScaleMeasurement[] tupleScaleData = OpenScale.getInstance(getApplicationContext()).getTupleScaleData(id);
-        ScaleMeasurement prevScaleMeasurement = tupleScaleData[0];
-
-        if (prevScaleMeasurement != null) {
+        if (previousMeasurement != null) {
             saveScaleData();
-            getIntent().putExtra("id", prevScaleMeasurement.getId());
+            getIntent().putExtra("id", previousMeasurement.getId());
             updateOnView();
             return true;
         }
@@ -339,9 +269,9 @@ public class DataEntryActivity extends Activity {
         return false;
     }
 
-    private boolean moveRight()
-    {
-        ScaleMeasurement[] tupleScaleData = OpenScale.getInstance(getApplicationContext()).getTupleScaleData(id);
+    private boolean moveRight() {
+        ScaleMeasurement[] tupleScaleData = OpenScale.getInstance(getApplicationContext())
+                .getTupleScaleData(scaleMeasurement.getId());
         ScaleMeasurement nextScaleMeasurement = tupleScaleData[2];
 
         if (nextScaleMeasurement != null) {
@@ -357,23 +287,12 @@ public class DataEntryActivity extends Activity {
     private class onMeasurementViewUpdateListener implements MeasurementViewUpdateListener {
         @Override
         public void onMeasurementViewUpdate(MeasurementView view) {
-            ArrayList<MeasurementView> viewsToUpdate = new ArrayList<>();
-            if (view == weightMeasurement) {
-                viewsToUpdate.add(bmiMeasurementView);
-                viewsToUpdate.add(bmrMeasurementView);
-            } else if (view == waistMeasurement) {
-                viewsToUpdate.add(wHtRMeasurementView);
-                viewsToUpdate.add(whrMeasurementView);
-            } else if (view == hipMeasurement) {
-                viewsToUpdate.add(whrMeasurementView);
-            } else if (view == dateMeasurement) {
-                viewsToUpdate.add(bmrMeasurementView);
-            }
+            view.saveTo(scaleMeasurement);
+            isDirty = true;
 
-            if (!viewsToUpdate.isEmpty()) {
-                ScaleMeasurement scaleMeasurement = createScaleDataFromMeasurement();
-                for (MeasurementView measurement : viewsToUpdate) {
-                    measurement.updateValue(scaleMeasurement);
+            for (MeasurementView measurement : dataEntryMeasurements) {
+                if (measurement != view) {
+                    measurement.loadFrom(scaleMeasurement, previousMeasurement);
                 }
             }
         }
@@ -394,7 +313,9 @@ public class DataEntryActivity extends Activity {
 
                 infoDialog.show();
             } else {
-                ScaleMeasurement scaleMeasurement = createScaleDataFromMeasurement();
+                for (MeasurementView measurement : dataEntryMeasurements) {
+                    measurement.saveTo(scaleMeasurement);
+                }
 
                 OpenScale openScale = OpenScale.getInstance(getApplicationContext());
                 openScale.addScaleData(scaleMeasurement);
@@ -463,7 +384,7 @@ public class DataEntryActivity extends Activity {
         }
 
         void deleteMeasurement() {
-            int delId = id;
+            int delId = scaleMeasurement.getId();
 
             boolean hasNext = moveLeft();
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -138,10 +138,8 @@ public class DataEntryActivity extends Activity {
         dataEntryMeasurements.add(dateMeasurement);
         dataEntryMeasurements.add(timeMeasurement);
 
-        Collections.reverse(dataEntryMeasurements);
-
         for (MeasurementView measurement : dataEntryMeasurements) {
-            tableLayoutDataEntry.addView(measurement, 0);
+            tableLayoutDataEntry.addView(measurement);
         }
 
         txtDataNr = (TextView) findViewById(R.id.txtDataNr);

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -180,6 +180,7 @@ public class DataEntryActivity extends Activity {
         }
 
         ScaleMeasurement scaleMeasurement;
+        OpenScale openScale = OpenScale.getInstance(context);
 
         if (id > 0) {
             // keep edit mode state if we are moving to left or right
@@ -198,8 +199,6 @@ public class DataEntryActivity extends Activity {
                 expandButton.setBackgroundTintList(ColorStateList.valueOf(Color.parseColor("#D3D3D3")));
             }
 
-            OpenScale openScale = OpenScale.getInstance(context);
-
             ScaleMeasurement[] tupleScaleData = openScale.getTupleScaleData(id);
             ScaleMeasurement prevScaleMeasurement = tupleScaleData[0];
             scaleMeasurement = tupleScaleData[1];
@@ -217,13 +216,14 @@ public class DataEntryActivity extends Activity {
         } else {
             setViewMode(MeasurementView.MeasurementViewMode.ADD);
 
-            if (OpenScale.getInstance(getApplicationContext()).getScaleMeasurementList().isEmpty()) {
+            if (openScale.getScaleMeasurementList().isEmpty()) {
                 // Show default values
                 scaleMeasurement = new ScaleMeasurement();
+                scaleMeasurement.setWeight(openScale.getSelectedScaleUser().getInitialWeight());
             }
             else {
                 // Show the last scale data as default
-                scaleMeasurement = OpenScale.getInstance(getApplicationContext()).getScaleMeasurementList().get(0);
+                scaleMeasurement = openScale.getScaleMeasurementList().get(0);
                 scaleMeasurement.setDateTime(new Date());
                 scaleMeasurement.setComment("");
             }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -179,8 +179,7 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             lastScaleMeasurement = new ScaleMeasurement();
         } else if (userSelectedData != null) {
             lastScaleMeasurement = userSelectedData;
-        }
-        else {
+        } else {
             lastScaleMeasurement = scaleMeasurementList.get(0);
         }
 
@@ -197,14 +196,9 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         ScaleMeasurement[] tupleScaleData = OpenScale.getInstance(context).getTupleScaleData(lastScaleMeasurement.getId());
         ScaleMeasurement prevScaleMeasurement = tupleScaleData[0];
 
-        if (prevScaleMeasurement == null) {
-            prevScaleMeasurement = new ScaleMeasurement();
-        }
-
         for (MeasurementView measurement : overviewMeasurements) {
             measurement.updatePreferences(prefs);
-            measurement.updateValue(lastScaleMeasurement);
-            measurement.updateDiff(lastScaleMeasurement, prevScaleMeasurement);
+            measurement.loadFrom(lastScaleMeasurement, prevScaleMeasurement);
         }
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -201,31 +201,24 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
 
         int displayCount = 0;
 
-        for (int i = (maxSize * selectedSubpageNr); i< scaleMeasurementList.size(); i++) {
+        for (int i = (maxSize * selectedSubpageNr); i < scaleMeasurementList.size(); i++) {
             ScaleMeasurement scaleMeasurement = scaleMeasurementList.get(i);
 
-            ScaleMeasurement prevScaleMeasurement;
-
-            if (i >= scaleMeasurementList.size()-1) {
-                prevScaleMeasurement = new ScaleMeasurement();
-            } else {
-                prevScaleMeasurement = scaleMeasurementList.get(i+1);
+            ScaleMeasurement prevScaleMeasurement = null;
+            if (i < scaleMeasurementList.size() - 1) {
+                prevScaleMeasurement = scaleMeasurementList.get(i + 1);
             }
-
 
             HashMap<Integer,String> dataRow = new HashMap<>();
 
             int columnNr = 0;
-            dataRow.put(columnNr, Long.toString(scaleMeasurement.getId()));
+            dataRow.put(columnNr++, Long.toString(scaleMeasurement.getId()));
 
-            for (int j=0; j< measurementsList.size(); j++) {
-                MeasurementView measurement = measurementsList.get(j);
-                measurement.updateValue(scaleMeasurement);
-                measurement.updateDiff(scaleMeasurement, prevScaleMeasurement);
+            for (MeasurementView measurement : measurementsList) {
+                measurement.loadFrom(scaleMeasurement, prevScaleMeasurement);
 
                 if (measurement.isVisible()) {
-                    columnNr++;
-                    dataRow.put(columnNr, measurement.getValueAsString() + "<br>" + measurement.getDiffValue());
+                    dataRow.put(columnNr++, measurement.getValueAsString() + "<br>" + measurement.getDiffValue());
                 }
             }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -24,10 +24,15 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class BMIMeasurementView extends MeasurementView {
+public class BMIMeasurementView extends FloatMeasurementView {
 
     public BMIMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmi), ContextCompat.getDrawable(context, R.drawable.ic_bmi));
+    }
+
+    @Override
+    public void updatePreferences(SharedPreferences preferences) {
+        setVisible(preferences.getBoolean("weightEnable", true));
     }
 
     @Override
@@ -36,32 +41,27 @@ public class BMIMeasurementView extends MeasurementView {
     }
 
     @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getBMI(getScaleUser().getBodyHeight()));
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getBMI(getScaleUser().getBodyHeight());
     }
 
     @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getBMI(getScaleUser().getBodyHeight()), lastMeasurement.getBMI(getScaleUser().getBodyHeight()));
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        // Empty
     }
 
     @Override
-    public String getUnit() {
+    protected String getUnit() {
         return "";
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateBMI(value);
-    }
-
-    @Override
-    public float getMaxValue() {
+    protected float getMaxValue() {
         return 50;
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("weightEnable", true));
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateBMI(value);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -24,10 +24,17 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class BMRMeasurementView extends MeasurementView {
+import java.util.Locale;
+
+public class BMRMeasurementView extends FloatMeasurementView {
 
     public BMRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmr), ContextCompat.getDrawable(context, R.drawable.ic_bmr));
+    }
+
+    @Override
+    public void updatePreferences(SharedPreferences preferences) {
+        setVisible(preferences.getBoolean("weightEnable", true));
     }
 
     @Override
@@ -36,32 +43,32 @@ public class BMRMeasurementView extends MeasurementView {
     }
 
     @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getBMR(getScaleUser()));
+    protected String formatValue(float value) {
+        return String.format(Locale.getDefault(), "%d", Math.round(value));
     }
 
     @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getBMR(getScaleUser()), lastMeasurement.getBMR(getScaleUser()));
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getBMR(getScaleUser());
     }
 
     @Override
-    public String getUnit() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        // Empty
+    }
+
+    @Override
+    protected String getUnit() {
         return "kCal";
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
-    }
-
-    @Override
-    public float getMaxValue() {
+    protected float getMaxValue() {
         return 5000;
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("weightEnable", true));
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return null;
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -24,25 +24,10 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class BoneMeasurementView extends MeasurementView {
+public class BoneMeasurementView extends FloatMeasurementView {
 
     public BoneMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bone), ContextCompat.getDrawable(context, R.drawable.ic_bone));
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getBone());
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getBone(), lastMeasurement.getBone());
-    }
-
-    @Override
-    public String getUnit() {
-        return "kg";
     }
 
     @Override
@@ -51,12 +36,27 @@ public class BoneMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getBone();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setBone(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "kg";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 50;
+    }
+
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return null;
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -23,57 +23,56 @@ import android.widget.EditText;
 
 import com.health.openscale.R;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
-import com.health.openscale.core.evaluation.EvaluationResult;
-import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class CommentMeasurementView extends MeasurementView {
+    private String comment;
 
     public CommentMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_comment), ContextCompat.getDrawable(context, R.drawable.ic_comment));
     }
 
+    private void setValue(String newComment, boolean callListener) {
+        if (!newComment.equals(comment)) {
+            comment = newComment;
+            setValueView(comment, callListener);
+        }
+    }
+
     @Override
-    public boolean validateInput(EditText view) {
+    public void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement) {
+        setValue(measurement.getComment(), false);
+    }
+
+    @Override
+    public void saveTo(ScaleMeasurement measurement) {
+        measurement.setComment(comment);
+    }
+
+    @Override
+    public void updatePreferences(SharedPreferences preferences) {
+        // Empty
+    }
+
+    @Override
+    public String getValueAsString() {
+        return comment;
+    }
+
+    @Override
+    protected boolean validateAndSetInput(EditText view) {
+        setValue(view.getText().toString(), true);
         return true;
     }
 
+    @Override
     protected int getInputType() {
-        return InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+        return InputType.TYPE_CLASS_TEXT
+                | InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE
+                | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
     }
 
     @Override
     protected String getHintText() {
         return getResources().getString(R.string.info_enter_comment);
     }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getComment());
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-
-    }
-
-    @Override
-    public String getUnit() {
-        return null;
-    }
-
-    @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
-    }
-
-    @Override
-    public float getMaxValue() {
-        return 0;
-    }
-
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -24,39 +24,12 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class FatMeasurementView extends MeasurementView {
+public class FatMeasurementView extends FloatMeasurementView {
 
     private boolean estimateFatEnable;
 
     public FatMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_fat), ContextCompat.getDrawable(context, R.drawable.ic_fat));
-    }
-
-    @Override
-    public boolean isEditable() {
-        if (estimateFatEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        if (estimateFatEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            setValueOnView(newMeasurement.getDateTime(), (getContext().getString(R.string.label_automatic)));
-        } else {
-            setValueOnView(newMeasurement.getDateTime(), newMeasurement.getFat());
-        }
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getFat(), lastMeasurement.getFat());
-    }
-
-    @Override
-    public String getUnit() {
-        return "%";
     }
 
     @Override
@@ -66,13 +39,32 @@ public class FatMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateBodyFat(value);
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getFat();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setFat(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "%";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 80;
     }
 
+    @Override
+    protected boolean isEstimationEnabled() {
+        return estimateFatEnable;
+    }
+
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateBodyFat(value);
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -20,8 +20,11 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
-import android.text.Html;
 import android.text.InputType;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.RelativeSizeSpan;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
@@ -38,9 +41,9 @@ import java.util.Date;
 import java.util.Locale;
 
 public abstract class FloatMeasurementView extends MeasurementView {
-    private static String SYMBOL_UP = "&#10138;";
-    private static String SYMBOL_NEUTRAL = "&#10137;";
-    private static String SYMBOL_DOWN = "&#10136;";
+    private static char SYMBOL_UP = '\u279a';
+    private static char SYMBOL_NEUTRAL = '\u2799';
+    private static char SYMBOL_DOWN = '\u2798';
 
     private static float NO_VALUE = -1.0f;
     private static float AUTO_VALUE = -2.0f;
@@ -142,7 +145,7 @@ public abstract class FloatMeasurementView extends MeasurementView {
             if (previousValue >= 0.0f) {
                 final float diff = value - previousValue;
 
-                String symbol;
+                char symbol;
 
                 if (diff > 0.0) {
                     symbol = SYMBOL_UP;
@@ -152,10 +155,22 @@ public abstract class FloatMeasurementView extends MeasurementView {
                     symbol = SYMBOL_NEUTRAL;
                 }
 
-                setNameView(Html.fromHtml(
-                        String.format(
-                                "%s <br> <font color='grey'>%s<small>%s%s</small></font>",
-                                nameText, symbol, formatValue(diff), suffix)));
+                SpannableStringBuilder text = new SpannableStringBuilder(nameText);
+                text.append("\n");
+
+                int start = text.length();
+                text.append(symbol);
+                text.setSpan(new ForegroundColorSpan(Color.GRAY), start, text.length(),
+                        Spanned.SPAN_EXCLUSIVE_INCLUSIVE);
+
+                start = text.length();
+                text.append(' ');
+                text.append(formatValue(diff));
+                text.append(suffix);
+                text.setSpan(new RelativeSizeSpan(0.8f), start, text.length(),
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+                setNameView(text);
             } else {
                 setNameView(nameText);
             }
@@ -227,7 +242,7 @@ public abstract class FloatMeasurementView extends MeasurementView {
             return "";
         }
 
-        String symbol;
+        char symbol;
         String color;
 
         final float diff = value - previousValue;

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -1,0 +1,372 @@
+/* Copyright (C) 2018 Erik Johansson <erik@ejohansson.se>
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package com.health.openscale.gui.views;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.text.Html;
+import android.text.InputType;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TableRow;
+
+import com.health.openscale.R;
+import com.health.openscale.core.datatypes.ScaleMeasurement;
+import com.health.openscale.core.evaluation.EvaluationResult;
+import com.health.openscale.core.evaluation.EvaluationSheet;
+
+import java.util.Date;
+import java.util.Locale;
+
+public abstract class FloatMeasurementView extends MeasurementView {
+    private static String SYMBOL_UP = "&#10138;";
+    private static String SYMBOL_NEUTRAL = "&#10137;";
+    private static String SYMBOL_DOWN = "&#10136;";
+
+    private static float NO_VALUE = -1.0f;
+    private static float AUTO_VALUE = -2.0f;
+
+    Date dateTime;
+    float value = NO_VALUE;
+    float previousValue = NO_VALUE;
+    EvaluationResult evaluationResult;
+
+    private String nameText;
+
+    private Button incButton;
+    private Button decButton;
+
+    public FloatMeasurementView(Context context, String text, Drawable icon) {
+        super(context, text, icon);
+        initView(context);
+
+        nameText = text;
+    }
+
+    private void initView(Context context) {
+        incButton = new Button(context);
+        decButton = new Button(context);
+
+        LinearLayout incDecLayout = getIncDecLayout();
+        incDecLayout.addView(incButton);
+        incDecLayout.addView(decButton);
+
+        incButton.setText("+");
+        incButton.setBackgroundColor(Color.TRANSPARENT);
+        incButton.setPadding(0,0,0,0);
+        incButton.setLayoutParams(new TableRow.LayoutParams(LayoutParams.MATCH_PARENT, 0, 0.50f));
+        incButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                incValue();
+            }
+        });
+        incButton.setOnTouchListener(new RepeatListener(400, 100, new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                incValue();
+            }
+        }));
+        incButton.setVisibility(View.GONE);
+
+        decButton.setText("-");
+        decButton.setBackgroundColor(Color.TRANSPARENT);
+        decButton.setPadding(0,0,0,0);
+        decButton.setLayoutParams(new TableRow.LayoutParams(LayoutParams.MATCH_PARENT, 0, 0.50f));
+        decButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                decValue();
+            }
+        });
+
+        decButton.setOnTouchListener(new RepeatListener(400, 100, new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                decValue();
+            }
+        }));
+        decButton.setVisibility(View.GONE);
+    }
+
+    private float clampValue(float value) {
+        return Math.max(0.0f, Math.min(getMaxValue(), value));
+    }
+
+    private void setValue(float newValue, float newPreviousValue, boolean callListener) {
+        final String unit = getUnit();
+        final String suffix = unit.isEmpty() ? "" : " " + unit;
+
+        final boolean valueChanged = newValue != value;
+        final boolean previousValueChanged = newPreviousValue != previousValue;
+
+        if (valueChanged) {
+            value = newValue;
+            evaluationResult = null;
+
+            if (value == AUTO_VALUE) {
+                setValueView(getContext().getString(R.string.label_automatic), false);
+            }
+            else {
+                setValueView(formatValue(value) + suffix, callListener);
+
+                if (getMeasurementMode() != MeasurementViewMode.ADD) {
+                    EvaluationSheet evalSheet = new EvaluationSheet(getScaleUser(), dateTime);
+                    evaluationResult = evaluateSheet(evalSheet, value);
+                }
+            }
+            setEvaluationView(evaluationResult);
+        }
+
+        if (valueChanged || previousValueChanged) {
+            previousValue = newPreviousValue;
+            if (previousValue >= 0.0f) {
+                final float diff = value - previousValue;
+
+                String symbol;
+
+                if (diff > 0.0) {
+                    symbol = SYMBOL_UP;
+                } else if (diff < 0.0) {
+                    symbol = SYMBOL_DOWN;
+                } else {
+                    symbol = SYMBOL_NEUTRAL;
+                }
+
+                setNameView(Html.fromHtml(
+                        String.format(
+                                "%s <br> <font color='grey'>%s<small>%s%s</small></font>",
+                                nameText, symbol, formatValue(diff), suffix)));
+            } else {
+                setNameView(nameText);
+            }
+        }
+    }
+
+    private void incValue() {
+        setValue(clampValue(value + 0.1f), previousValue, true);
+    }
+    private void decValue() {
+        setValue(clampValue(value - 0.1f), previousValue, true);
+    }
+
+    protected String formatValue(float value) {
+        return String.format(Locale.getDefault(), "%.2f", value);
+    }
+
+    protected abstract float getMeasurementValue(ScaleMeasurement measurement);
+    protected abstract void setMeasurementValue(float value, ScaleMeasurement measurement);
+
+    protected abstract String getUnit();
+    protected abstract float getMaxValue();
+
+    protected boolean isEstimationEnabled() {
+        return false;
+    }
+
+    protected abstract EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value);
+
+    private boolean useAutoValue() {
+        return isEstimationEnabled() && getMeasurementMode() == MeasurementViewMode.ADD;
+    }
+
+    @Override
+    public void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement) {
+        dateTime = measurement.getDateTime();
+
+        float newValue = AUTO_VALUE;
+        float newPreviousValue = NO_VALUE;
+
+        if (!useAutoValue()) {
+            newValue = clampValue(getMeasurementValue(measurement));
+            if (previousMeasurement != null) {
+                newPreviousValue = clampValue(getMeasurementValue(previousMeasurement));
+            }
+        }
+
+        setValue(newValue, newPreviousValue, false);
+    }
+
+    @Override
+    public void saveTo(ScaleMeasurement measurement) {
+        if (!useAutoValue()) {
+            setMeasurementValue(value, measurement);
+        }
+    }
+
+    @Override
+    public String getValueAsString() {
+        if (useAutoValue()) {
+            return getContext().getString(R.string.label_automatic);
+        }
+        return formatValue(value);
+    }
+
+    @Override
+    public String getDiffValue() {
+        if (previousValue < 0.0f) {
+            return "";
+        }
+
+        String symbol;
+        String color;
+
+        final float diff = value - previousValue;
+        if (diff > 0.0f) {
+            symbol = SYMBOL_UP;
+            color = "green";
+        } else if (diff < 0.0f) {
+            symbol = SYMBOL_DOWN;
+            color = "red";
+        } else {
+            symbol = SYMBOL_NEUTRAL;
+            color = "grey";
+        }
+        return String.format(
+                "<font color='%s'>%s</font><font color='grey'><small>%s</small></font>",
+                color, symbol, formatValue(diff));
+    }
+
+    @Override
+    protected boolean isEditable() {
+        if (useAutoValue()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void setEditMode(MeasurementViewMode mode) {
+        super.setEditMode(mode);
+
+        if (mode == MeasurementViewMode.VIEW || !isEditable()) {
+            incButton.setVisibility(View.GONE);
+            decButton.setVisibility(View.GONE);
+        }
+        else {
+            incButton.setVisibility(View.VISIBLE);
+            decButton.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Override
+    public void setExpand(boolean state) {
+        final boolean show = state && isVisible() && evaluationResult != null;
+        showEvaluatorRow(show);
+    }
+
+    @Override
+    protected boolean validateAndSetInput(EditText view) {
+        final String text = view.getText().toString();
+
+        if (text.isEmpty()) {
+            view.setError(getResources().getString(R.string.error_value_required));
+            return false;
+        }
+
+        float newValue;
+        try {
+            newValue = Float.valueOf(text.replace(',', '.'));
+        }
+        catch (NumberFormatException ex) {
+            newValue = -1;
+        }
+
+        if (newValue < 0 || newValue > getMaxValue()) {
+            view.setError(getResources().getString(R.string.error_value_range));
+            return false;
+        }
+
+        setValue(newValue, previousValue, true);
+        return true;
+    }
+
+    @Override
+    protected int getInputType() {
+        return InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
+    }
+
+    @Override
+    protected String getHintText() {
+        return getResources().getString(R.string.info_enter_value_unit) + " " + getUnit();
+    }
+
+    private class RepeatListener implements OnTouchListener {
+        private Handler handler = new Handler();
+
+        private int initialInterval;
+        private final int normalInterval;
+        private final OnClickListener clickListener;
+
+        private Runnable handlerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                handler.postDelayed(this, normalInterval);
+                clickListener.onClick(downView);
+            }
+        };
+
+        private View downView;
+
+        /**
+         * RepeatListener cyclically runs a clickListener, emulating keyboard-like behaviour. First
+         * click is fired immediately, next one after the initialInterval, and subsequent ones after the normalInterval.
+         *
+         * @param initialInterval The interval after first click event
+         * @param normalInterval The interval after second and subsequent click events
+         * @param clickListener The OnClickListener, that will be called periodically
+         */
+        public RepeatListener(int initialInterval, int normalInterval,
+                              OnClickListener clickListener) {
+            if (clickListener == null) {
+                throw new IllegalArgumentException("null runnable");
+            }
+            if (initialInterval < 0 || normalInterval < 0) {
+                throw new IllegalArgumentException("negative interval");
+            }
+
+            this.initialInterval = initialInterval;
+            this.normalInterval = normalInterval;
+            this.clickListener = clickListener;
+        }
+
+        public boolean onTouch(View view, MotionEvent motionEvent) {
+            switch (motionEvent.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    handler.removeCallbacks(handlerRunnable);
+                    handler.postDelayed(handlerRunnable, initialInterval);
+                    downView = view;
+                    downView.setPressed(true);
+                    clickListener.onClick(view);
+                    return true;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    handler.removeCallbacks(handlerRunnable);
+                    downView.setPressed(false);
+                    downView = null;
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -24,25 +24,10 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class HipMeasurementView extends MeasurementView {
+public class HipMeasurementView extends FloatMeasurementView {
 
     public HipMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_hip), ContextCompat.getDrawable(context, R.drawable.ic_hip));
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getHip());
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getHip(), lastMeasurement.getHip());
-    }
-
-    @Override
-    public String getUnit() {
-        return "cm";
     }
 
     @Override
@@ -51,13 +36,27 @@ public class HipMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getHip();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setHip(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "cm";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 200;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return null;
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -24,39 +24,12 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class LBWMeasurementView extends MeasurementView {
+public class LBWMeasurementView extends FloatMeasurementView {
 
     private boolean estimateLBWEnable;
 
     public LBWMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_lbw), ContextCompat.getDrawable(context, R.drawable.ic_lbw));
-    }
-
-    @Override
-    public boolean isEditable() {
-        if (estimateLBWEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        if (estimateLBWEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            setValueOnView(newMeasurement.getDateTime(), (getContext().getString(R.string.label_automatic)));
-        } else {
-            setValueOnView(newMeasurement.getDateTime(), newMeasurement.getLbw());
-        }
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getLbw(), lastMeasurement.getLbw());
-    }
-
-    @Override
-    public String getUnit() {
-        return "kg";
     }
 
     @Override
@@ -66,13 +39,32 @@ public class LBWMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getLbw();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setLbw(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "kg";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 300;
     }
 
+    @Override
+    protected boolean isEstimationEnabled() {
+        return estimateLBWEnable;
+    }
+
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return null;
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -24,30 +24,10 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class MuscleMeasurementView extends MeasurementView {
+public class MuscleMeasurementView extends FloatMeasurementView {
 
     public MuscleMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_muscle), ContextCompat.getDrawable(context, R.drawable.ic_muscle));
-    }
-
-    @Override
-    public boolean isEditable() {
-        return true;
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getMuscle());
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getMuscle(), lastMeasurement.getMuscle());
-    }
-
-    @Override
-    public String getUnit() {
-        return "%";
     }
 
     @Override
@@ -56,13 +36,27 @@ public class MuscleMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateBodyMuscle(value);
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getMuscle();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setMuscle(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "%";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 80;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateBodyMuscle(value);
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -20,12 +20,11 @@ import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.v4.content.ContextCompat;
+import android.widget.EditText;
 import android.widget.TimePicker;
 
 import com.health.openscale.R;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
-import com.health.openscale.core.evaluation.EvaluationResult;
-import com.health.openscale.core.evaluation.EvaluationSheet;
 
 import java.text.DateFormat;
 import java.util.Calendar;
@@ -33,65 +32,89 @@ import java.util.Date;
 
 public class TimeMeasurementView extends MeasurementView {
     private DateFormat timeFormat;
+    private Date time;
 
     public TimeMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_time), ContextCompat.getDrawable(context, R.drawable.ic_daysleft));
         timeFormat = android.text.format.DateFormat.getTimeFormat(context);
     }
 
+    private void setValue(Date newTime, boolean callListener) {
+        if (!newTime.equals(time)) {
+            time = newTime;
+            setValueView(timeFormat.format(time), callListener);
+        }
+    }
+
+    @Override
+    public void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement) {
+        setValue(measurement.getDateTime(), false);
+    }
+
+    @Override
+    public void saveTo(ScaleMeasurement measurement) {
+        Calendar target = Calendar.getInstance();
+        target.setTime(measurement.getDateTime());
+
+        Calendar source = Calendar.getInstance();
+        source.setTime(time);
+
+        target.set(Calendar.HOUR, source.get(Calendar.HOUR));
+        target.set(Calendar.MINUTE, source.get(Calendar.MINUTE));
+        target.set(Calendar.SECOND, 0);
+        target.set(Calendar.MILLISECOND, 0);
+
+        measurement.setDateTime(target.getTime());
+    }
+
+    @Override
+    public void updatePreferences(SharedPreferences preferences) {
+        // Empty
+    }
+
+    @Override
+    public String getValueAsString() {
+        return timeFormat.format(time);
+    }
+
+    @Override
+    protected boolean validateAndSetInput(EditText view) {
+        return false;
+    }
+
+    @Override
+    protected int getInputType() {
+        return 0;
+    }
+
+    @Override
+    protected String getHintText() {
+        return null;
+    }
+
     private TimePickerDialog.OnTimeSetListener timePickerListener = new TimePickerDialog.OnTimeSetListener() {
         @Override
         public void onTimeSet(TimePicker view, int hourOfDay, int minute) {
             Calendar cal = Calendar.getInstance();
+            cal.setTime(time);
+
             cal.set(Calendar.HOUR_OF_DAY, hourOfDay);
             cal.set(Calendar.MINUTE, minute);
             cal.set(Calendar.SECOND, 0);
-            Date date = cal.getTime();
-            setValueOnView(date, timeFormat.format(date));
+            cal.set(Calendar.MILLISECOND, 0);
+
+            setValue(cal.getTime(), true);
         }
     };
 
     @Override
     protected AlertDialog getInputDialog() {
         Calendar cal = Calendar.getInstance();
-        cal.setTime(getDateTime());
+        cal.setTime(time);
 
-        TimePickerDialog timePicker = new TimePickerDialog(
+        return new TimePickerDialog(
             getContext(), timePickerListener,
             cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE),
             android.text.format.DateFormat.is24HourFormat(getContext()));
-
-        return timePicker;
     }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), timeFormat.format(newMeasurement.getDateTime()));
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-
-    }
-
-    @Override
-    public String getUnit() {
-        return null;
-    }
-
-    @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return null;
-    }
-
-    @Override
-    public float getMaxValue() {
-        return 0;
-    }
-
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -24,10 +24,16 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class WHRMeasurementView extends MeasurementView {
+public class WHRMeasurementView extends FloatMeasurementView {
 
     public WHRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whr), ContextCompat.getDrawable(context, R.drawable.ic_whr));
+    }
+
+    @Override
+    public void updatePreferences(SharedPreferences preferences) {
+        setVisible(preferences.getBoolean("hipEnable", false)
+                && preferences.getBoolean("waistEnable", false));
     }
 
     @Override
@@ -36,33 +42,27 @@ public class WHRMeasurementView extends MeasurementView {
     }
 
     @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getWHR());
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getWHR();
     }
 
     @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getWHR(), lastMeasurement.getWHR());
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        // Empty
     }
 
     @Override
-    public String getUnit() {
+    protected String getUnit() {
         return "";
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("hipEnable", false) && preferences.getBoolean("waistEnable", false));
-    }
-
-    @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateWHR(value);
-    }
-
-    @Override
-    public float getMaxValue() {
+    protected float getMaxValue() {
         return 1.5f;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateWHR(value);
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -24,30 +24,10 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class WHtRMeasurementView extends MeasurementView {
+public class WHtRMeasurementView extends FloatMeasurementView {
 
     public WHtRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whtr), ContextCompat.getDrawable(context, R.drawable.ic_whtr));
-    }
-
-    @Override
-    public boolean isEditable() {
-        return false;
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getWHtR(getScaleUser().getBodyHeight()));
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getWHtR(getScaleUser().getBodyHeight()), lastMeasurement.getWHtR(getScaleUser().getBodyHeight()));
-    }
-
-    @Override
-    public String getUnit() {
-        return "";
     }
 
     @Override
@@ -56,13 +36,32 @@ public class WHtRMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateWHtR(value);
+    public boolean isEditable() {
+        return false;
     }
 
     @Override
-    public float getMaxValue() {
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getWHtR(getScaleUser().getBodyHeight());
+    }
+
+    @Override
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        // Empty
+    }
+
+    @Override
+    protected String getUnit() {
+        return "";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 1;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateWHtR(value);
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -24,25 +24,10 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class WaistMeasurementView extends MeasurementView {
+public class WaistMeasurementView extends FloatMeasurementView {
 
     public WaistMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_waist), ContextCompat.getDrawable(context, R.drawable.ic_waist));
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getWaist());
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getWaist(), lastMeasurement.getWaist());
-    }
-
-    @Override
-    public String getUnit() {
-        return "cm";
     }
 
     @Override
@@ -51,13 +36,27 @@ public class WaistMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateWaist(value);
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getWaist();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setWaist(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "cm";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 200;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateWaist(value);
+    }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -24,39 +24,12 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class WaterMeasurementView extends MeasurementView {
+public class WaterMeasurementView extends FloatMeasurementView {
 
     private boolean estimateWaterEnable;
 
     public WaterMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_water), ContextCompat.getDrawable(context, R.drawable.ic_water));
-    }
-
-    @Override
-    public boolean isEditable() {
-        if (estimateWaterEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        if (estimateWaterEnable && getMeasurementMode() == MeasurementViewMode.ADD) {
-            setValueOnView(newMeasurement.getDateTime(), (getContext().getString(R.string.label_automatic)));
-        } else {
-            setValueOnView(newMeasurement.getDateTime(), newMeasurement.getWater());
-        }
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getWater(), lastMeasurement.getWater());
-    }
-
-    @Override
-    public String getUnit() {
-        return "%";
     }
 
     @Override
@@ -66,12 +39,32 @@ public class WaterMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateBodyWater(value);
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getWater();
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setWater(value);
+    }
+
+    @Override
+    protected String getUnit() {
+        return "%";
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 80;
+    }
+
+    @Override
+    protected boolean isEstimationEnabled() {
+        return estimateWaterEnable;
+    }
+
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateBodyWater(value);
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -25,25 +25,10 @@ import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
-public class WeightMeasurementView extends MeasurementView {
+public class WeightMeasurementView extends FloatMeasurementView {
 
     public WeightMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_weight), ContextCompat.getDrawable(context, R.drawable.ic_weight));
-    }
-
-    @Override
-    public void updateValue(ScaleMeasurement newMeasurement) {
-        setValueOnView(newMeasurement.getDateTime(), newMeasurement.getConvertedWeight(getScaleUser().getScaleUnit()));
-    }
-
-    @Override
-    public void updateDiff(ScaleMeasurement newMeasurement, ScaleMeasurement lastMeasurement) {
-        setDiffOnView(newMeasurement.getConvertedWeight(getScaleUser().getScaleUnit()), lastMeasurement.getConvertedWeight(getScaleUser().getScaleUnit()));
-    }
-
-    @Override
-    public String getUnit() {
-        return ScaleUser.UNIT_STRING[getScaleUser().getScaleUnit()];
     }
 
     @Override
@@ -52,13 +37,27 @@ public class WeightMeasurementView extends MeasurementView {
     }
 
     @Override
-    public EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
-        return evalSheet.evaluateWeight(value);
+    protected float getMeasurementValue(ScaleMeasurement measurement) {
+        return measurement.getConvertedWeight(getScaleUser().getScaleUnit());
     }
 
     @Override
-    public float getMaxValue() {
+    protected void setMeasurementValue(float value, ScaleMeasurement measurement) {
+        measurement.setConvertedWeight(value, getScaleUser().getScaleUnit());
+    }
+
+    @Override
+    protected String getUnit() {
+        return ScaleUser.UNIT_STRING[getScaleUser().getScaleUnit()];
+    }
+
+    @Override
+    protected float getMaxValue() {
         return 300;
     }
 
+    @Override
+    protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {
+        return evalSheet.evaluateWeight(value);
+    }
 }


### PR DESCRIPTION
The biggest part of this PR involves refactoring the inheritance hierarchy for MeasurementViews by adding a new FloatMeasurementView that all measurement views that holds a float inherits from. This way the base class MeasurementView can be cleaned up as much code is moved to FloatMeasurementView where it can deal with the value in a more explicit way as it is always float there.

The second part of this involves changing the DataEntryActivity to not save measurements to the database when navigating between them unless they have been modified. This improves the performance when switching between measurements. I have some more things I would like to do in this area, such as changing how the active user is handled, but that is for later.

DataEntryActivity now holds on to a clone of the ScaleMeasurement it is displaying, which makes it easier to update when something changes and cascade the changes to the other views.

Other performance improvements includes not updating the views unless the value has changed and using SpannableStringBuilder instead of Html.fromHtml to style text (only in MeasurementView, not yet in TableFragment).