### PR TITLE
Verify that it's possible to get filename from old export

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -604,6 +604,7 @@ public class MainActivity extends AppCompatActivity
             String exportUri = prefs.getString(getExportPreferenceKey(selectedScaleUser), "");
             uri = Uri.parse(exportUri);
             getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            openScale.getFilenameFromUri(uri);
         }
         catch (Exception ex) {
             uri = null;


### PR DESCRIPTION
Fixes crash when trying to export to a files that has been removed.