### PR TITLE
Activity state

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/utils/CsvHelper.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/CsvHelper.java
@@ -32,7 +32,7 @@ public class CsvHelper {
         csvProcessor.writeAll(writer, measurements, true);
     }
 
-    static private String[] getOldStyleHeaders(String sampleLine) {
+    private static String[] getOldStyleHeaders(String sampleLine) {
         final String[] fields = sampleLine.split(",", -1);
 
         // Return an array with header fields so that all the headers that actually are

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -135,6 +135,24 @@ public class DataEntryActivity extends Activity {
         updateOnView();
     }
 
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+
+        for (MeasurementView measurement : dataEntryMeasurements) {
+            measurement.restoreState(savedInstanceState);
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        for (MeasurementView measurement : dataEntryMeasurements) {
+            measurement.saveState(outState);
+        }
+    }
+
     private void updateOnView()
     {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -23,6 +23,7 @@ import android.graphics.Color;
 import android.graphics.DashPathEffect;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
 import android.view.GestureDetector;
@@ -88,6 +89,9 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     private Calendar calYears;
     private Calendar calLastSelected;
 
+    static private String CAL_YEARS_KEY = "calYears";
+    static private String CAL_LAST_SELECTED_KEY = "calLastSelected";
+
     private List<ScaleMeasurement> scaleMeasurementList;
     private List<ScaleMeasurement> pointIndexScaleMeasurementList;
 
@@ -101,10 +105,16 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     {
         openScale = OpenScale.getInstance(getContext());
 
-        scaleMeasurementList = openScale.getScaleMeasurementList();
-        if (!scaleMeasurementList.isEmpty()) {
-            calYears.setTime(scaleMeasurementList.get(0).getDateTime());
-            calLastSelected.setTime(scaleMeasurementList.get(0).getDateTime());
+        if (savedInstanceState == null) {
+            scaleMeasurementList = openScale.getScaleMeasurementList();
+            if (!scaleMeasurementList.isEmpty()) {
+                calYears.setTime(scaleMeasurementList.get(0).getDateTime());
+                calLastSelected.setTime(scaleMeasurementList.get(0).getDateTime());
+            }
+        }
+        else {
+            calYears.setTimeInMillis(savedInstanceState.getLong(CAL_YEARS_KEY));
+            calLastSelected.setTimeInMillis(savedInstanceState.getLong(CAL_LAST_SELECTED_KEY));
         }
 
         graphView = inflater.inflate(R.layout.fragment_graph, container, false);
@@ -195,6 +205,14 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
         openScale.registerFragment(this);
 
         return graphView;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putLong(CAL_YEARS_KEY, calYears.getTimeInMillis());
+        outState.putLong(CAL_LAST_SELECTED_KEY, calLastSelected.getTimeInMillis());
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -23,7 +23,6 @@ import android.graphics.Color;
 import android.graphics.DashPathEffect;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
 import android.view.GestureDetector;
@@ -219,7 +218,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     }
 
     @Override
-    public void onSaveInstanceState(@NonNull Bundle outState) {
+    public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
         outState.putLong(CAL_YEARS_KEY, calYears.getTimeInMillis());

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -92,7 +92,6 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     static private String CAL_YEARS_KEY = "calYears";
     static private String CAL_LAST_SELECTED_KEY = "calLastSelected";
 
-    private List<ScaleMeasurement> scaleMeasurementList;
     private List<ScaleMeasurement> pointIndexScaleMeasurementList;
 
     public GraphFragment() {
@@ -106,7 +105,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
         openScale = OpenScale.getInstance(getContext());
 
         if (savedInstanceState == null) {
-            scaleMeasurementList = openScale.getScaleMeasurementList();
+            List<ScaleMeasurement> scaleMeasurementList = openScale.getScaleMeasurementList();
             if (!scaleMeasurementList.isEmpty()) {
                 calYears.setTime(scaleMeasurementList.get(0).getDateTime());
                 calLastSelected.setTime(scaleMeasurementList.get(0).getDateTime());
@@ -244,7 +243,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
         return false;
     }
 
-    private void generateLineData(int field)
+    private void generateLineData(int field, List<ScaleMeasurement> scaleMeasurementList)
     {
         SimpleDateFormat day_date = new SimpleDateFormat("D", Locale.getDefault());
 
@@ -511,7 +510,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
         int firstYear = selectedYear;
         int lastYear = selectedYear;
 
-        scaleMeasurementList = openScale.getScaleMeasurementList();
+        List<ScaleMeasurement> scaleMeasurementList = openScale.getScaleMeasurementList();
         if (!scaleMeasurementList.isEmpty()) {
             Calendar cal = Calendar.getInstance();
 
@@ -540,7 +539,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             generateColumnData();
             scaleMeasurementList = openScale.getScaleDataOfMonth(selectedYear, calLastSelected.get(Calendar.MONTH));
 
-            generateLineData(Calendar.DAY_OF_MONTH);
+            generateLineData(Calendar.DAY_OF_MONTH, scaleMeasurementList);
         // show only yearly diagram and hide monthly diagram
         } else {
             chartTop.setVisibility(View.GONE);
@@ -548,7 +547,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
 
             scaleMeasurementList = openScale.getScaleDataOfYear(selectedYear);
 
-            generateLineData(Calendar.DAY_OF_YEAR);
+            generateLineData(Calendar.DAY_OF_YEAR, scaleMeasurementList);
         }
     }
 
@@ -561,8 +560,9 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
 
             calLastSelected = cal;
 
-            scaleMeasurementList = openScale.getScaleDataOfMonth(calYears.get(Calendar.YEAR), calLastSelected.get(Calendar.MONTH));
-            generateLineData(Calendar.DAY_OF_MONTH);
+            List<ScaleMeasurement> scaleMeasurementList =
+                    openScale.getScaleDataOfMonth(calYears.get(Calendar.YEAR), calLastSelected.get(Calendar.MONTH));
+            generateLineData(Calendar.DAY_OF_MONTH, scaleMeasurementList);
         }
 
         @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -88,8 +88,8 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     private Calendar calYears;
     private Calendar calLastSelected;
 
-    static private String CAL_YEARS_KEY = "calYears";
-    static private String CAL_LAST_SELECTED_KEY = "calLastSelected";
+    private static String CAL_YEARS_KEY = "calYears";
+    private static String CAL_LAST_SELECTED_KEY = "calLastSelected";
 
     private List<ScaleMeasurement> pointIndexScaleMeasurementList;
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -188,6 +188,12 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             public void onClick(View view) {
                 calYears.roll(Calendar.YEAR, false);
                 txtYear.setText(Integer.toString(calYears.get(Calendar.YEAR)));
+
+                List<ScaleMeasurement> scaleMeasurementList =
+                        OpenScale.getInstance(getContext()).getScaleDataOfYear(calYears.get(Calendar.YEAR));
+                if (!scaleMeasurementList.isEmpty()) {
+                    calLastSelected.setTime(scaleMeasurementList.get(0).getDateTime());
+                }
                 updateOnView(null);
             }
         });
@@ -197,6 +203,12 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             public void onClick(View view) {
                 calYears.roll(Calendar.YEAR, true);
                 txtYear.setText(Integer.toString(calYears.get(Calendar.YEAR)));
+
+                List<ScaleMeasurement> scaleMeasurementList =
+                        OpenScale.getInstance(getContext()).getScaleDataOfYear(calYears.get(Calendar.YEAR));
+                if (!scaleMeasurementList.isEmpty()) {
+                    calLastSelected.setTime(scaleMeasurementList.get(scaleMeasurementList.size() - 1).getDateTime());
+                }
                 updateOnView(null);
             }
         });

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -25,7 +25,6 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
@@ -135,7 +134,7 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
     }
 
     @Override
-    public void onSaveInstanceState(@NonNull Bundle outState) {
+    public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(SELECTED_SUBPAGE_NR_KEY, selectedSubpageNr);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -25,6 +25,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
@@ -82,6 +83,7 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
     private ArrayList <MeasurementView> measurementsList;
 
     private int selectedSubpageNr;
+    static private String SELECTED_SUBPAGE_NR_KEY = "selectedSubpageNr";
 
     public TableFragment() {
 
@@ -120,11 +122,22 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
 
         prefs = PreferenceManager.getDefaultSharedPreferences(tableView.getContext());
 
+        if (savedInstanceState == null) {
+            selectedSubpageNr = 0;
+        }
+        else {
+            selectedSubpageNr = savedInstanceState.getInt(SELECTED_SUBPAGE_NR_KEY);
+        }
+
         OpenScale.getInstance(getContext()).registerFragment(this);
 
-        selectedSubpageNr = 0;
-
         return tableView;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(SELECTED_SUBPAGE_NR_KEY, selectedSubpageNr);
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -82,7 +82,7 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
     private ArrayList <MeasurementView> measurementsList;
 
     private int selectedSubpageNr;
-    static private String SELECTED_SUBPAGE_NR_KEY = "selectedSubpageNr";
+    private static String SELECTED_SUBPAGE_NR_KEY = "selectedSubpageNr";
 
     public TableFragment() {
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -17,6 +17,7 @@ package com.health.openscale.gui.views;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.widget.EditText;
@@ -26,6 +27,7 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
     private String comment;
+    static private String COMMENT_KEY = "comment";
 
     public CommentMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_comment), ContextCompat.getDrawable(context, R.drawable.ic_comment));
@@ -46,6 +48,16 @@ public class CommentMeasurementView extends MeasurementView {
     @Override
     public void saveTo(ScaleMeasurement measurement) {
         measurement.setComment(comment);
+    }
+
+    @Override
+    public void restoreState(Bundle state) {
+        setValue(state.getString(COMMENT_KEY), true);
+    }
+
+    @Override
+    public void saveState(Bundle state) {
+        state.putString(COMMENT_KEY, comment);
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -27,7 +27,7 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
     private String comment;
-    static private String COMMENT_KEY = "comment";
+    private static String COMMENT_KEY = "comment";
 
     public CommentMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_comment), ContextCompat.getDrawable(context, R.drawable.ic_comment));

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -19,6 +19,7 @@ import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.widget.DatePicker;
 import android.widget.EditText;
@@ -33,6 +34,7 @@ import java.util.Date;
 public class DateMeasurementView extends MeasurementView {
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
+    static private String DATE_KEY = "date";
 
     public DateMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_date), ContextCompat.getDrawable(context, R.drawable.ic_lastmonth));
@@ -62,6 +64,16 @@ public class DateMeasurementView extends MeasurementView {
                 source.get(Calendar.DAY_OF_MONTH));
 
         measurement.setDateTime(target.getTime());
+    }
+
+    @Override
+    public void restoreState(Bundle state) {
+        setValue(new Date(state.getLong(DATE_KEY)), true);
+    }
+
+    @Override
+    public void saveState(Bundle state) {
+        state.putLong(DATE_KEY, date.getTime());
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -34,7 +34,7 @@ import java.util.Date;
 public class DateMeasurementView extends MeasurementView {
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
-    static private String DATE_KEY = "date";
+    private static String DATE_KEY = "date";
 
     public DateMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_date), ContextCompat.getDrawable(context, R.drawable.ic_lastmonth));

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -19,6 +19,7 @@ package com.health.openscale.gui.views;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 import android.os.Handler;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
@@ -226,6 +227,16 @@ public abstract class FloatMeasurementView extends MeasurementView {
         if (!useAutoValue()) {
             setMeasurementValue(value, measurement);
         }
+    }
+
+    @Override
+    public void restoreState(Bundle state) {
+        setValue(state.getFloat(nameText), previousValue, true);
+    }
+
+    @Override
+    public void saveState(Bundle state) {
+        state.putFloat(nameText, value);
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -21,6 +21,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -150,6 +151,9 @@ public abstract class MeasurementView extends TableLayout {
 
     public abstract void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement);
     public abstract void saveTo(ScaleMeasurement measurement);
+
+    public abstract void restoreState(Bundle state);
+    public abstract void saveState(Bundle state);
 
     public abstract void updatePreferences(SharedPreferences preferences);
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -19,6 +19,7 @@ import android.app.AlertDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.widget.EditText;
 import android.widget.TimePicker;
@@ -33,6 +34,7 @@ import java.util.Date;
 public class TimeMeasurementView extends MeasurementView {
     private DateFormat timeFormat;
     private Date time;
+    static private String TIME_KEY = "time";
 
     public TimeMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_time), ContextCompat.getDrawable(context, R.drawable.ic_daysleft));
@@ -65,6 +67,16 @@ public class TimeMeasurementView extends MeasurementView {
         target.set(Calendar.MILLISECOND, 0);
 
         measurement.setDateTime(target.getTime());
+    }
+
+    @Override
+    public void restoreState(Bundle state) {
+        setValue(new Date(state.getLong(TIME_KEY)), true);
+    }
+
+    @Override
+    public void saveState(Bundle state) {
+        state.putLong(TIME_KEY, time.getTime());
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -34,7 +34,7 @@ import java.util.Date;
 public class TimeMeasurementView extends MeasurementView {
     private DateFormat timeFormat;
     private Date time;
-    static private String TIME_KEY = "time";
+    private static String TIME_KEY = "time";
 
     public TimeMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_time), ContextCompat.getDrawable(context, R.drawable.ic_daysleft));


### PR DESCRIPTION
Make data entry activity and graph and table fragment remember the state so that when the user e.g. rotates the screen, the state isn't lost.

Also made switching year in graph view move from e.g. January 2018 to December 2017 instead of to January 2017.