### PR TITLE
Database upgrade and cleanup

### DIFF
--- a/android_app/app/schemas/com.health.openscale.core.database.AppDatabase/2.json
+++ b/android_app/app/schemas/com.health.openscale.core.database.AppDatabase/2.json
@@ -1,0 +1,195 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "166a2a83c723c4117edaf1d107ac5194",
+    "entities": [
+      {
+        "tableName": "scaleMeasurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `userId` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `datetime` INTEGER, `weight` REAL NOT NULL, `fat` REAL NOT NULL, `water` REAL NOT NULL, `muscle` REAL NOT NULL, `lbw` REAL NOT NULL, `waist` REAL NOT NULL, `hip` REAL NOT NULL, `bone` REAL NOT NULL, `comment` TEXT, FOREIGN KEY(`userId`) REFERENCES `scaleUsers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "datetime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fat",
+            "columnName": "fat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "water",
+            "columnName": "water",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscle",
+            "columnName": "muscle",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lbw",
+            "columnName": "lbw",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "waist",
+            "columnName": "waist",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hip",
+            "columnName": "hip",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bone",
+            "columnName": "bone",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_scaleMeasurements_datetime_userId",
+            "unique": true,
+            "columnNames": [
+              "datetime",
+              "userId"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_scaleMeasurements_datetime_userId` ON `${TABLE_NAME}` (`datetime`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "scaleUsers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "scaleUsers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT, `birthday` INTEGER, `bodyHeight` INTEGER NOT NULL, `scaleUnit` INTEGER NOT NULL, `gender` INTEGER NOT NULL, `initialWeight` REAL NOT NULL, `goalWeight` REAL NOT NULL, `goalDate` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "birthday",
+            "columnName": "birthday",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bodyHeight",
+            "columnName": "bodyHeight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scaleUnit",
+            "columnName": "scaleUnit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialWeight",
+            "columnName": "initialWeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goalWeight",
+            "columnName": "goalWeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goalDate",
+            "columnName": "goalDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"166a2a83c723c4117edaf1d107ac5194\")"
+    ]
+  }
+}

--- a/android_app/app/src/androidTest/java/com/health/openscale/DatabaseMigrationTest.java
+++ b/android_app/app/src/androidTest/java/com/health/openscale/DatabaseMigrationTest.java
@@ -1,0 +1,110 @@
+/* Copyright (C) 2018 Erik Johansson <erik@ejohansson.se>
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package com.health.openscale;
+
+import android.arch.persistence.db.SupportSQLiteDatabase;
+import android.arch.persistence.db.SupportSQLiteOpenHelper;
+import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory;
+import android.arch.persistence.room.testing.MigrationTestHelper;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.health.openscale.core.database.AppDatabase;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class DatabaseMigrationTest {
+    private static final String TEST_DB = "migration-test";
+
+    @Rule
+    public MigrationTestHelper helper;
+
+    public DatabaseMigrationTest() {
+        helper = new MigrationTestHelper(
+                InstrumentationRegistry.getInstrumentation(),
+                AppDatabase.class.getCanonicalName(),
+                new FrameworkSQLiteOpenHelperFactory());
+    }
+
+    @Test
+    public void migrate1To2() throws Exception {
+        SupportSQLiteDatabase db = helper.createDatabase(TEST_DB, 1);
+
+        ContentValues users = new ContentValues();
+        for (int i = 1; i < 4; ++i) {
+            users.put("id", i);
+            users.put("username", String.format("test%d", i));
+            users.put("bodyHeight", i * 50);
+            users.put("scaleUnit", 0);
+            users.put("gender", 0);
+            users.put("initialWeight", i * 25);
+            users.put("goalWeight", i * 20);
+            assertNotSame(-1, db.insert("scaleUsers", SQLiteDatabase.CONFLICT_ABORT, users));
+        }
+
+        ContentValues measurement = new ContentValues();
+        for (int i = 2; i < 5; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                measurement.put("userId", i);
+                measurement.put("enabled", j);
+                measurement.put("comment", "a string");
+                for (String type : new String[]{"weight", "fat", "water", "muscle", "lbw", "waist", "hip", "bone"}) {
+                    measurement.put(type, i * j);
+                }
+
+                assertNotSame(-1, db.insert("scaleMeasurements", SQLiteDatabase.CONFLICT_ABORT, measurement));
+            }
+        }
+
+        // Prepare for the next version.
+        db.close();
+
+        // Re-open the database with version 2 and provide MIGRATION_1_2 as the migration process.
+        db = helper.runMigrationsAndValidate(TEST_DB, 2, true, AppDatabase.MIGRATION_1_2);
+
+        // MigrationTestHelper automatically verifies the schema changes.
+
+        Cursor cursor = db.query("SELECT * FROM scaleMeasurements ORDER BY id, userId");
+        assertEquals(2 * 2, cursor.getCount());
+
+        cursor.moveToFirst();
+        for (int i = 2; i < 4; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                assertEquals(i, cursor.getInt(cursor.getColumnIndex("userId")));
+                assertEquals(j, cursor.getInt(cursor.getColumnIndex("enabled")));
+                assertEquals("a string", cursor.getString(cursor.getColumnIndex("comment")));
+                for (String type : new String[]{"weight", "fat", "water", "muscle", "lbw", "waist", "hip", "bone"}) {
+                    assertEquals((float) i * j, cursor.getFloat(cursor.getColumnIndex(type)));
+                }
+
+                cursor.moveToNext();
+            }
+        }
+
+        assertTrue(cursor.isAfterLast());
+    }
+}

--- a/android_app/app/src/androidTest/java/com/health/openscale/DatabaseTest.java
+++ b/android_app/app/src/androidTest/java/com/health/openscale/DatabaseTest.java
@@ -65,7 +65,7 @@ public class DatabaseTest {
     @Test
     public void userOperations() throws Exception {
         ScaleUser user1 = new ScaleUser();
-        ScaleUser user2  = new ScaleUser();
+        ScaleUser user2 = new ScaleUser();
 
         user1.setUserName("foo");
         user2.setUserName("bar");
@@ -121,8 +121,14 @@ public class DatabaseTest {
 
     @Test
     public void measurementOperations() throws Exception {
+        final ScaleUser scaleUser1 = new ScaleUser();
+        final ScaleUser scaleUser2 = new ScaleUser();
+
+        scaleUser1.setId((int)userDao.insert(scaleUser1));
+        scaleUser2.setId((int)userDao.insert(scaleUser2));
+
         // User 1 data initialization
-        final int user1 = 0;
+        final int user1 = scaleUser1.getId();
         ScaleMeasurement measurement11 = new ScaleMeasurement();
         ScaleMeasurement measurement12 = new ScaleMeasurement();
         ScaleMeasurement measurement13 = new ScaleMeasurement();
@@ -140,7 +146,7 @@ public class DatabaseTest {
         measurement13.setDateTime(new Date(300));
 
         // User 2 data initialization
-        final int user2 = 1;
+        final int user2 = scaleUser2.getId();
         ScaleMeasurement measurement21 = new ScaleMeasurement();
         ScaleMeasurement measurement22 = new ScaleMeasurement();
 

--- a/android_app/app/src/androidTest/java/com/health/openscale/gui/ScreenshotRecorder.java
+++ b/android_app/app/src/androidTest/java/com/health/openscale/gui/ScreenshotRecorder.java
@@ -35,6 +35,7 @@ import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.CsvHelper;
+import com.health.openscale.core.utils.DateTimeHelpers;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -113,26 +114,22 @@ public class ScreenshotRecorder {
 
     ScaleUser getTestUser() {
         ScaleUser user = new ScaleUser();
-        user.setUserName("test");
+        user.setUserName("Test");
         user.setBodyHeight(180);
         user.setInitialWeight(80.0f);
         user.setGoalWeight(60.0f);
 
         Calendar birthday = Calendar.getInstance();
-        birthday.setTimeInMillis(0);
-        birthday.set(Calendar.YEAR, 1990);
-        birthday.set(Calendar.MONTH, Calendar.JANUARY);
-        birthday.set(Calendar.DAY_OF_MONTH, 19);
-        birthday.set(Calendar.HOUR_OF_DAY, 0);
+        birthday.add(Calendar.YEAR, -28);
+        birthday.set(birthday.get(Calendar.YEAR), Calendar.JANUARY, 19, 0, 0, 0);
+        birthday.set(Calendar.MILLISECOND, 0);
 
         user.setBirthday(birthday.getTime());
 
         Calendar goalDate = Calendar.getInstance();
-        goalDate.setTimeInMillis(0);
-        goalDate.set(Calendar.YEAR, 2018);
-        goalDate.set(Calendar.MONTH, Calendar.JANUARY);
-        goalDate.set(Calendar.DAY_OF_MONTH, 31);
-        goalDate.set(Calendar.HOUR_OF_DAY, 0);
+        goalDate.add(Calendar.YEAR, 1);
+        goalDate.set(goalDate.get(Calendar.YEAR), Calendar.JANUARY, 31, 0, 0, 0);
+        goalDate.set(Calendar.MILLISECOND, 0);
 
         user.setGoalDate(goalDate.getTime());
 
@@ -199,13 +196,16 @@ public class ScreenshotRecorder {
             e.printStackTrace();
         }
 
-        // set current year to the measurement data
+        // Move measurements forward in time
         Calendar measurementDate = Calendar.getInstance();
-        int year = measurementDate.get(Calendar.YEAR);
+        if (!scaleMeasurementList.isEmpty()) {
+            measurementDate.setTime(scaleMeasurementList.get(0).getDateTime());
+        }
+        final int daysToAdvance = DateTimeHelpers.daysBetween(measurementDate, Calendar.getInstance());
 
         for (ScaleMeasurement measurement : scaleMeasurementList) {
             measurementDate.setTime(measurement.getDateTime());
-            measurementDate.set(Calendar.YEAR, year);
+            measurementDate.add(Calendar.DAY_OF_YEAR, daysToAdvance);
             measurement.setDateTime(measurementDate.getTime());
         }
 

--- a/android_app/app/src/androidTest/java/com/health/openscale/gui/ScreenshotRecorder.java
+++ b/android_app/app/src/androidTest/java/com/health/openscale/gui/ScreenshotRecorder.java
@@ -213,7 +213,8 @@ public class ScreenshotRecorder {
     }
 
     private void prepareData() {
-        openScale.addScaleUser(getTestUser());
+        int userId = openScale.addScaleUser(getTestUser());
+        openScale.selectScaleUser(userId);
 
         List<ScaleMeasurement> scaleMeasurementList = getTestMeasurements();
 

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -65,6 +65,8 @@ public class OpenScale {
     private AppDatabase appDB;
     private ScaleMeasurementDAO measurementDAO;
     private ScaleUserDAO userDAO;
+
+    private ScaleUser selectedScaleUser;
     private List<ScaleMeasurement> scaleMeasurementList;
 
     private BluetoothCommunication btCom;
@@ -145,50 +147,55 @@ public class OpenScale {
     public void selectScaleUser(int userId) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         prefs.edit().putInt("selectedUserId", userId).commit();
+
+        selectedScaleUser = null;
     }
 
     public int getSelectedScaleUserId() {
+        if (selectedScaleUser != null) {
+            return selectedScaleUser.getId();
+        }
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         return prefs.getInt("selectedUserId", -1);
     }
 
-    public List<ScaleUser> getScaleUserList()
-    {
+    public List<ScaleUser> getScaleUserList() {
         return userDAO.getAll();
     }
 
-    public ScaleUser getScaleUser(int userId)
-    {
+    public ScaleUser getScaleUser(int userId) {
+        if (selectedScaleUser != null && selectedScaleUser.getId() == userId) {
+            return selectedScaleUser;
+        }
         return userDAO.get(userId);
     }
 
-    public ScaleUser getSelectedScaleUser()
-    {
-        ScaleUser scaleUser = new ScaleUser();
+    public ScaleUser getSelectedScaleUser() {
+        if (selectedScaleUser != null) {
+            return selectedScaleUser;
+        }
 
         try {
-            int selectedUserId = getSelectedScaleUserId();
-
-            if (selectedUserId == -1) {
-                return scaleUser;
+            final int selectedUserId = getSelectedScaleUserId();
+            if (selectedUserId != -1) {
+                selectedScaleUser = userDAO.get(selectedUserId);
+                return selectedScaleUser;
             }
-
-            scaleUser = userDAO.get(selectedUserId);
         } catch (Exception e) {
             Toast.makeText(context, "Error: " + e.getMessage(), Toast.LENGTH_SHORT).show();
         }
 
-        return scaleUser;
+        return new ScaleUser();
     }
 
-    public void deleteScaleUser(int id)
-    {
+    public void deleteScaleUser(int id) {
         userDAO.delete(userDAO.get(id));
+        selectedScaleUser = null;
     }
 
-    public void updateScaleUser(ScaleUser user)
-    {
+    public void updateScaleUser(ScaleUser user) {
         userDAO.update(user);
+        selectedScaleUser = null;
     }
 
     public List<ScaleMeasurement> getScaleMeasurementList() {

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -138,12 +138,18 @@ public class OpenScale {
         scaleDB.close();
     }
 
-    public void addScaleUser(final ScaleUser user)
-    {
-        long userId = userDAO.insert(user);
+    public int addScaleUser(final ScaleUser user) {
+        return (int)userDAO.insert(user);
+    }
 
+    public void selectScaleUser(int userId) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        prefs.edit().putInt("selectedUserId", (int)userId).commit();
+        prefs.edit().putInt("selectedUserId", userId).commit();
+    }
+
+    public int getSelectedScaleUserId() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return prefs.getInt("selectedUserId", -1);
     }
 
     public List<ScaleUser> getScaleUserList()
@@ -161,8 +167,7 @@ public class OpenScale {
         ScaleUser scaleUser = new ScaleUser();
 
         try {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            int selectedUserId  = prefs.getInt("selectedUserId", -1);
+            int selectedUserId = getSelectedScaleUserId();
 
             if (selectedUserId == -1) {
                 return scaleUser;
@@ -355,8 +360,7 @@ public class OpenScale {
     }
 
     public int[] getCountsOfMonth(int year) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+        int selectedUserId = getSelectedScaleUserId();
 
         int [] numOfMonth = new int[12];
 
@@ -375,8 +379,7 @@ public class OpenScale {
     }
 
     public List<ScaleMeasurement> getScaleDataOfMonth(int year, int month) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+        int selectedUserId = getSelectedScaleUserId();
 
         Calendar startCalender = Calendar.getInstance();
         Calendar endCalender = Calendar.getInstance();
@@ -389,8 +392,7 @@ public class OpenScale {
     }
 
     public List<ScaleMeasurement> getScaleDataOfYear(int year) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+        int selectedUserId = getSelectedScaleUserId();
 
         Calendar startCalender = Calendar.getInstance();
         Calendar endCalender = Calendar.getInstance();
@@ -430,18 +432,15 @@ public class OpenScale {
     public void registerFragment(FragmentUpdateListener fragment) {
         fragmentList.add(fragment);
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+        int selectedUserId = getSelectedScaleUserId();
 
         scaleMeasurementList = measurementDAO.getAll(selectedUserId);
 
         fragment.updateOnView(scaleMeasurementList);
     }
 
-    public void updateScaleData()
-    {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+    public void updateScaleData() {
+        int selectedUserId = getSelectedScaleUserId();
 
         scaleMeasurementList = measurementDAO.getAll(selectedUserId);
 

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -16,11 +16,14 @@
 
 package com.health.openscale.core;
 
+import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.arch.persistence.room.Room;
+import android.arch.persistence.room.RoomDatabase;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.text.format.DateFormat;
 import android.util.Log;
@@ -81,7 +84,17 @@ public class OpenScale {
         alarmHandler = new AlarmHandler();
         btCom = null;
         fragmentList = new ArrayList<>();
-        appDB = Room.databaseBuilder(context, AppDatabase.class, "openScale.db").allowMainThreadQueries().build();
+        appDB = Room.databaseBuilder(context, AppDatabase.class, "openScale.db")
+                .allowMainThreadQueries()
+                .addCallback(new RoomDatabase.Callback() {
+                    @Override
+                    public void onOpen(@NonNull SupportSQLiteDatabase db) {
+                        super.onOpen(db);
+                        db.setForeignKeyConstraintsEnabled(true);
+                    }
+                })
+                .addMigrations(AppDatabase.MIGRATION_1_2)
+                .build();
         measurementDAO = appDB.measurementDAO();
         userDAO = appDB.userDAO();
 

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -84,6 +84,26 @@ public class OpenScale {
         alarmHandler = new AlarmHandler();
         btCom = null;
         fragmentList = new ArrayList<>();
+
+        reopenDatabase();
+
+        migrateSQLtoRoom();
+        updateScaleData();
+    }
+
+    public static OpenScale getInstance(Context context) {
+        if (instance == null) {
+            instance = new OpenScale(context);
+        }
+
+        return instance;
+    }
+
+    public void reopenDatabase() {
+        if (appDB != null) {
+            appDB.close();
+        }
+
         appDB = Room.databaseBuilder(context, AppDatabase.class, "openScale.db")
                 .allowMainThreadQueries()
                 .addCallback(new RoomDatabase.Callback() {
@@ -97,17 +117,6 @@ public class OpenScale {
                 .build();
         measurementDAO = appDB.measurementDAO();
         userDAO = appDB.userDAO();
-
-        migrateSQLtoRoom();
-        updateScaleData();
-    }
-
-    public static OpenScale getInstance(Context context) {
-        if (instance == null) {
-            instance = new OpenScale(context);
-        }
-
-        return instance;
     }
 
     private void migrateSQLtoRoom() {

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -48,7 +48,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -70,8 +69,6 @@ public class OpenScale {
     private BluetoothCommunication btCom;
     private String btDeviceName;
     private AlarmHandler alarmHandler;
-
-    private SimpleDateFormat dateTimeFormat = new SimpleDateFormat("dd.MM.yyyy HH:mm");
 
     private Context context;
 

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -65,8 +65,6 @@ public class OpenScale {
     private AppDatabase appDB;
     private ScaleMeasurementDAO measurementDAO;
     private ScaleUserDAO userDAO;
-    private ScaleDatabase scaleDB;
-    private ScaleUserDatabase scaleUserDB;
     private List<ScaleMeasurement> scaleMeasurementList;
 
     private BluetoothCommunication btCom;
@@ -79,8 +77,6 @@ public class OpenScale {
 
     private OpenScale(Context context) {
         this.context = context;
-        scaleDB = new ScaleDatabase(context);
-        scaleUserDB = new ScaleUserDatabase(context);
         alarmHandler = new AlarmHandler();
         btCom = null;
         fragmentList = new ArrayList<>();
@@ -120,6 +116,10 @@ public class OpenScale {
     }
 
     private void migrateSQLtoRoom() {
+        // TODO: check if databases exist before opening and possibly creating them
+        ScaleDatabase scaleDB = new ScaleDatabase(context);
+        ScaleUserDatabase scaleUserDB = new ScaleUserDatabase(context);
+
         List<ScaleUser> oldScaleUserList = scaleUserDB.getScaleUserList();
 
         if (scaleDB.getReadableDatabase().getVersion() == 6 && userDAO.getAll().isEmpty() && !oldScaleUserList.isEmpty()) {
@@ -133,6 +133,9 @@ public class OpenScale {
 
             Toast.makeText(context, "Finished migrating old SQL database to new database format", Toast.LENGTH_LONG).show();
         }
+
+        scaleUserDB.close();
+        scaleDB.close();
     }
 
     public void addScaleUser(final ScaleUser user)

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothExingtechY1.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothExingtechY1.java
@@ -62,8 +62,7 @@ public class BluetoothExingtechY1 extends BluetoothCommunication {
                 byte height = (byte)(selectedUser.getBodyHeight() & 0xff); // cm
                 byte age = (byte)(selectedUser.getAge(new Date()) & 0xff);
 
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-                int userId = prefs.getInt("selectedUserId", -1);
+                int userId = selectedUser.getId();
 
                 byte cmdByte[] = {(byte)0x10, (byte)userId, gender, age, height};
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale.java
@@ -285,7 +285,7 @@ public class BluetoothMiScale extends BluetoothCommunication {
             prefs.edit().putInt("uniqueNumber", uniqueNumber).commit();
         }
 
-        int userId = prefs.getInt("selectedUserId", -1);
+        int userId = OpenScale.getInstance(context).getSelectedScaleUserId();
 
         return uniqueNumber + userId;
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale2.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale2.java
@@ -257,7 +257,7 @@ public class BluetoothMiScale2 extends BluetoothCommunication {
             prefs.edit().putInt("uniqueNumber", uniqueNumber).commit();
         }
 
-        int userId = prefs.getInt("selectedUserId", -1);
+        int userId = OpenScale.getInstance(context).getSelectedScaleUserId();
 
         return uniqueNumber + userId;
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiMini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiMini.java
@@ -154,7 +154,7 @@ public class BluetoothYunmaiMini extends BluetoothCommunication {
             prefs.edit().putInt("uniqueNumber", uniqueNumber).commit();
         }
 
-        int userId = prefs.getInt("selectedUserId", -1);
+        int userId = OpenScale.getInstance(context).getSelectedScaleUserId();
 
         return uniqueNumber + userId;
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE.java
@@ -152,7 +152,7 @@ public class BluetoothYunmaiSE extends BluetoothCommunication {
             prefs.edit().putInt("uniqueNumber", uniqueNumber).commit();
         }
 
-        int userId = prefs.getInt("selectedUserId", -1);
+        int userId = OpenScale.getInstance(context).getSelectedScaleUserId();
 
         return uniqueNumber + userId;
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/database/ScaleUserDatabase.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/database/ScaleUserDatabase.java
@@ -16,10 +16,8 @@
 
 package com.health.openscale.core.database;
 
-import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
@@ -60,9 +58,6 @@ public class ScaleUserDatabase extends SQLiteOpenHelper {
                     COLUMN_NAME_GOAL_DATE + " TEXT" +
                     ")";
 
-    private static final String SQL_DELETE_ENTRIES =
-            "DROP TABLE IF EXISTS " + TABLE_NAME;
-
     private static String[] projection = {
             COLUMN_NAME_ID,
             COLUMN_NAME_USER_NAME,
@@ -97,84 +92,6 @@ public class ScaleUserDatabase extends SQLiteOpenHelper {
         if (oldVersion == 2 && newVersion == 3) {
             db.execSQL("ALTER TABLE " + TABLE_NAME + " ADD COLUMN " + COLUMN_NAME_INITIAL_WEIGHT + " REAL DEFAULT 0");
         }
-    }
-
-    public void clearDatabase() {
-        SQLiteDatabase db = getWritableDatabase();
-
-        db.delete(TABLE_NAME, null, null);
-    }
-
-    public boolean insertEntry(ScaleUser scaleUser) {
-        SQLiteDatabase db = getWritableDatabase();
-
-        ContentValues values = new ContentValues();
-        values.put(COLUMN_NAME_USER_NAME, scaleUser.getUserName());
-        values.put(COLUMN_NAME_BIRTHDAY, formatDateTime.format(scaleUser.getBirthday()));
-        values.put(COLUMN_NAME_BODY_HEIGHT, scaleUser.getBodyHeight());
-        values.put(COLUMN_NAME_SCALE_UNIT, scaleUser.getScaleUnit().toInt());
-        values.put(COLUMN_NAME_GENDER, scaleUser.getGender().toInt());
-        values.put(COLUMN_NAME_INITIAL_WEIGHT, scaleUser.getInitialWeight());
-        values.put(COLUMN_NAME_GOAL_WEIGHT, scaleUser.getGoalWeight());
-        values.put(COLUMN_NAME_GOAL_DATE, formatDateTime.format(scaleUser.getGoalDate()));
-
-        try
-        {
-            db.insertOrThrow(TABLE_NAME, null, values);
-        }
-        catch (SQLException e)
-        {
-            Log.e("ScaleUserDatabase", "An error occured while inserting a new entry into the scale user database: " + e.toString());
-            return false;
-        }
-
-        return true;
-    }
-
-    public void deleteEntry(int id) {
-        SQLiteDatabase db = getWritableDatabase();
-
-        db.delete(TABLE_NAME, COLUMN_NAME_ID + "= ?", new String[] {String.valueOf(id)});
-    }
-
-    public void updateScaleUser(ScaleUser scaleUser)
-    {
-        SQLiteDatabase db = getWritableDatabase();
-
-        ContentValues values = new ContentValues();
-        values.put(COLUMN_NAME_USER_NAME, scaleUser.getUserName());
-        values.put(COLUMN_NAME_BIRTHDAY, formatDateTime.format(scaleUser.getBirthday()));
-        values.put(COLUMN_NAME_BODY_HEIGHT, scaleUser.getBodyHeight());
-        values.put(COLUMN_NAME_SCALE_UNIT, scaleUser.getScaleUnit().toInt());
-        values.put(COLUMN_NAME_GENDER, scaleUser.getGender().toInt());
-        values.put(COLUMN_NAME_INITIAL_WEIGHT, scaleUser.getInitialWeight());
-        values.put(COLUMN_NAME_GOAL_WEIGHT, scaleUser.getGoalWeight());
-        values.put(COLUMN_NAME_GOAL_DATE, formatDateTime.format(scaleUser.getGoalDate()));
-
-        db.update(TABLE_NAME, values, COLUMN_NAME_ID + "=" + scaleUser.getId(), null);
-    }
-
-    public ScaleUser getScaleUser(int id)
-    {
-        SQLiteDatabase db = getReadableDatabase();
-
-        Cursor cursorScaleDB = db.query(
-                TABLE_NAME,     // The table to query
-                projection,     // The columns to return
-                COLUMN_NAME_ID + "=?",             // The columns for the WHERE clause
-                new String[] {Integer.toString(id)},             // The values for the WHERE clause
-                null,             // don't group the rows
-                null,            // don't filter by row groups
-                null          // The sort order
-        );
-
-        cursorScaleDB.moveToFirst();
-
-        ScaleUser scaleUser = readAtCursor(cursorScaleDB);
-
-        cursorScaleDB.close();
-
-        return scaleUser;
     }
 
     public ArrayList<ScaleUser> getScaleUserList() {

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
@@ -18,6 +18,7 @@ package com.health.openscale.core.datatypes;
 
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.ForeignKey;
 import android.arch.persistence.room.Index;
 import android.arch.persistence.room.PrimaryKey;
 
@@ -26,7 +27,13 @@ import com.j256.simplecsv.common.CsvColumn;
 
 import java.util.Date;
 
-@Entity(tableName = "scaleMeasurements", indices = {@Index(value = {"datetime"}, unique = true)})
+@Entity(tableName = "scaleMeasurements",
+        indices = {@Index(value = {"datetime", "userId"}, unique = true)},
+        foreignKeys = @ForeignKey(
+                entity = ScaleUser.class,
+                parentColumns = "id",
+                childColumns = "userId",
+                onDelete = ForeignKey.CASCADE))
 public class ScaleMeasurement implements Cloneable {
 
     @PrimaryKey(autoGenerate = true)

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -301,8 +301,9 @@ public class DataEntryActivity extends Activity {
     private class onClickListenerAdd implements View.OnClickListener {
         @Override
         public void onClick(View v) {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            int selectedUserId = prefs.getInt("selectedUserId", -1);
+            OpenScale openScale = OpenScale.getInstance(getApplicationContext());
+
+            int selectedUserId = openScale.getSelectedScaleUserId();
 
             if (selectedUserId == -1) {
                 AlertDialog.Builder infoDialog = new AlertDialog.Builder(context);
@@ -317,7 +318,6 @@ public class DataEntryActivity extends Activity {
                     measurement.saveTo(scaleMeasurement);
                 }
 
-                OpenScale openScale = OpenScale.getInstance(getApplicationContext());
                 openScale.addScaleData(scaleMeasurement);
 
                 finish();

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
@@ -280,54 +280,52 @@ public class UserSettingsActivity extends Activity {
                     float initial_weight = Float.valueOf(txtInitialWeight.getText().toString());
                     float goal_weight = Float.valueOf(txtGoalWeight.getText().toString());
 
-                    int scale_unit = -1;
+                    Converters.WeightUnit scale_unit = Converters.WeightUnit.KG;
 
                     switch (checkedRadioButtonId) {
                         case R.id.btnRadioKG:
-                            scale_unit = 0;
+                            scale_unit = Converters.WeightUnit.KG;
                             break;
                         case R.id.btnRadioLB:
-                            scale_unit = 1;
+                            scale_unit = Converters.WeightUnit.LB;
                             break;
                         case R.id.btnRadioST:
-                            scale_unit = 2;
+                            scale_unit = Converters.WeightUnit.ST;
                             break;
                     }
 
-                    int gender = -1;
+                    Converters.Gender gender = Converters.Gender.MALE;
 
                     switch (checkedGenderId) {
                         case R.id.btnRadioMale:
-                            gender = 0;
+                            gender = Converters.Gender.MALE;
                             break;
                         case R.id.btnRadioWoman:
-                            gender = 1;
+                            gender = Converters.Gender.FEMALE;
                             break;
                     }
-
-                    int id = 0;
 
                     final ScaleUser scaleUser = new ScaleUser();
 
                     scaleUser.setUserName(name);
                     scaleUser.setBirthday(birthday);
                     scaleUser.setBodyHeight(body_height);
-                    scaleUser.setScaleUnit(Converters.fromWeightUnitInt(scale_unit));
-                    scaleUser.setGender(Converters.fromGenderInt(gender));
+                    scaleUser.setScaleUnit(scale_unit);
+                    scaleUser.setGender(gender);
                     scaleUser.setConvertedInitialWeight(initial_weight);
                     scaleUser.setGoalWeight(goal_weight);
                     scaleUser.setGoalDate(goal_date);
 
                     if (getIntent().getExtras().getInt("mode") == EDIT_USER_REQUEST) {
-                        id = getIntent().getExtras().getInt("id");
+                        int id = getIntent().getExtras().getInt("id");
                         scaleUser.setId(id);
                         openScale.updateScaleUser(scaleUser);
                     } else {
-                        id = openScale.addScaleUser(scaleUser);
+                        int id = openScale.addScaleUser(scaleUser);
+                        scaleUser.setId(id);
                     }
 
-                    openScale.selectScaleUser(id);
-
+                    openScale.selectScaleUser(scaleUser.getId());
                     openScale.updateScaleData();
 
                     Intent returnIntent = new Intent();

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/UserSettingsActivity.java
@@ -246,9 +246,7 @@ public class UserSettingsActivity extends Activity {
                         lastUserId = scaleUser.get(0).getId();
                     }
 
-                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-                    prefs.edit().putInt("selectedUserId", lastUserId).commit();
-
+                    openScale.selectScaleUser(lastUserId);
                     openScale.updateScaleData();
 
                     Intent returnIntent = new Intent();
@@ -325,13 +323,10 @@ public class UserSettingsActivity extends Activity {
                         scaleUser.setId(id);
                         openScale.updateScaleUser(scaleUser);
                     } else {
-                        openScale.addScaleUser(scaleUser);
-
-                        id = openScale.getScaleUserList().get(openScale.getScaleUserList().size() - 1).getId();
+                        id = openScale.addScaleUser(scaleUser);
                     }
 
-                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-                    prefs.edit().putInt("selectedUserId", id).commit();
+                    openScale.selectScaleUser(id);
 
                     openScale.updateScaleData();
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -476,13 +476,13 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
              if (parent.getChildCount() > 0) {
                  ((TextView) parent.getChildAt(0)).setTextColor(Color.GRAY);
 
-                 List<ScaleUser> scaleUserList = OpenScale.getInstance(getContext()).getScaleUserList();
+                 OpenScale openScale = OpenScale.getInstance(getContext());
 
+                 List<ScaleUser> scaleUserList = openScale.getScaleUserList();
                  ScaleUser scaleUser = scaleUserList.get(position);
 
-                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-                 prefs.edit().putInt("selectedUserId", scaleUser.getId()).commit();
-                 OpenScale.getInstance(getContext()).updateScaleData();
+                 openScale.selectScaleUser(scaleUser.getId());
+                 openScale.updateScaleData();
              }
         }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -263,8 +263,7 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
         @Override
         public void onClick(View v) {
 
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(v.getContext());
-            int selectedUserId  = prefs.getInt("selectedUserId", -1);
+            int selectedUserId = OpenScale.getInstance(getContext()).getSelectedScaleUserId();
 
             if (selectedUserId == -1)
             {

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/BackupPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/BackupPreferences.java
@@ -125,8 +125,7 @@ public class BackupPreferences extends PreferenceFragment {
             List<ScaleUser> scaleUserList = openScale.getScaleUserList();
 
             if (!scaleUserList.isEmpty()) {
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
-                prefs.edit().putInt("selectedUserId", scaleUserList.get(0).getId()).commit();
+                openScale.selectScaleUser(scaleUserList.get(0).getId());
                 openScale.updateScaleData();
             }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/BackupPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/BackupPreferences.java
@@ -119,12 +119,15 @@ public class BackupPreferences extends PreferenceFragment {
 
             importBackup("openScale.db", exportDir);
 
-            List<ScaleUser> scaleUserList = OpenScale.getInstance(getActivity().getApplicationContext()).getScaleUserList();
+            OpenScale openScale = OpenScale.getInstance(getActivity().getApplicationContext());
+            openScale.reopenDatabase();
+
+            List<ScaleUser> scaleUserList = openScale.getScaleUserList();
 
             if (!scaleUserList.isEmpty()) {
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
                 prefs.edit().putInt("selectedUserId", scaleUserList.get(0).getId()).commit();
-                OpenScale.getInstance(getActivity().getApplicationContext()).updateScaleData();
+                openScale.updateScaleData();
             }
 
             return true;

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -247,10 +247,10 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
 
             deleteAllDialog.setPositiveButton(getResources().getString(R.string.label_yes), new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {
-                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
-                    int selectedUserId  = prefs.getInt("selectedUserId", -1);
+                    OpenScale openScale = OpenScale.getInstance(getActivity().getApplicationContext());
+                    int selectedUserId = openScale.getSelectedScaleUserId();
 
-                    OpenScale.getInstance(getActivity().getApplicationContext()).clearScaleData(selectedUserId);
+                    openScale.clearScaleData(selectedUserId);
 
                     Toast.makeText(getActivity().getApplicationContext(), getResources().getString(R.string.info_data_all_deleted), Toast.LENGTH_SHORT).show();
                 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/UsersPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/UsersPreferences.java
@@ -41,14 +41,12 @@ public class UsersPreferences extends PreferenceFragment {
         updateUserPreferences();
     }
 
-    private void updateUserPreferences()
-    {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
-        int selectedUserId  = prefs.getInt("selectedUserId", -1);
+    private void updateUserPreferences() {
+        OpenScale openScale = OpenScale.getInstance(getActivity().getApplicationContext());
+
+        int selectedUserId = openScale.getSelectedScaleUserId();
 
         getPreferenceScreen().removeAll();
-
-        OpenScale openScale = OpenScale.getInstance(getActivity().getApplicationContext());
 
         List<ScaleUser> scaleUserList = openScale.getScaleUserList();
 


### PR DESCRIPTION
Changes the constraint for datetime to also include userId so that two users can have measurement for the same time. Also added a foreign key constraint so that there must be an user to be able to add a measurement. Added migration + test to verify that the upgrade works.

Tested import of a backup database with version 1. To have the migration steps run after import I changed the code to reopen the database after the import is done.

Also introduced caching of the selected scale user so that it doesn't have to be read from the database all the time.

Also some cleanups, such as the removal of unused methods from the old database classes. 