### PR TITLE
Measurements

### DIFF
--- a/android_app/app/src/androidTest/java/com/health/openscale/DatabaseMigrationTest.java
+++ b/android_app/app/src/androidTest/java/com/health/openscale/DatabaseMigrationTest.java
@@ -17,7 +17,6 @@
 package com.health.openscale;
 
 import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.db.SupportSQLiteOpenHelper;
 import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory;
 import android.arch.persistence.room.testing.MigrationTestHelper;
 import android.content.ContentValues;

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothExingtechY1.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothExingtechY1.java
@@ -19,8 +19,6 @@ package com.health.openscale.core.bluetooth;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale2.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMiScale2.java
@@ -26,7 +26,6 @@ import android.util.Log;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
-import com.health.openscale.core.utils.Converters;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -280,9 +280,11 @@ public class MainActivity extends AppCompatActivity {
                 Intent settingsIntent = new Intent(this, SettingsActivity.class);
                 settingsIntent.putExtra(SettingsActivity.EXTRA_TINT_COLOR, navDrawer.getItemTextColor().getDefaultColor());
                 startActivity(settingsIntent);
+                drawerLayout.closeDrawers();
                 return;
             case R.id.nav_help:
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/oliexdev/openScale/wiki")));
+                drawerLayout.closeDrawers();
                 return;
             default:
                 fragmentClass = OverviewFragment.class;

--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -513,7 +513,7 @@ public class MainActivity extends AppCompatActivity {
                 item.setPadding(0, 20, 0, 0);
                 // set once again checked value, so view will be updated
                 //noinspection RestrictedApi
-                //item.setChecked(item.getItemData().isChecked());
+                item.setChecked(item.getItemData().isChecked());
             }
         } catch (NoSuchFieldException e) {
             Log.e("BNVHelper", "Unable to get shift mode field", e);

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -94,7 +94,8 @@ public class DataEntryActivity extends AppCompatActivity {
 
         tableLayoutDataEntry = (TableLayout) findViewById(R.id.tableLayoutDataEntry);
 
-        dataEntryMeasurements = MeasurementView.getMeasurementList(context);
+        dataEntryMeasurements = MeasurementView.getMeasurementList(
+                context, MeasurementView.DateTimeOrder.LAST);
 
         txtDataNr = (TextView) findViewById(R.id.txtDataNr);
         btnLeft = (Button) findViewById(R.id.btnLeft);

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -261,12 +261,6 @@ public class DataEntryActivity extends AppCompatActivity {
     }
 
     private void updateOnView() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-
-        for (MeasurementView measurement : dataEntryMeasurements) {
-            measurement.updatePreferences(prefs);
-        }
-
         int id = 0;
         if (getIntent().hasExtra(EXTRA_ID)) {
             id = getIntent().getExtras().getInt(EXTRA_ID);

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -72,6 +72,10 @@ public class DataEntryActivity extends AppCompatActivity {
 
     private Context context;
 
+    private boolean isAddActivity() {
+        return !getIntent().hasExtra(EXTRA_ID);
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         String app_theme = PreferenceManager.getDefaultSharedPreferences(this).getString("app_theme", "Light");
@@ -117,12 +121,19 @@ public class DataEntryActivity extends AppCompatActivity {
             }
         });
 
+        final MeasurementView.MeasurementViewMode mode = isAddActivity()
+                ? MeasurementView.MeasurementViewMode.ADD
+                : MeasurementView.MeasurementViewMode.VIEW;
+        for (MeasurementView measurement : dataEntryMeasurements) {
+            measurement.setEditMode(mode);
+        }
+
         updateOnView();
 
         onMeasurementViewUpdateListener updateListener = new onMeasurementViewUpdateListener();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        final boolean expand = getIntent().hasExtra(EXTRA_ID)
-                ? prefs.getBoolean(PREF_EXPAND, true) : false;
+        final boolean expand = isAddActivity()
+                ? false : prefs.getBoolean(PREF_EXPAND, true);
 
         for (MeasurementView measurement : dataEntryMeasurements) {
             tableLayoutDataEntry.addView(measurement);
@@ -183,11 +194,11 @@ public class DataEntryActivity extends AppCompatActivity {
         deleteButton = menu.findItem(R.id.deleteButton);
 
         // Hide/show icons as appropriate for the view mode
-        if (getIntent().hasExtra(EXTRA_ID)) {
-            setViewMode(MeasurementView.MeasurementViewMode.VIEW);
+        if (isAddActivity()) {
+            setViewMode(MeasurementView.MeasurementViewMode.ADD);
         }
         else {
-            setViewMode(MeasurementView.MeasurementViewMode.ADD);
+            setViewMode(MeasurementView.MeasurementViewMode.VIEW);
         }
 
         return super.onCreateOptionsMenu(menu);

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -31,6 +31,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -328,6 +329,7 @@ public class DataEntryActivity extends AppCompatActivity {
                 expandButton.setVisible(true);
                 deleteButton.setVisible(true);
 
+                ((LinearLayout)txtDataNr.getParent()).setVisibility(View.VISIBLE);
                 btnLeft.setVisibility(View.VISIBLE);
                 btnRight.setVisibility(View.VISIBLE);
                 btnLeft.setEnabled(previousMeasurement != null);
@@ -341,6 +343,7 @@ public class DataEntryActivity extends AppCompatActivity {
                 expandButton.setVisible(true);
                 deleteButton.setVisible(true);
 
+                ((LinearLayout)txtDataNr.getParent()).setVisibility(View.VISIBLE);
                 btnLeft.setVisibility(View.VISIBLE);
                 btnRight.setVisibility(View.VISIBLE);
                 btnLeft.setEnabled(false);
@@ -352,8 +355,7 @@ public class DataEntryActivity extends AppCompatActivity {
                 expandButton.setVisible(false);
                 deleteButton.setVisible(false);
 
-                btnLeft.setVisibility(View.GONE);
-                btnRight.setVisibility(View.GONE);
+                ((LinearLayout)txtDataNr.getParent()).setVisibility(View.GONE);
                 break;
         }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/SettingsActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/SettingsActivity.java
@@ -16,6 +16,7 @@
 package com.health.openscale.gui.activities;
 
 import android.app.Fragment;
+import android.content.SharedPreferences;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -30,7 +31,8 @@ import com.health.openscale.gui.utils.PermissionHelper;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SettingsActivity extends PreferenceActivity {
+public class SettingsActivity extends PreferenceActivity
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
     public static String EXTRA_TINT_COLOR = "tintColor";
     private static List<String> fragments = new ArrayList<String>();
     private Fragment currentFragment;
@@ -44,6 +46,28 @@ public class SettingsActivity extends PreferenceActivity {
         }
 
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .registerOnSharedPreferenceChangeListener(this);
+
+    }
+
+    @Override
+    public void onPause() {
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .unregisterOnSharedPreferenceChangeListener(this);
+        super.onPause();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences preferences, String key) {
+        if (key.equals("app_theme")) {
+            recreate();
+        }
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -315,7 +315,6 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
                     continue;
                 }
 
-                measurementView.updatePreferences(prefs);
                 Stack<PointValue> valuesStack = new Stack<PointValue>();
 
                 for (ScaleMeasurement measurement : scaleMeasurementList) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -181,7 +181,6 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
 
-
                 switch (item.getItemId()) {
                     case R.id.enableMonth:
                         if (item.isChecked()) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -174,7 +174,8 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             }
         });
 
-        measurementViews = MeasurementView.getMeasurementList(getContext());
+        measurementViews = MeasurementView.getMeasurementList(
+                getContext(), MeasurementView.DateTimeOrder.NONE);
 
         popup = new PopupMenu(getContext(), optionMenu);
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -166,7 +166,6 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         updateLastLineChart(scaleMeasurementList);
 
         for (MeasurementView measurement : measurementViews) {
-            measurement.updatePreferences(prefs);
             measurement.loadFrom(lastScaleMeasurement, prevScaleMeasurement);
         }
     }
@@ -220,8 +219,6 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
                 if (measurementView.getName().equals(getString(R.string.label_bmr))) {
                     continue;
                 }
-
-                measurementView.updatePreferences(prefs);
 
                 Stack<PointValue> valuesStack = new Stack<PointValue>();
 
@@ -283,7 +280,6 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
                     continue;
                 }
 
-                measurementView.updatePreferences(prefs);
                 measurementView.loadFrom(lastScaleMeasurement, null);
 
                 if (measurementView.getValue() != 0) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -38,10 +38,8 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
 import com.health.openscale.core.utils.DateTimeHelpers;
-import com.health.openscale.gui.views.DateMeasurementView;
 import com.health.openscale.gui.views.FloatMeasurementView;
 import com.health.openscale.gui.views.MeasurementView;
-import com.health.openscale.gui.views.TimeMeasurementView;
 
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -120,13 +118,10 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         pieChartLast.setOnValueTouchListener(new PieChartLastTouchListener());
         pieChartLast.setChartRotationEnabled(false);
 
-        measurementViews = MeasurementView.getMeasurementList(getContext());
+        measurementViews = MeasurementView.getMeasurementList(
+                getContext(), MeasurementView.DateTimeOrder.NONE);
 
         for (MeasurementView measurement : measurementViews) {
-            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
-                continue;
-            }
-
             tableOverviewLayout.addView(measurement);
         }
 
@@ -171,10 +166,6 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
         updateLastLineChart(scaleMeasurementList);
 
         for (MeasurementView measurement : measurementViews) {
-            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
-                continue;
-            }
-
             measurement.updatePreferences(prefs);
             measurement.loadFrom(lastScaleMeasurement, prevScaleMeasurement);
         }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -112,7 +112,8 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
             selectedSubpageNr = savedInstanceState.getInt(SELECTED_SUBPAGE_NR_KEY);
         }
 
-        measurementViews = MeasurementView.getMeasurementList(getContext());
+        measurementViews = MeasurementView.getMeasurementList(
+                getContext(), MeasurementView.DateTimeOrder.FIRST);
 
         for (MeasurementView measurement : measurementViews) {
             measurement.setUpdateViews(false);

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/TableFragment.java
@@ -219,7 +219,6 @@ public class TableFragment extends Fragment implements FragmentUpdateListener {
 
         ArrayList<MeasurementView> visibleMeasurements = new ArrayList<>();
         for (MeasurementView measurement : measurementViews) {
-            measurement.updatePreferences(prefs);
 
             if (measurement.isVisible()) {
                 ImageView headerIcon = new ImageView(tableView.getContext());

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GeneralPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GeneralPreferences.java
@@ -44,16 +44,6 @@ public class GeneralPreferences extends PreferenceFragment implements SharedPref
 
         appThemeList = (ListPreference)findPreference(PREFERENCE_KEY_APP_THEME);
 
-        appThemeList.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object o) {
-                Toast.makeText(getActivity().getApplicationContext(), getResources().getString(R.string.info_app_restart_required), Toast.LENGTH_LONG).show();
-
-                return true;
-            }
-        });
-
-
         initSummary(getPreferenceScreen());
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -26,7 +26,6 @@ import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
-import android.preference.PreferenceManager;
 import android.preference.SwitchPreference;
 import android.widget.Toast;
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/UsersPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/UsersPreferences.java
@@ -16,11 +16,9 @@
 package com.health.openscale.gui.preferences;
 
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
 
 import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -22,6 +22,7 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableStringBuilder;
 import android.util.TypedValue;
@@ -105,6 +106,12 @@ public abstract class MeasurementView extends TableLayout {
         if (order == DateTimeOrder.LAST) {
             measurementViews.add(new DateMeasurementView(context));
             measurementViews.add(new TimeMeasurementView(context));
+        }
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+        for (MeasurementView measurement : measurementViews) {
+            measurement.updatePreferences(prefs);
         }
 
         return measurementViews;

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -80,11 +80,15 @@ public abstract class MeasurementView extends TableLayout {
         iconView.setImageDrawable(icon);
     }
 
-    public static final List<MeasurementView> getMeasurementList(Context context) {
+    public enum DateTimeOrder { FIRST, LAST, NONE }
+
+    public static final List<MeasurementView> getMeasurementList(Context context, DateTimeOrder order) {
         final List<MeasurementView> measurementViews = new ArrayList<>();
 
-        measurementViews.add(new DateMeasurementView(context));
-        measurementViews.add(new TimeMeasurementView(context));
+        if (order == DateTimeOrder.FIRST) {
+            measurementViews.add(new DateMeasurementView(context));
+            measurementViews.add(new TimeMeasurementView(context));
+        }
         measurementViews.add(new WeightMeasurementView(context));
         measurementViews.add(new BMIMeasurementView(context));
         measurementViews.add(new WaterMeasurementView(context));
@@ -98,6 +102,10 @@ public abstract class MeasurementView extends TableLayout {
         measurementViews.add(new WHRMeasurementView(context));
         measurementViews.add(new BMRMeasurementView(context));
         measurementViews.add(new CommentMeasurementView(context));
+        if (order == DateTimeOrder.LAST) {
+            measurementViews.add(new DateMeasurementView(context));
+            measurementViews.add(new TimeMeasurementView(context));
+        }
 
         return measurementViews;
     }

--- a/android_app/app/src/main/res/values-cs/strings.xml
+++ b/android_app/app/src/main/res/values-cs/strings.xml
@@ -40,7 +40,7 @@
 	<item quantity="one">%d den</item>
 	<item quantity="few">%d dny</item>
 	<item quantity="other">%d dnů</item>
-</plurals>
+    </plurals>
     <string name="label_last_week">Uplynulých 7 dnů</string>
     <string name="label_last_month">Uplynulých 30 dnů</string>
     <string name="label_weight_difference">Rozdíl hmotnosti</string>
@@ -118,7 +118,6 @@
     <string name="label_automatic">automaticky</string>
 
     <string name="label_theme">Téma vzhledu</string>
-    <string name="info_app_restart_required">Aby se změny projevily, je třeba aplikaci restartovat</string>
 
     <string name="label_reminder">Připomínání</string>
     <string name="label_reminder_weekdays">Dny v týdnu</string>

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -180,7 +180,6 @@
     <string name="customactivityoncrash_error_activity_error_details_clipboard_label">Fehlerinformationen</string>
     <string name="title_general">Allgmein</string>
     <string name="label_theme">Theme</string>
-    <string name="info_app_restart_required">Um die Änderungen zu übernehmen, ist ein App Neustart erforderlich</string>
     <string name="label_share">Teilen</string>
     <string name="label_bluetooth_searching_finished">Suche beendet nach Bluetooth Waagen</string>
     <string name="label_help">Hilfe</string>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -197,7 +197,6 @@
 
     <string name="label_bluetooth_searching_finished">Finalizada la búsqueda de básculas Bluetooth</string>
     <string name="label_theme">Tema</string>
-    <string name="info_app_restart_required">Para aplicar los cambios se requiere un reinicio de la aplicación</string>
 
     <string name="label_help">Ayuda</string>
 

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -164,7 +164,6 @@
     <string name="title_general">Allmänt</string>
     <string name="error_user_name_too_short">Fel: namnet måste vara minst 3 tecken</string>
     <string name="label_theme">Tema</string>
-    <string name="info_app_restart_required">En app-omstart krävs för att applicera ändringarna</string>
     <string name="label_feedback_message_enjoying">Uppskattar du openScale?</string>
     <string name="label_feedback_message_rate_app">Vad sägs om ett betyg på GooglePlay eller på GitHub?</string>
     <string name="label_feedback_message_issue">Skulle du ha något emot att ge oss lite återkoppling?</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -155,7 +155,6 @@
     <string name="label_automatic">auto</string>
 
     <string name="label_theme">Theme</string>
-    <string name="info_app_restart_required">To apply changes an app restart is required</string>
 
     <string name="label_reminder">Reminder</string>
     <string name="label_reminder_weekdays">Weekdays</string>


### PR DESCRIPTION
Recreate activity after settings have changed. This makes both the app theme take effect immediately and updates measurement views correctly after adding/removing measurements.

Add option so that date/time is once again placed last on the data entry activity. The views don't jump around as much then when switching between edit/view. 

Some other minor changes/improvements.