### PR TITLE
Update dependency type to match what the dependency is used for

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -33,6 +33,7 @@ android {
         }
     }
 }
+
 ext {
     supportLibVersion = '27.0.2'
 }
@@ -41,17 +42,30 @@ dependencies {
     implementation "com.android.support:design:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
+
+    // HelloCharts
     implementation 'com.github.lecho:hellocharts-library:1.5.8@aar'
+
+    // Simple CSV
     implementation 'com.j256.simplecsv:simplecsv:2.2'
+
+    // CustomActivityOnCrash
     implementation 'cat.ereza:customactivityoncrash:2.2.0'
+
+    // Room
     implementation 'android.arch.persistence.room:runtime:1.0.0'
-    implementation 'junit:junit:4.12'
-    implementation 'android.arch.persistence.room:testing:1.0.0'
-    implementation 'com.android.support.test:runner:1.0.1'
-    implementation 'com.android.support.test:rules:1.0.1'
-    implementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-    implementation 'com.android.support.test.espresso:espresso-contrib:3.0.1'
     annotationProcessor 'android.arch.persistence.room:compiler:1.0.0'
+    androidTestImplementation 'android.arch.persistence.room:testing:1.0.0'
+
+    // Local unit tests
+    testImplementation 'junit:junit:4.12'
+
+    // Instrumented unit tests
+    androidTestImplementation "com.android.support:support-annotations:${supportLibVersion}"
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.1'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Fixes some of the build problems I've been having when rebuilding tests and saves about 1.5MB when comparing app-debug.apk between master and this branch.