### PR TITLE
Change order of columns in index

### DIFF
--- a/android_app/app/schemas/com.health.openscale.core.database.AppDatabase/2.json
+++ b/android_app/app/schemas/com.health.openscale.core.database.AppDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "166a2a83c723c4117edaf1d107ac5194",
+    "identityHash": "29790d4babbe129963d2c9282393c2d2",
     "entities": [
       {
         "tableName": "scaleMeasurements",
@@ -95,13 +95,13 @@
         },
         "indices": [
           {
-            "name": "index_scaleMeasurements_datetime_userId",
+            "name": "index_scaleMeasurements_userId_datetime",
             "unique": true,
             "columnNames": [
-              "datetime",
-              "userId"
+              "userId",
+              "datetime"
             ],
-            "createSql": "CREATE UNIQUE INDEX `index_scaleMeasurements_datetime_userId` ON `${TABLE_NAME}` (`datetime`, `userId`)"
+            "createSql": "CREATE UNIQUE INDEX `index_scaleMeasurements_userId_datetime` ON `${TABLE_NAME}` (`userId`, `datetime`)"
           }
         ],
         "foreignKeys": [
@@ -189,7 +189,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"166a2a83c723c4117edaf1d107ac5194\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"29790d4babbe129963d2c9282393c2d2\")"
     ]
   }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/database/AppDatabase.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/database/AppDatabase.java
@@ -54,8 +54,8 @@ public abstract class AppDatabase extends RoomDatabase {
                         + " ON UPDATE NO ACTION ON DELETE CASCADE)");
 
                 // Create new index on datetime + userId
-                database.execSQL("CREATE UNIQUE INDEX index_scaleMeasurements_datetime_userId"
-                        + " ON scaleMeasurements (datetime, userId)");
+                database.execSQL("CREATE UNIQUE INDEX index_scaleMeasurements_userId_datetime"
+                        + " ON scaleMeasurements (userId, datetime)");
 
                 // Copy data from the old table, ignoring those with invalid userId (if any)
                 database.execSQL("INSERT INTO scaleMeasurements"

--- a/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/datatypes/ScaleMeasurement.java
@@ -28,7 +28,7 @@ import com.j256.simplecsv.common.CsvColumn;
 import java.util.Date;
 
 @Entity(tableName = "scaleMeasurements",
-        indices = {@Index(value = {"datetime", "userId"}, unique = true)},
+        indices = {@Index(value = {"userId", "datetime"}, unique = true)},
         foreignKeys = @ForeignKey(
                 entity = ScaleUser.class,
                 parentColumns = "id",


### PR DESCRIPTION
By putting userId first we avoid a compiler warnings an most likely
make better use of the index.