### PR TITLE
Make it possible to change order of measurment views

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -59,7 +59,6 @@ import com.health.openscale.gui.fragments.OverviewFragment;
 import com.health.openscale.gui.fragments.StatisticsFragment;
 import com.health.openscale.gui.fragments.TableFragment;
 import com.health.openscale.gui.utils.PermissionHelper;
-import com.health.openscale.gui.views.MeasurementView;
 
 import java.lang.reflect.Field;
 
@@ -204,7 +203,7 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences preferences, String key) {
-        if (settingsActivityRunning || key == MeasurementView.PREF_MEASUREMENT_ORDER) {
+        if (settingsActivityRunning) {
             recreate();
         }
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -536,7 +536,7 @@ public class DataEntryActivity extends AppCompatActivity {
                     }
                     break;
                 case DragEvent.ACTION_DROP:
-                    View draggedView = (View) event.getLocalState();
+                    MeasurementView draggedView = (MeasurementView) event.getLocalState();
                     TableLayout table = (TableLayout) draggedView.getParent();
                     final int draggedIndex = table.indexOfChild(draggedView);
                     final int targetIndex = table.indexOfChild(view);
@@ -545,7 +545,9 @@ public class DataEntryActivity extends AppCompatActivity {
                         // and a view that is moved up is placed before the target view.
                         table.removeView(draggedView);
                         table.addView(draggedView, targetIndex);
-                        MeasurementView.saveMeasurementViewsOrder(table);
+                        dataEntryMeasurements.remove(draggedView);
+                        dataEntryMeasurements.add(targetIndex, draggedView);
+                        MeasurementView.saveMeasurementViewsOrder(getApplicationContext(), dataEntryMeasurements);
                     }
                     break;
                 case DragEvent.ACTION_DRAG_ENDED:

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -20,18 +20,15 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.graphics.Color;
-import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.view.DragEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -130,16 +127,6 @@ public class DataEntryActivity extends AppCompatActivity {
                 : MeasurementView.MeasurementViewMode.VIEW;
         for (MeasurementView measurement : dataEntryMeasurements) {
             measurement.setEditMode(mode);
-
-            // Date and time can not be reordered (as they can be both first and last)
-            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
-                continue;
-            }
-
-            onLongClickListener longClickListener = new onLongClickListener();
-            measurement.setOnTouchListener(longClickListener);
-            measurement.setOnLongClickListener(longClickListener);
-            measurement.setOnDragListener(new onDragListener());
         }
 
         updateOnView();
@@ -467,99 +454,6 @@ public class DataEntryActivity extends AppCompatActivity {
                     measurement.loadFrom(scaleMeasurement, previousMeasurement);
                 }
             }
-        }
-    }
-
-    private class onLongClickListener implements View.OnTouchListener, View.OnLongClickListener {
-        float x = 0;
-        float y = 0;
-
-        @Override
-        public boolean onTouch(View view, MotionEvent event) {
-            if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
-                // Save x and y so that the drag shadow can have the touch point set to where
-                // the user did the touch (and not in the center of the view).
-                x = event.getX();
-                y = event.getY();
-            }
-            return false;
-        }
-
-        @Override
-        public boolean onLongClick(View view) {
-            return view.startDrag(null, new dragShadowBuilder(view), view, 0);
-        }
-
-        private class dragShadowBuilder extends View.DragShadowBuilder {
-            public dragShadowBuilder(View view) {
-                super(view);
-            }
-
-            @Override
-            public void onProvideShadowMetrics(Point outShadowSize, Point outShadowTouchPoint) {
-                super.onProvideShadowMetrics(outShadowSize, outShadowTouchPoint);
-                outShadowTouchPoint.set(Math.round(x), Math.round(y));
-            }
-        }
-    }
-
-    private class onDragListener implements View.OnDragListener {
-        Drawable background = null;
-        // background may be set to null, thus the extra boolean
-        boolean hasBackground = false;
-
-        @Override
-        public boolean onDrag(View view, DragEvent event) {
-            switch (event.getAction()) {
-                case DragEvent.ACTION_DRAG_STARTED:
-                    if (view == event.getLocalState() && !hasBackground) {
-                        background = view.getBackground();
-                        hasBackground = true;
-                        view.setBackgroundColor(Color.GRAY);
-                    }
-                    break;
-                case DragEvent.ACTION_DRAG_LOCATION:
-                    // Ignore
-                    break;
-                case DragEvent.ACTION_DRAG_ENTERED:
-                    if (view != event.getLocalState()) {
-                        background = view.getBackground();
-                        hasBackground = true;
-                        view.setBackgroundColor(Color.LTGRAY);
-                    }
-                    break;
-                case DragEvent.ACTION_DRAG_EXITED:
-                    if (view != event.getLocalState() && hasBackground) {
-                        view.setBackground(background);
-                        background = null;
-                        hasBackground = false;
-                    }
-                    break;
-                case DragEvent.ACTION_DROP:
-                    MeasurementView draggedView = (MeasurementView) event.getLocalState();
-                    TableLayout table = (TableLayout) draggedView.getParent();
-                    final int draggedIndex = table.indexOfChild(draggedView);
-                    final int targetIndex = table.indexOfChild(view);
-                    if (draggedIndex != targetIndex) {
-                        // A view that is moved down is placed after the target view,
-                        // and a view that is moved up is placed before the target view.
-                        table.removeView(draggedView);
-                        table.addView(draggedView, targetIndex);
-                        dataEntryMeasurements.remove(draggedView);
-                        dataEntryMeasurements.add(targetIndex, draggedView);
-                        MeasurementView.saveMeasurementViewsOrder(getApplicationContext(), dataEntryMeasurements);
-                    }
-                    break;
-                case DragEvent.ACTION_DRAG_ENDED:
-                    if (hasBackground) {
-                        // Restore background
-                        view.setBackground(background);
-                        background = null;
-                        hasBackground = false;
-                    }
-                    break;
-            }
-            return true;
         }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -330,7 +330,7 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
             parentGroup = parent;
             measurement = measurementView;
             setIcon(measurement.getIcon());
-            setTitle(measurement.getNameText());
+            setTitle(measurement.getName());
         }
 
         public PreferenceGroup getParent() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -32,6 +32,11 @@ public class BMIMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "bmi";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("weightEnable", true));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -34,6 +34,11 @@ public class BMRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "bmr";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("weightEnable", true));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -32,6 +32,11 @@ public class BoneMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "bone";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("boneEnable", false));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -27,10 +27,14 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
     private String comment;
