### PR TITLE
Move test to the location where gradle expects to find them

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -5,6 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.health.openscale"
+        testApplicationId "com.health.openscale.test"
         minSdkVersion 18
         targetSdkVersion 22 // don't set target sdk > 22 otherwise bluetooth le discovery need permission to ACCESS_COARSE_LOCATION
         versionCode 22

--- a/android_app/app/src/androidTest/java/com.health.openscale/DatabaseTest.java
+++ b/android_app/app/src/androidTest/java/com.health.openscale/DatabaseTest.java
@@ -13,7 +13,7 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
-package com.health.openscale.junit;
+package com.health.openscale;
 
 import android.arch.persistence.room.Room;
 import android.content.Context;

--- a/android_app/app/src/test/java/com.health.openscale/CsvHelperTest.java
+++ b/android_app/app/src/test/java/com.health.openscale/CsvHelperTest.java
@@ -14,7 +14,7 @@
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-package com.health.openscale.junit;
+package com.health.openscale;
 
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.utils.CsvHelper;

--- a/android_app/app/src/test/java/com.health.openscale/DateTimeHelpersTest.java
+++ b/android_app/app/src/test/java/com.health.openscale/DateTimeHelpersTest.java
@@ -14,7 +14,7 @@
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-package com.health.openscale.junit;
+package com.health.openscale;
 
 import com.health.openscale.core.utils.DateTimeHelpers;
 


### PR DESCRIPTION
I was trying to add another android test but I couldn't figure out how to actually run it. But after moving the test to androidTest it was really simple to run from android studio.

I also looked at the build log from Travis and as far as I can tell the unit tests aren't running there as no test sources could be found. By moving them to where gradle expects them the tests are now run.

I know you didn't want the tests here, but it makes it much simpler to actually run them so I hope you can accept it.