-    private static String COMMENT_KEY = "comment";
 
     public CommentMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_comment), ContextCompat.getDrawable(context, R.drawable.ic_comment));
+    }
+
+    @Override
+    public String getKey() {
+        return "comment";
     }
 
     private void setValue(String newComment, boolean callListener) {
@@ -52,12 +56,12 @@ public class CommentMeasurementView extends MeasurementView {
 
     @Override
     public void restoreState(Bundle state) {
-        setValue(state.getString(COMMENT_KEY), true);
+        setValue(state.getString(getKey()), true);
     }
 
     @Override
     public void saveState(Bundle state) {
-        state.putString(COMMENT_KEY, comment);
+        state.putString(getKey(), comment);
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -34,11 +34,16 @@ import java.util.Date;
 public class DateMeasurementView extends MeasurementView {
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
-    private static String DATE_KEY = "date";
 
     public DateMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_date), ContextCompat.getDrawable(context, R.drawable.ic_lastmonth));
     }
+
+    @Override
+    public String getKey() {
+        return "date";
+    }
+
 
     private void setValue(Date newDate, boolean callListener) {
         if (!newDate.equals(date)) {
@@ -70,12 +75,12 @@ public class DateMeasurementView extends MeasurementView {
 
     @Override
     public void restoreState(Bundle state) {
-        setValue(new Date(state.getLong(DATE_KEY)), true);
+        setValue(new Date(state.getLong(getKey())), true);
     }
 
     @Override
     public void saveState(Bundle state) {
-        state.putLong(DATE_KEY, date.getTime());
+        state.putLong(getKey(), date.getTime());
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -35,6 +35,11 @@ public class FatMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "fat";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("fatEnable", true));
         estimateFatEnable = preferences.getBoolean("estimateFatEnable", false);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -271,7 +271,8 @@ public abstract class FloatMeasurementView extends MeasurementView {
         return value;
     }
 
-    public String getName() {
+    @Override
+    public CharSequence getName() {
         return nameText;
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -251,12 +251,12 @@ public abstract class FloatMeasurementView extends MeasurementView {
 
     @Override
     public void restoreState(Bundle state) {
-        setValue(state.getFloat(nameText), previousValue, true);
+        setValue(state.getFloat(getKey()), previousValue, true);
     }
 
     @Override
     public void saveState(Bundle state) {
-        state.putFloat(nameText, value);
+        state.putFloat(getKey(), value);
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -32,6 +32,11 @@ public class HipMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "hip";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("hipEnable", false));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -34,6 +34,11 @@ public class LBWMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "lbw";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("lbwEnable", false));
         estimateLBWEnable = preferences.getBoolean("estimateLBWEnable", false);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -144,17 +144,15 @@ public abstract class MeasurementView extends TableLayout {
         return sorted;
     }
 
-    public static void saveMeasurementViewsOrder(TableLayout tableLayout) {
+    public static void saveMeasurementViewsOrder(Context context, List<MeasurementView> measurementViews) {
         ArrayList<String> order = new ArrayList<>();
-        for (int i = 0; i < tableLayout.getChildCount(); ++i) {
-            MeasurementView view = (MeasurementView) tableLayout.getChildAt(i);
-            if (view instanceof DateMeasurementView || view instanceof TimeMeasurementView) {
+        for (MeasurementView measurement : measurementViews) {
+            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
                 continue;
             }
-            order.add(view.getKey());
+            order.add(measurement.getKey());
         }
-        PreferenceManager.getDefaultSharedPreferences(tableLayout.getContext())
-                .edit()
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString(PREF_MEASUREMENT_ORDER, TextUtils.join(",", order))
                 .commit();
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -247,7 +247,7 @@ public abstract class MeasurementView extends TableLayout {
 
     public abstract void updatePreferences(SharedPreferences preferences);
 
-    public CharSequence getNameText() { return nameView.getText(); }
+    public CharSequence getName() { return nameView.getText(); }
     public abstract String getValueAsString();
     public void appendDiffValue(SpannableStringBuilder builder) { }
     public Drawable getIcon() { return iconView.getDrawable(); }
@@ -379,7 +379,7 @@ public abstract class MeasurementView extends TableLayout {
 
     protected AlertDialog getInputDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-        builder.setTitle(getNameText());
+        builder.setTitle(getName());
         builder.setIcon(getIcon());
 
         final EditText input = new EditText(getContext());

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -147,9 +147,6 @@ public abstract class MeasurementView extends TableLayout {
     public static void saveMeasurementViewsOrder(Context context, List<MeasurementView> measurementViews) {
         ArrayList<String> order = new ArrayList<>();
         for (MeasurementView measurement : measurementViews) {
-            if (measurement instanceof DateMeasurementView || measurement instanceof TimeMeasurementView) {
-                continue;
-            }
             order.add(measurement.getKey());
         }
         PreferenceManager.getDefaultSharedPreferences(context).edit()

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -247,6 +247,7 @@ public abstract class MeasurementView extends TableLayout {
 
     public abstract void updatePreferences(SharedPreferences preferences);
 
+    public CharSequence getNameText() { return nameView.getText(); }
     public abstract String getValueAsString();
     public void appendDiffValue(SpannableStringBuilder builder) { }
     public Drawable getIcon() { return iconView.getDrawable(); }
@@ -378,8 +379,8 @@ public abstract class MeasurementView extends TableLayout {
 
     protected AlertDialog getInputDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-        builder.setTitle(nameView.getText());
-        builder.setIcon(iconView.getDrawable());
+        builder.setTitle(getNameText());
+        builder.setIcon(getIcon());
 
         final EditText input = new EditText(getContext());
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -200,6 +200,8 @@ public abstract class MeasurementView extends TableLayout {
         return updateViews;
     }
 
+    public abstract String getKey();
+
     public abstract void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement);
     public abstract void saveTo(ScaleMeasurement measurement);
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -34,6 +34,11 @@ public class MuscleMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "muscle";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("muscleEnable", true));
         percentageEnable = preferences.getBoolean("musclePercentageEnable", true);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -34,11 +34,15 @@ import java.util.Date;
 public class TimeMeasurementView extends MeasurementView {
     private DateFormat timeFormat;
     private Date time;
-    private static String TIME_KEY = "time";
 
     public TimeMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_time), ContextCompat.getDrawable(context, R.drawable.ic_daysleft));
         timeFormat = android.text.format.DateFormat.getTimeFormat(context);
+    }
+
+    @Override
+    public String getKey() {
+        return "time";
     }
 
     private void setValue(Date newTime, boolean callListener) {
@@ -73,12 +77,12 @@ public class TimeMeasurementView extends MeasurementView {
 
     @Override
     public void restoreState(Bundle state) {
-        setValue(new Date(state.getLong(TIME_KEY)), true);
+        setValue(new Date(state.getLong(getKey())), true);
     }
 
     @Override
     public void saveState(Bundle state) {
-        state.putLong(TIME_KEY, time.getTime());
+        state.putLong(getKey(), time.getTime());
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -32,6 +32,11 @@ public class WHRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "whr";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("hipEnable", false)
                 && preferences.getBoolean("waistEnable", false));

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -32,6 +32,11 @@ public class WHtRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "whtr";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("waistEnable", false));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -32,6 +32,11 @@ public class WaistMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "waist";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("waistEnable", false));
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -35,6 +35,11 @@ public class WaterMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "water";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("waterEnable", true));
         estimateWaterEnable = preferences.getBoolean("estimateWaterEnable", false);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -33,6 +33,11 @@ public class WeightMeasurementView extends FloatMeasurementView {
     }
 
     @Override
+    public String getKey() {
+        return "weight";
+    }
+
+    @Override
     public void updatePreferences(SharedPreferences preferences) {
         setVisible(preferences.getBoolean("weightEnable", true));
     }

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -222,5 +222,8 @@
     <string name="permission_bluetooth_info">openScale requires permission to access the coarse location to search for Bluetooth devices</string>
     <string name="permission_bluetooth_info_title">Information</string>
     <string name="label_next">Next</string>
+    <string name="label_measurement_order">Measurement order</string>
+    <string name="label_press_hold_reorder">Press and hold to reorder</string>
+    <string name="label_set_default_order">Set default order</string>
 
 </resources>

--- a/android_app/app/src/main/res/xml/measurement_preferences.xml
+++ b/android_app/app/src/main/res/xml/measurement_preferences.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/label_category_display">
+        <PreferenceScreen android:title="@string/label_measurement_order" android:key="measurementOrder" />
         <CheckBoxPreference android:title="@string/label_fat" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key="fatEnable" android:defaultValue="true"/>
         <SwitchPreference android:title="@string/label_fat_percentage" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key ="fatPercentageEnable" android:defaultValue="true"/>
         <CheckBoxPreference android:title="@string/label_water" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"   android:key="waterEnable" android:defaultValue="true"/>


### PR DESCRIPTION
By long pressing a view in the data entry activity, the view can be dragged up or down to change the order. The order is then saved and reflected in overview, graph, table and data entry fragments/activity.

This fixes part of #81 (and #164).