### PR TITLE
 Refactor preferences

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -259,21 +259,21 @@ public class OpenScale {
         }
 
         MeasurementViewSettings settings = new MeasurementViewSettings(prefs, WaterMeasurementView.KEY);
-        if (settings.isEstimationEnabled()) {
+        if (settings.isEnabled() && settings.isEstimationEnabled()) {
             EstimatedWaterMetric waterMetric = EstimatedWaterMetric.getEstimatedMetric(
                     EstimatedWaterMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setWater(waterMetric.getWater(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));
         }
 
         settings = new MeasurementViewSettings(prefs, LBWMeasurementView.KEY);
-        if (settings.isEstimationEnabled()) {
+        if (settings.isEnabled() && settings.isEstimationEnabled()) {
             EstimatedLBWMetric lbwMetric = EstimatedLBWMetric.getEstimatedMetric(
                     EstimatedLBWMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setLbw(lbwMetric.getLBW(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));
         }
 
         settings = new MeasurementViewSettings(prefs, FatMeasurementView.KEY);
-        if (settings.isEstimationEnabled()) {
+        if (settings.isEnabled() && settings.isEstimationEnabled()) {
             EstimatedFatMetric fatMetric = EstimatedFatMetric.getEstimatedMetric(
                     EstimatedFatMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setFat(fatMetric.getFat(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));

--- a/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/OpenScale.java
@@ -47,6 +47,10 @@ import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
 import com.health.openscale.core.utils.CsvHelper;
 import com.health.openscale.gui.fragments.FragmentUpdateListener;
+import com.health.openscale.gui.views.FatMeasurementView;
+import com.health.openscale.gui.views.LBWMeasurementView;
+import com.health.openscale.gui.views.MeasurementViewSettings;
+import com.health.openscale.gui.views.WaterMeasurementView;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -254,21 +258,24 @@ public class OpenScale {
             }
         }
 
-        if (prefs.getBoolean("estimateWaterEnable", false)) {
-            EstimatedWaterMetric waterMetric = EstimatedWaterMetric.getEstimatedMetric(EstimatedWaterMetric.FORMULA.valueOf(prefs.getString("estimateWaterFormula", "TBW_LEESONGKIM")));
-
+        MeasurementViewSettings settings = new MeasurementViewSettings(prefs, WaterMeasurementView.KEY);
+        if (settings.isEstimationEnabled()) {
+            EstimatedWaterMetric waterMetric = EstimatedWaterMetric.getEstimatedMetric(
+                    EstimatedWaterMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setWater(waterMetric.getWater(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));
         }
 
-        if (prefs.getBoolean("estimateLBWEnable", false)) {
-            EstimatedLBWMetric lbwMetric = EstimatedLBWMetric.getEstimatedMetric(EstimatedLBWMetric.FORMULA.valueOf(prefs.getString("estimateLBWFormula", "LBW_HUME")));
-
+        settings = new MeasurementViewSettings(prefs, LBWMeasurementView.KEY);
+        if (settings.isEstimationEnabled()) {
+            EstimatedLBWMetric lbwMetric = EstimatedLBWMetric.getEstimatedMetric(
+                    EstimatedLBWMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setLbw(lbwMetric.getLBW(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));
         }
 
-        if (prefs.getBoolean("estimateFatEnable", false)) {
-            EstimatedFatMetric fatMetric = EstimatedFatMetric.getEstimatedMetric(EstimatedFatMetric.FORMULA.valueOf(prefs.getString("estimateFatFormula", "BF_GALLAGHER")));
-
+        settings = new MeasurementViewSettings(prefs, FatMeasurementView.KEY);
+        if (settings.isEstimationEnabled()) {
+            EstimatedFatMetric fatMetric = EstimatedFatMetric.getEstimatedMetric(
+                    EstimatedFatMetric.FORMULA.valueOf(settings.getEstimationFormula()));
             scaleMeasurement.setFat(fatMetric.getFat(getScaleUser(scaleMeasurement.getUserId()), scaleMeasurement));
         }
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothIhealthHS3.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothIhealthHS3.java
@@ -27,12 +27,9 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Date;
-import java.util.Calendar;
 import java.util.Arrays;
 
 public class BluetoothIhealthHS3 extends BluetoothCommunication {

--- a/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/activities/DataEntryActivity.java
@@ -302,6 +302,15 @@ public class DataEntryActivity extends AppCompatActivity {
             }
 
             isDirty = true;
+
+            // Measurements that aren't visible should not store any value. Since we use values from
+            // the previous measurement there might be values for entries not shown. The loop below
+            // clears these values.
+            for (MeasurementView measurement : dataEntryMeasurements) {
+                if (!measurement.isVisible()) {
+                    measurement.clearIn(scaleMeasurement);
+                }
+            }
         }
 
         for (MeasurementView measurement : dataEntryMeasurements) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -43,6 +43,7 @@ import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.utils.PolynomialFitter;
 import com.health.openscale.gui.activities.DataEntryActivity;
+import com.health.openscale.gui.views.BMRMeasurementView;
 import com.health.openscale.gui.views.FloatMeasurementView;
 import com.health.openscale.gui.views.MeasurementView;
 import com.health.openscale.gui.views.WeightMeasurementView;
@@ -326,7 +327,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
             if (view instanceof FloatMeasurementView) {
                 FloatMeasurementView measurementView = (FloatMeasurementView) view;
 
-                if (measurementView.getName().equals(getString(R.string.label_bmr))) {
+                if (measurementView instanceof BMRMeasurementView) {
                     continue;
                 }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/GraphFragment.java
@@ -46,6 +46,7 @@ import com.health.openscale.gui.activities.DataEntryActivity;
 import com.health.openscale.gui.views.BMRMeasurementView;
 import com.health.openscale.gui.views.FloatMeasurementView;
 import com.health.openscale.gui.views.MeasurementView;
+import com.health.openscale.gui.views.MeasurementViewSettings;
 import com.health.openscale.gui.views.WeightMeasurementView;
 
 import java.text.SimpleDateFormat;
@@ -250,7 +251,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
     private void addFloatingActionButton(FloatMeasurementView measurementView) {
         FloatingActionButton actionButton = new FloatingActionButton(getContext());
 
-        actionButton.setTag("actionButton" + measurementView.getName());
+        actionButton.setTag(measurementView.getKey());
         actionButton.setColorFilter(Color.parseColor("#000000"));
         actionButton.setImageDrawable(measurementView.getIcon());
         actionButton.setClickable(true);
@@ -260,11 +261,9 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
         actionButton.setLayoutParams(lay);
         actionButton.setOnClickListener(new onClickListenerDiagramLines());
 
-        if (prefs.getBoolean(String.valueOf("actionButton" + measurementView.getName()), true)) {
-            actionButton.setBackgroundTintList(ColorStateList.valueOf(measurementView.getColor()));
-        } else {
-            actionButton.setBackgroundTintList(ColorStateList.valueOf(Color.parseColor("#d3d3d3")));
-        }
+        int color = measurementView.getSettings().isInGraph()
+                ? measurementView.getColor() : Color.parseColor("#d3d3d3");
+        actionButton.setBackgroundTintList(ColorStateList.valueOf(color));
 
         floatingActionBar.addView(actionButton);
     }
@@ -386,7 +385,7 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
                 if (measurementView.isVisible()) {
                     addFloatingActionButton(measurementView);
 
-                    if (prefs.getBoolean(String.valueOf("actionButton" + measurementView.getName()), true)) {
+                    if (measurementView.getSettings().isInGraph()) {
                         diagramLineList.add(diagramLine);
                     }
                 }
@@ -588,11 +587,9 @@ public class GraphFragment extends Fragment implements FragmentUpdateListener {
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
 
-            if (prefs.getBoolean(String.valueOf(actionButton.getTag()), true)) {
-                prefs.edit().putBoolean(String.valueOf(actionButton.getTag()), false).commit();
-            } else {
-                prefs.edit().putBoolean(String.valueOf(actionButton.getTag()), true).commit();
-            }
+            String key = String.valueOf(actionButton.getTag());
+            MeasurementViewSettings settings = new MeasurementViewSettings(prefs, key);
+            prefs.edit().putBoolean(settings.getInGraphKey(), !settings.isInGraph()).apply();
 
             generateGraphs();
         }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -227,8 +227,7 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
 
         for (MeasurementView view : measurementViews) {
             if (!view.isVisible()
-                    || !prefs.getBoolean(String.valueOf("actionButton" + view.getName()), true)
-                    || view.getName().equals(getString(R.string.label_bmr))
+                    || !view.getSettings().isOnOverviewGraph()
                     || !(view instanceof FloatMeasurementView)) {
                 continue;
             }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -38,6 +38,7 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
 import com.health.openscale.core.utils.DateTimeHelpers;
+import com.health.openscale.gui.views.BMRMeasurementView;
 import com.health.openscale.gui.views.FloatMeasurementView;
 import com.health.openscale.gui.views.MeasurementView;
 
@@ -276,7 +277,7 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
             if (view instanceof FloatMeasurementView) {
                 FloatMeasurementView measurementView = (FloatMeasurementView) view;
 
-                if (measurementView.getName().equals(getString(R.string.label_bmr))) {
+                if (measurementView instanceof BMRMeasurementView) {
                     continue;
                 }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/OverviewFragment.java
@@ -228,7 +228,7 @@ public class OverviewFragment extends Fragment implements FragmentUpdateListener
 
         for (MeasurementView view : measurementViews) {
             if (!view.isVisible()
-                    || !view.getSettings().isOnOverviewGraph()
+                    || !view.getSettings().isInOverviewGraph()
                     || !(view instanceof FloatMeasurementView)) {
                 continue;
             }

--- a/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/fragments/StatisticsFragment.java
@@ -16,9 +16,7 @@
 
 package com.health.openscale.gui.fragments;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.text.Html;
 import android.view.LayoutInflater;
@@ -67,7 +65,6 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
     private TableLayout tableMonthAveragesLayoutColumnA;
     private TableLayout tableMonthAveragesLayoutColumnB;
 
-    private SharedPreferences prefs;
     private ScaleUser currentScaleUser;
     private ScaleMeasurement lastScaleMeasurement;
 
@@ -77,8 +74,6 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         statisticsView = inflater.inflate(R.layout.fragment_statistics, container, false);
-
-        prefs = PreferenceManager.getDefaultSharedPreferences(statisticsView.getContext());
 
         txtGoalWeight = (TextView) statisticsView.findViewById(R.id.txtGoalWeight);
         txtGoalDiff = (TextView) statisticsView.findViewById(R.id.txtGoalDiff);
@@ -110,9 +105,9 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
 
         for (MeasurementView measurement : viewMeasurementsListWeek) {
             measurement.setEditMode(STATISTIC);
-            measurement.updatePreferences(prefs);
 
-            if (measurement.isVisible()) {
+            if (measurement.getSettings().isEnabled()) {
+                measurement.setVisible(true);
                 measurement.setPadding(-1, -1, -1, paddingBottom);
                 if ((i % 2) == 0) {
                     tableWeekAveragesLayoutColumnA.addView(measurement);
@@ -138,9 +133,9 @@ public class StatisticsFragment extends Fragment implements FragmentUpdateListen
 
         for (MeasurementView measurement : viewMeasurementsListMonth) {
             measurement.setEditMode(STATISTIC);
-            measurement.updatePreferences(prefs);
 
-            if (measurement.isVisible()) {
+            if (measurement.getSettings().isEnabled()) {
+                measurement.setVisible(true);
                 measurement.setPadding(-1, -1, -1, paddingBottom);
                 if ((i % 2) == 0) {
                     tableMonthAveragesLayoutColumnA.addView(measurement);

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GeneralPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GeneralPreferences.java
@@ -23,7 +23,6 @@ import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
-import android.widget.Toast;
 
 import com.health.openscale.R;
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014  olie.xdev <olie.xdev@googlemail.com>
+*  Copyright (C) 2018 Erik Johansson <erik@ejohansson.se>
 *
 *    This program is free software: you can redistribute it and/or modify
 *    it under the terms of the GNU General Public License as published by
@@ -16,75 +17,46 @@
 package com.health.openscale.gui.preferences;
 
 import android.app.AlertDialog;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
+import android.database.DataSetObserver;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
-import android.preference.EditTextPreference;
-import android.preference.ListPreference;
-import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
-import android.preference.SwitchPreference;
+import android.preference.PreferenceScreen;
+import android.util.TypedValue;
 import android.view.DragEvent;
+import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.CompoundButton;
+import android.widget.ListAdapter;
+import android.widget.Switch;
 import android.widget.Toast;
 
 import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
-import com.health.openscale.core.bodymetric.EstimatedFatMetric;
-import com.health.openscale.core.bodymetric.EstimatedLBWMetric;
-import com.health.openscale.core.bodymetric.EstimatedWaterMetric;
 import com.health.openscale.gui.views.MeasurementView;
+import com.health.openscale.gui.views.WeightMeasurementView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-public class MeasurementPreferences extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener  {
+public class MeasurementPreferences extends PreferenceFragment {
     public static final String PREFERENCE_KEY_DELETE_ALL = "deleteAll";
-    public static final String PREFERENCE_KEY_FAT = "fatEnable";
-    public static final String PREFERENCE_KEY_FAT_PERCENTAGE = "fatPercentageEnable";
-    public static final String PREFERENCE_KEY_WATER = "waterEnable";
-    public static final String PREFERENCE_KEY_WATER_PERCENTAGE = "waterPercentageEnable";
-    public static final String PREFERENCE_KEY_MUSCLE = "muscleEnable";
-    public static final String PREFERENCE_KEY_MUSCLE_PERCENTAGE = "musclePercentageEnable";
-    public static final String PREFERENCE_KEY_ESTIMATE_WATER = "estimateWaterEnable";
-    public static final String PREFERENCE_KEY_ESTIMATE_WATER_FORMULA = "estimateWaterFormula";
-    public static final String PREFERENCE_KEY_ESTIMATE_LBW = "estimateLBWEnable";
-    public static final String PREFERENCE_KEY_ESTIMATE_LBW_FORMULA = "estimateLBWFormula";
-    public static final String PREFERENCE_KEY_ESTIMATE_FAT = "estimateFatEnable";
-    public static final String PREFERENCE_KEY_ESTIMATE_FAT_FORMULA = "estimateFatFormula";
-
     public static final String PREFERENCE_KEY_RESET_ORDER = "resetOrder";
-    public static final String PREFERENCE_KEY_ORDER_CATEGORY = "orderCategory";
+    public static final String PREFERENCE_KEY_MEASUREMENTS = "measurements";
 
     private Preference deleteAll;
-
-    private PreferenceCategory measurementOrderCategory;
-
-    private CheckBoxPreference fatEnable;
-    private SwitchPreference fatPercentageEnable;
-    private CheckBoxPreference waterEnable;
-    private SwitchPreference waterPercentageEnable;
-    private CheckBoxPreference muscleEnable;
-    private SwitchPreference musclePercentageEnable;
-
-    private CheckBoxPreference estimateWaterEnable;
-    private ListPreference estimateWaterFormula;
-    private CheckBoxPreference estimateLBWEnable;
-    private ListPreference estimateLBWFormula;
-    private CheckBoxPreference estimateFatEnable;
-    private ListPreference estimateFatFormula;
+    private PreferenceCategory measurementCategory;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -92,203 +64,46 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
 
         addPreferencesFromResource(R.xml.measurement_preferences);
 
-        deleteAll = (Preference) findPreference(PREFERENCE_KEY_DELETE_ALL);
+        deleteAll = findPreference(PREFERENCE_KEY_DELETE_ALL);
         deleteAll.setOnPreferenceClickListener(new onClickListenerDeleteAll());
 
-        final Context context = getActivity().getBaseContext();
-
-        measurementOrderCategory = (PreferenceCategory) findPreference(PREFERENCE_KEY_ORDER_CATEGORY);
-        measurementOrderCategory.setOrderingAsAdded(true);
+        measurementCategory = (PreferenceCategory) findPreference(PREFERENCE_KEY_MEASUREMENTS);
 
         Preference resetOrder = findPreference(PREFERENCE_KEY_RESET_ORDER);
         resetOrder.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
-                PreferenceManager.getDefaultSharedPreferences(context).edit()
-                        .remove(MeasurementView.PREF_MEASUREMENT_ORDER).commit();
-                measurementOrderCategory.removeAll();
-                updateMeasurementOrderScreen(context, measurementOrderCategory);
+                PreferenceManager.getDefaultSharedPreferences(getActivity()).edit()
+                        .remove(MeasurementView.PREF_MEASUREMENT_ORDER).apply();
+                updateMeasurementPreferences();
                 return true;
             }
         });
 
-        updateMeasurementOrderScreen(context, measurementOrderCategory);
-
-        estimateWaterEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_ESTIMATE_WATER);
-        estimateWaterFormula = (ListPreference) findPreference(PREFERENCE_KEY_ESTIMATE_WATER_FORMULA);
-        estimateLBWEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_ESTIMATE_LBW);
-        estimateLBWFormula = (ListPreference) findPreference(PREFERENCE_KEY_ESTIMATE_LBW_FORMULA);
-        estimateFatEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_ESTIMATE_FAT);
-        estimateFatFormula = (ListPreference) findPreference(PREFERENCE_KEY_ESTIMATE_FAT_FORMULA);
-
-        fatEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_FAT);
-        fatPercentageEnable = (SwitchPreference) findPreference(PREFERENCE_KEY_FAT_PERCENTAGE);
-        waterEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_WATER);
-        waterPercentageEnable = (SwitchPreference) findPreference(PREFERENCE_KEY_WATER_PERCENTAGE);
-        muscleEnable = (CheckBoxPreference) findPreference(PREFERENCE_KEY_MUSCLE);
-        musclePercentageEnable = (SwitchPreference) findPreference(PREFERENCE_KEY_MUSCLE_PERCENTAGE);
-
-        updateWaterListPreferences();
-        updateLBWListPreferences();
-        updateFatListPreferences();
-
-        initSummary(getPreferenceScreen());
+        updateMeasurementPreferences();
     }
 
-    private void updateMeasurementOrderScreen(Context context, PreferenceCategory category) {
+    private void updateMeasurementPreferences() {
+        measurementCategory.removeAll();
+
         List<MeasurementView> measurementViews = MeasurementView.getMeasurementList(
-                context, MeasurementView.DateTimeOrder.NONE);
+                getActivity(), MeasurementView.DateTimeOrder.NONE);
+
         for (MeasurementView measurement : measurementViews) {
-            Preference preference = new MeasurementOrderPreference(context, category, measurement);
-            preference.setShouldDisableView(true);
-            preference.setEnabled(measurement.isVisible());
-            category.addPreference(preference);
-        }
-    }
+            Preference preference = new MeasurementOrderPreference(
+                    getActivity(), measurementCategory, measurement);
+            preference.setKey(measurement.getSettings().getEnabledKey());
+            preference.setDefaultValue(measurement.getSettings().isEnabled());
+            preference.setPersistent(true);
+            preference.setEnabled(!measurement.getIsDisabledByDependency());
 
-    public void updateWaterListPreferences() {
-        ArrayList<String> listEntries = new ArrayList();
-        ArrayList<String> listEntryValues = new ArrayList();
+            Drawable icon = measurement.getIcon();
+            icon.setColorFilter(measurement.getForegroundColor(), PorterDuff.Mode.SRC_IN);
+            preference.setIcon(icon);
 
-        for (EstimatedWaterMetric.FORMULA formulaWater : EstimatedWaterMetric.FORMULA.values()) {
-            EstimatedWaterMetric waterMetric = EstimatedWaterMetric.getEstimatedMetric(formulaWater);
+            preference.setTitle(measurement.getName());
 
-            listEntries.add(waterMetric.getName());
-            listEntryValues.add(formulaWater.toString());
-        }
-
-        estimateWaterFormula.setEntries(listEntries.toArray(new CharSequence[listEntries.size()]));
-        estimateWaterFormula.setEntryValues(listEntryValues.toArray(new CharSequence[listEntryValues.size()]));
-    }
-
-    public void updateLBWListPreferences() {
-        ArrayList<String> listEntries = new ArrayList();
-        ArrayList<String> listEntryValues = new ArrayList();
-
-        for (EstimatedLBWMetric.FORMULA formulaLBW : EstimatedLBWMetric.FORMULA.values()) {
-            EstimatedLBWMetric muscleMetric = EstimatedLBWMetric.getEstimatedMetric(formulaLBW);
-
-            listEntries.add(muscleMetric.getName());
-            listEntryValues.add(formulaLBW.toString());
-        }
-
-        estimateLBWFormula.setEntries(listEntries.toArray(new CharSequence[listEntries.size()]));
-        estimateLBWFormula.setEntryValues(listEntryValues.toArray(new CharSequence[listEntryValues.size()]));
-    }
-
-
-    public void updateFatListPreferences() {
-        ArrayList<String> listEntries = new ArrayList();
-        ArrayList<String> listEntryValues = new ArrayList();
-
-        for (EstimatedFatMetric.FORMULA formulaFat : EstimatedFatMetric.FORMULA.values()) {
-            EstimatedFatMetric fatMetric = EstimatedFatMetric.getEstimatedMetric(formulaFat);
-
-            listEntries.add(fatMetric.getName());
-            listEntryValues.add(formulaFat.toString());
-        }
-
-        estimateFatFormula.setEntries(listEntries.toArray(new CharSequence[listEntries.size()]));
-        estimateFatFormula.setEntryValues(listEntryValues.toArray(new CharSequence[listEntryValues.size()]));
-    }
-
-
-    private void initSummary(Preference p) {
-        if (p instanceof PreferenceGroup) {
-            PreferenceGroup pGrp = (PreferenceGroup) p;
-            for (int i = 0; i < pGrp.getPreferenceCount(); i++) {
-                initSummary(pGrp.getPreference(i));
-            }
-        } else {
-            updatePrefSummary(p);
-        }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
-    }
-
-    @Override
-    public void onPause() {
-        getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
-        super.onPause();
-    }
-
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        updatePrefSummary(findPreference(key));
-        if (!key.equals(MeasurementView.PREF_MEASUREMENT_ORDER)) {
-            measurementOrderCategory.removeAll();
-            updateMeasurementOrderScreen(getActivity().getApplicationContext(), measurementOrderCategory);
-        }
-    }
-
-    private void updatePrefSummary(Preference p) {
-        if (estimateWaterEnable.isChecked()) {
-            estimateWaterFormula.setEnabled(true);
-        } else {
-            estimateWaterFormula.setEnabled(false);
-        }
-
-        if (estimateLBWEnable.isChecked()) {
-            estimateLBWFormula.setEnabled(true);
-        } else {
-            estimateLBWFormula.setEnabled(false);
-        }
-
-        if (estimateFatEnable.isChecked()) {
-            estimateFatFormula.setEnabled(true);
-        } else {
-            estimateFatFormula.setEnabled(false);
-        }
-
-        if (fatEnable.isChecked()) {
-            fatPercentageEnable.setEnabled(true);
-        } else {
-            fatPercentageEnable.setEnabled(false);
-        }
-
-        if (waterEnable.isChecked()) {
-            waterPercentageEnable.setEnabled(true);
-        } else {
-            waterPercentageEnable.setEnabled(false);
-        }
-
-        if (muscleEnable.isChecked()) {
-            musclePercentageEnable.setEnabled(true);
-        } else {
-            musclePercentageEnable.setEnabled(false);
-        }
-
-        estimateWaterFormula.setSummary(EstimatedWaterMetric.getEstimatedMetric(EstimatedWaterMetric.FORMULA.valueOf(estimateWaterFormula.getValue())).getName());
-        estimateLBWFormula.setSummary(EstimatedLBWMetric.getEstimatedMetric(EstimatedLBWMetric.FORMULA.valueOf(estimateLBWFormula.getValue())).getName());
-        estimateFatFormula.setSummary(EstimatedFatMetric.getEstimatedMetric(EstimatedFatMetric.FORMULA.valueOf(estimateFatFormula.getValue())).getName());
-
-        if (p instanceof EditTextPreference) {
-            EditTextPreference editTextPref = (EditTextPreference) p;
-            if (p.getTitle().toString().contains("assword"))
-            {
-                p.setSummary("******");
-            } else {
-                p.setSummary(editTextPref.getText());
-            }
-        }
-
-        if (p instanceof MultiSelectListPreference) {
-            MultiSelectListPreference editMultiListPref = (MultiSelectListPreference) p;
-
-            CharSequence[] entries = editMultiListPref.getEntries();
-            CharSequence[] entryValues = editMultiListPref.getEntryValues();
-            List<String> currentEntries = new ArrayList<>();
-            Set<String> currentEntryValues = editMultiListPref.getValues();
-
-            for (int i = 0; i < entries.length; i++)
-                if (currentEntryValues.contains(entryValues[i]))
-                    currentEntries.add(entries[i].toString());
-
-            p.setSummary(currentEntries.toString());
+            measurementCategory.addPreference(preference);
         }
     }
 
@@ -323,19 +138,25 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
         }
     }
 
-    private class MeasurementOrderPreference extends Preference {
+    private class MeasurementOrderPreference extends Preference
+            implements GestureDetector.OnGestureListener {
         PreferenceGroup parentGroup;
         MeasurementView measurement;
+
+        GestureDetector gestureDetector;
+
         View boundView;
+        Switch measurementSwitch;
 
         MeasurementOrderPreference(Context context, PreferenceGroup parent, MeasurementView measurementView) {
             super(context);
             parentGroup = parent;
             measurement = measurementView;
-            Drawable icon = measurement.getIcon();
-            icon.setColorFilter(measurementView.getForegroundColor(), PorterDuff.Mode.SRC_IN);
-            setIcon(icon);
-            setTitle(measurement.getName());
+
+            gestureDetector = new GestureDetector(getContext(), this);
+            gestureDetector.setIsLongpressEnabled(true);
+
+            setWidgetLayoutResource(R.layout.measurement_preferences_widget_layout);
         }
 
         public PreferenceGroup getParent() {
@@ -347,46 +168,146 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
             super.onBindView(view);
             boundView = view;
 
-            onTouchClickListener touchClickListener = new onTouchClickListener(this);
-            view.setOnTouchListener(touchClickListener);
-            view.setOnLongClickListener(touchClickListener);
+            measurementSwitch = view.findViewById(R.id.measurement_switch);
+            if (measurement instanceof WeightMeasurementView) {
+                measurementSwitch.setVisibility(View.INVISIBLE);
+            }
+            else {
+                measurementSwitch.setChecked(getPersistedBoolean(true));
+                measurementSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                        persistBoolean(isChecked);
+                        setEnableOnDependants(isChecked);
+                    }
+                });
+            }
+
+            if (!measurement.hasExtraPreferences()) {
+                view.findViewById(R.id.measurement_switch_separator).setVisibility(View.GONE);
+            }
+
+            TypedValue outValue = new TypedValue();
+            getActivity().getTheme().resolveAttribute(R.attr.selectableItemBackground, outValue, true);
+            boundView.setBackgroundResource(outValue.resourceId);
+
+            view.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    return gestureDetector.onTouchEvent(event);
+                }
+            });
             view.setOnDragListener(new onDragListener());
         }
 
-        private class onTouchClickListener implements View.OnTouchListener, View.OnLongClickListener {
-            MeasurementOrderPreference preference;
-            int x = 0;
-            int y = 0;
-
-            onTouchClickListener(MeasurementOrderPreference pref) {
-                preference = pref;
-            }
-
-            @Override
-            public boolean onTouch(View view, MotionEvent event) {
-                if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
-                    x = Math.round(event.getX());
-                    y = Math.round(event.getY());
+        private void setEnableOnDependants(boolean enable) {
+            for (int i = 0; i < getParent().getPreferenceCount(); ++i) {
+                MeasurementOrderPreference preference =
+                        (MeasurementOrderPreference) getParent().getPreference(i);
+                for (String dep : preference.measurement.getDependencyKeys()) {
+                    if (dep.equals(measurement.getKey())) {
+                        preference.setEnabled(enable);
+                        break;
+                    }
                 }
-                return false;
             }
+        }
 
-            @Override
-            public boolean onLongClick(View view) {
-                return view.startDrag(null, new dragShadowBuilder(view), preference, 0);
-            }
+        @Override
+        public boolean onDown(MotionEvent e) {
+            return isEnabled();
+        }
 
-            private class dragShadowBuilder extends View.DragShadowBuilder {
-                public dragShadowBuilder(View view) {
-                    super(view);
+        @Override
+        public void onShowPress(MotionEvent e) {
+            boundView.setPressed(true);
+        }
+
+        @Override
+        public boolean onSingleTapUp(MotionEvent e) {
+            boundView.setPressed(false);
+
+            if (!measurement.hasExtraPreferences()) {
+                if (measurementSwitch.getVisibility() == View.VISIBLE) {
+                    measurementSwitch.toggle();
                 }
+                return true;
+            }
 
+            // Must be enabled to show extra preferences screen
+            if (!getPersistedBoolean(true)) {
+                return true;
+            }
+
+            final PreferenceScreen screen = getPreferenceManager().createPreferenceScreen(getActivity());
+
+            // Register as an observer so that the loop to getItem() below will find the new
+            // preference screen added at the end. The add is done on another thread so we must
+            // wait for it to complete.
+            final ListAdapter adapter = getPreferenceScreen().getRootAdapter();
+            adapter.registerDataSetObserver(new DataSetObserver() {
                 @Override
-                public void onProvideShadowMetrics(Point outShadowSize, Point outShadowTouchPoint) {
-                    super.onProvideShadowMetrics(outShadowSize, outShadowTouchPoint);
-                    outShadowTouchPoint.set(x, y);
+                public void onChanged() {
+                    adapter.unregisterDataSetObserver(this);
+
+                    // Simulate a click to have the preference screen open
+                    for (int i = adapter.getCount() - 1; i >= 0; --i) {
+                        if (adapter.getItem(i) == screen) {
+                            getPreferenceScreen().onItemClick(null, null, i, 0);
+                            break;
+                        }
+                    }
+
+                    // Remove the preference when the dialog is dismissed
+                    Dialog dialog = screen.getDialog();
+                    dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+                        @Override
+                        public void onDismiss(DialogInterface dialog) {
+                            screen.onDismiss(dialog);
+                            getPreferenceScreen().removePreference(screen);
+                        }
+                    });
                 }
+            });
+
+            getPreferenceScreen().addPreference(screen);
+            measurement.prepareExtraPreferencesScreen(screen);
+
+            return true;
+        }
+
+        @Override
+        public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
+            return false;
+        }
+
+        @Override
+        public void onLongPress(MotionEvent event) {
+            int x = Math.round(event.getX());
+            int y = Math.round(event.getY());
+
+            boundView.startDrag(null, new dragShadowBuilder(boundView, x, y), this, 0);
+        }
+
+        private class dragShadowBuilder extends View.DragShadowBuilder {
+            private int x;
+            private int y;
+            public dragShadowBuilder(View view, int x, int y) {
+                super(view);
+                this.x = x;
+                this.y = y;
             }
+
+            @Override
+            public void onProvideShadowMetrics(Point outShadowSize, Point outShadowTouchPoint) {
+                super.onProvideShadowMetrics(outShadowSize, outShadowTouchPoint);
+                outShadowTouchPoint.set(x, y);
+            }
+        }
+
+        @Override
+        public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+            return false;
         }
 
         private class onDragListener implements View.OnDragListener {
@@ -422,9 +343,6 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
             public boolean onDrag(View view, DragEvent event) {
                 switch (event.getAction()) {
                     case DragEvent.ACTION_DRAG_STARTED:
-                        if (isDraggedView(view, event)) {
-                            setTemporaryBackgroundColor(view, Color.GRAY);
-                        }
                         break;
                     case DragEvent.ACTION_DRAG_ENTERED:
                         if (!isDraggedView(view, event)) {
@@ -472,6 +390,5 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
                 return true;
             }
         }
-
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -173,7 +173,7 @@ public class MeasurementPreferences extends PreferenceFragment {
                 measurementSwitch.setVisibility(View.INVISIBLE);
             }
             else {
-                measurementSwitch.setChecked(getPersistedBoolean(true));
+                measurementSwitch.setChecked(measurement.getSettings().isEnabledIgnoringDependencies());
                 measurementSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                     @Override
                     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -33,7 +33,6 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
-import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.view.DragEvent;
 import android.view.MotionEvent;
@@ -71,7 +70,6 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
 
     private Preference deleteAll;
 
-    private PreferenceScreen measurementOrderScreen;
     private PreferenceCategory measurementOrderCategory;
 
     private CheckBoxPreference fatEnable;
@@ -98,7 +96,6 @@ public class MeasurementPreferences extends PreferenceFragment implements Shared
         deleteAll.setOnPreferenceClickListener(new onClickListenerDeleteAll());
 
         final Context context = getActivity().getBaseContext();
-        measurementOrderScreen = (PreferenceScreen) findPreference(MeasurementView.PREF_MEASUREMENT_ORDER);
 
         measurementOrderCategory = (PreferenceCategory) findPreference(PREFERENCE_KEY_ORDER_CATEGORY);
         measurementOrderCategory.setOrderingAsAdded(true);

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -93,9 +93,9 @@ public class MeasurementPreferences extends PreferenceFragment {
             Preference preference = new MeasurementOrderPreference(
                     getActivity(), measurementCategory, measurement);
             preference.setKey(measurement.getSettings().getEnabledKey());
-            preference.setDefaultValue(measurement.getSettings().isEnabled());
+            preference.setDefaultValue(measurement.getSettings().isEnabledIgnoringDependencies());
             preference.setPersistent(true);
-            preference.setEnabled(!measurement.getIsDisabledByDependency());
+            preference.setEnabled(measurement.getSettings().areDependenciesEnabled());
 
             Drawable icon = measurement.getIcon();
             icon.setColorFilter(measurement.getForegroundColor(), PorterDuff.Mode.SRC_IN);
@@ -178,7 +178,11 @@ public class MeasurementPreferences extends PreferenceFragment {
                     @Override
                     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                         persistBoolean(isChecked);
-                        setEnableOnDependants(isChecked);
+                        for (int i = 0; i < getParent().getPreferenceCount(); ++i) {
+                            MeasurementOrderPreference preference =
+                                    (MeasurementOrderPreference) getParent().getPreference(i);
+                            preference.setEnabled(preference.measurement.getSettings().areDependenciesEnabled());
+                        }
                     }
                 });
             }
@@ -198,19 +202,6 @@ public class MeasurementPreferences extends PreferenceFragment {
                 }
             });
             view.setOnDragListener(new onDragListener());
-        }
-
-        private void setEnableOnDependants(boolean enable) {
-            for (int i = 0; i < getParent().getPreferenceCount(); ++i) {
-                MeasurementOrderPreference preference =
-                        (MeasurementOrderPreference) getParent().getPreference(i);
-                for (String dep : preference.measurement.getDependencyKeys()) {
-                    if (dep.equals(measurement.getKey())) {
-                        preference.setEnabled(enable);
-                        break;
-                    }
-                }
-            }
         }
 
         @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BMIMeasurementView extends FloatMeasurementView {
-    public static String KEY = "bmi";
+    public static final String KEY = "bmi";
+    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public BMIMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmi), ContextCompat.getDrawable(context, R.drawable.ic_bmi));
@@ -38,7 +39,7 @@ public class BMIMeasurementView extends FloatMeasurementView {
 
     @Override
     public String[] getDependencyKeys() {
-        return new String[] {WeightMeasurementView.KEY};
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BMIMeasurementView extends FloatMeasurementView {
+    public static String KEY = "bmi";
 
     public BMIMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmi), ContextCompat.getDrawable(context, R.drawable.ic_bmi));
@@ -33,7 +34,7 @@ public class BMIMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "bmi";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BMIMeasurementView extends FloatMeasurementView {
     public static final String KEY = "bmi";
-    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public BMIMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmi), ContextCompat.getDrawable(context, R.drawable.ic_bmi));
@@ -35,11 +34,6 @@ public class BMIMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMIMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -38,8 +37,8 @@ public class BMIMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("weightEnable", true));
+    public String[] getDependencyKeys() {
+        return new String[] {WeightMeasurementView.KEY};
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 
 public class BMRMeasurementView extends FloatMeasurementView {
     public static final String KEY = "bmr";
-    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public BMRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmr), ContextCompat.getDrawable(context, R.drawable.ic_bmr));
@@ -37,11 +36,6 @@ public class BMRMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -28,6 +28,7 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 import java.util.Locale;
 
 public class BMRMeasurementView extends FloatMeasurementView {
+    public static String KEY = "bmr";
 
     public BMRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmr), ContextCompat.getDrawable(context, R.drawable.ic_bmr));
@@ -35,7 +36,7 @@ public class BMRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "bmr";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -40,8 +39,8 @@ public class BMRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("weightEnable", true));
+    public String[] getDependencyKeys() {
+        return new String[] {WeightMeasurementView.KEY};
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BMRMeasurementView.java
@@ -27,7 +27,8 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 import java.util.Locale;
 
 public class BMRMeasurementView extends FloatMeasurementView {
-    public static String KEY = "bmr";
+    public static final String KEY = "bmr";
+    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public BMRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bmr), ContextCompat.getDrawable(context, R.drawable.ic_bmr));
@@ -40,7 +41,7 @@ public class BMRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String[] getDependencyKeys() {
-        return new String[] {WeightMeasurementView.KEY};
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BoneMeasurementView extends FloatMeasurementView {
+    public static String KEY = "bone";
 
     public BoneMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bone), ContextCompat.getDrawable(context, R.drawable.ic_bone));
@@ -33,7 +34,7 @@ public class BoneMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "bone";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BoneMeasurementView extends FloatMeasurementView {
-    public static String KEY = "bone";
+    public static final String KEY = "bone";
+    private static final String[] DEPENDENCY = {};
 
     public BoneMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bone), ContextCompat.getDrawable(context, R.drawable.ic_bone));
@@ -34,6 +35,11 @@ public class BoneMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class BoneMeasurementView extends FloatMeasurementView {
     public static final String KEY = "bone";
-    private static final String[] DEPENDENCY = {};
 
     public BoneMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_bone), ContextCompat.getDrawable(context, R.drawable.ic_bone));
@@ -35,11 +34,6 @@ public class BoneMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/BoneMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -35,11 +34,6 @@ public class BoneMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("boneEnable", false));
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.text.InputType;
@@ -65,11 +64,6 @@ public class CommentMeasurementView extends MeasurementView {
     @Override
     public void saveState(Bundle state) {
         state.putString(getKey(), comment);
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        // Empty
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.R;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
-    public static String KEY = "comment";
+    public static final String KEY = "comment";
+    private static final String[] DEPENDENCY = {};
 
     private String comment;
 
@@ -37,6 +38,11 @@ public class CommentMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     private void setValue(String newComment, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -63,6 +63,11 @@ public class CommentMeasurementView extends MeasurementView {
     }
 
     @Override
+    public void clearIn(ScaleMeasurement measurement) {
+        measurement.setComment("");
+    }
+
+    @Override
     public void restoreState(Bundle state) {
         setValue(state.getString(getKey()), true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -27,7 +27,6 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
     public static final String KEY = "comment";
-    private static final String[] DEPENDENCY = {};
 
     private String comment;
 
@@ -38,11 +37,6 @@ public class CommentMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     private void setValue(String newComment, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/CommentMeasurementView.java
@@ -27,6 +27,8 @@ import com.health.openscale.R;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 
 public class CommentMeasurementView extends MeasurementView {
+    public static String KEY = "comment";
+
     private String comment;
 
     public CommentMeasurementView(Context context) {
@@ -35,7 +37,7 @@ public class CommentMeasurementView extends MeasurementView {
 
     @Override
     public String getKey() {
-        return "comment";
+        return KEY;
     }
 
     private void setValue(String newComment, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -78,6 +78,11 @@ public class DateMeasurementView extends MeasurementView {
     }
 
     @Override
+    public void clearIn(ScaleMeasurement measurement) {
+        // Ignore
+    }
+
+    @Override
     public void restoreState(Bundle state) {
         setValue(new Date(state.getLong(getKey())), true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -30,7 +30,6 @@ import java.util.Date;
 
 public class DateMeasurementView extends MeasurementView {
     public static final String KEY = "date";
-    private static final String[] DEPENDENCY = {};
 
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
@@ -42,11 +41,6 @@ public class DateMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     private void setValue(Date newDate, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
@@ -80,11 +79,6 @@ public class DateMeasurementView extends MeasurementView {
     @Override
     public void saveState(Bundle state) {
         state.putLong(getKey(), date.getTime());
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        // Empty
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -29,7 +29,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class DateMeasurementView extends MeasurementView {
-    public static String KEY = "date";
+    public static final String KEY = "date";
+    private static final String[] DEPENDENCY = {};
 
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
@@ -41,6 +42,11 @@ public class DateMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     private void setValue(Date newDate, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/DateMeasurementView.java
@@ -30,6 +30,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class DateMeasurementView extends MeasurementView {
+    public static String KEY = "date";
+
     private static DateFormat dateFormat = DateFormat.getDateInstance();
     private Date date;
 
@@ -39,9 +41,8 @@ public class DateMeasurementView extends MeasurementView {
 
     @Override
     public String getKey() {
-        return "date";
+        return KEY;
     }
-
 
     private void setValue(Date newDate, boolean callListener) {
         if (!newDate.equals(date)) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -17,9 +17,11 @@ package com.health.openscale.gui.views;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.preference.ListPreference;
 import android.support.v4.content.ContextCompat;
 
 import com.health.openscale.R;
+import com.health.openscale.core.bodymetric.EstimatedFatMetric;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
@@ -78,6 +80,22 @@ public class FatMeasurementView extends FloatMeasurementView {
 
     @Override
     protected boolean isEstimationSupported() { return true; }
+
+    @Override
+    protected void prepareEstimationFormulaPreference(ListPreference preference) {
+        String[] entries = new String[EstimatedFatMetric.FORMULA.values().length];
+        String[] values = new String[entries.length];
+
+        int idx = 0;
+        for (EstimatedFatMetric.FORMULA formula : EstimatedFatMetric.FORMULA.values()) {
+            entries[idx] = EstimatedFatMetric.getEstimatedMetric(formula).getName();
+            values[idx] = formula.name();
+            ++idx;
+        }
+
+        preference.setEntries(entries);
+        preference.setEntryValues(values);
+    }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -28,7 +28,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class FatMeasurementView extends FloatMeasurementView {
     public static final String KEY = "fat";
-    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public FatMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_fat), ContextCompat.getDrawable(context, R.drawable.ic_fat));
@@ -37,11 +36,6 @@ public class FatMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -28,9 +27,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 public class FatMeasurementView extends FloatMeasurementView {
     public static final String KEY = "fat";
     private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
-
-    private boolean estimateFatEnable;
-    private boolean percentageEnable;
 
     public FatMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_fat), ContextCompat.getDrawable(context, R.drawable.ic_fat));
@@ -47,15 +43,8 @@ public class FatMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        super.updatePreferences(preferences);
-        estimateFatEnable = preferences.getBoolean("estimateFatEnable", false);
-        percentageEnable = preferences.getBoolean("fatPercentageEnable", true);
-    }
-
-    @Override
-    protected boolean shouldConvertPercentageToAbsoluteWeight() {
-        return !percentageEnable;
+    protected boolean canConvertPercentageToAbsoluteWeight() {
+        return true;
     }
 
     @Override
@@ -70,11 +59,11 @@ public class FatMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getUnit() {
-        if (percentageEnable) {
-            return "%";
+        if (shouldConvertPercentageToAbsoluteWeight()) {
+            return getScaleUser().getScaleUnit().toString();
         }
 
-        return getScaleUser().getScaleUnit().toString();
+        return "%";
     }
 
     @Override
@@ -88,9 +77,7 @@ public class FatMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    protected boolean isEstimationEnabled() {
-        return estimateFatEnable;
-    }
+    protected boolean isEstimationSupported() { return true; }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -42,7 +42,7 @@ public class FatMeasurementView extends FloatMeasurementView {
 
     @Override
     public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("fatEnable", true));
+        super.updatePreferences(preferences);
         estimateFatEnable = preferences.getBoolean("estimateFatEnable", false);
         percentageEnable = preferences.getBoolean("fatPercentageEnable", true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class FatMeasurementView extends FloatMeasurementView {
-    public static String KEY = "fat";
+    public static final String KEY = "fat";
+    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     private boolean estimateFatEnable;
     private boolean percentageEnable;
@@ -38,6 +39,11 @@ public class FatMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FatMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class FatMeasurementView extends FloatMeasurementView {
+    public static String KEY = "fat";
 
     private boolean estimateFatEnable;
     private boolean percentageEnable;
@@ -36,7 +37,7 @@ public class FatMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "fat";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -430,7 +430,7 @@ public abstract class FloatMeasurementView extends MeasurementView {
         overview.setKey(settings.getInOverviewGraphKey());
         overview.setTitle(R.string.label_include_in_overview_graph);
         overview.setPersistent(true);
-        overview.setDefaultValue(settings.isOnOverviewGraph());
+        overview.setDefaultValue(settings.isInOverviewGraph());
         screen.addPreference(overview);
 
         if (canConvertPercentageToAbsoluteWeight()) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -17,10 +17,16 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
+import android.database.DataSetObserver;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
+import android.preference.CheckBoxPreference;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
@@ -31,6 +37,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.ListAdapter;
 import android.widget.TableRow;
 import android.widget.TextView;
 
@@ -228,6 +235,7 @@ public abstract class FloatMeasurementView extends MeasurementView {
     public abstract int getColor();
 
     protected boolean isEstimationSupported() { return false; }
+    protected void prepareEstimationFormulaPreference(ListPreference preference) {}
 
     protected abstract EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value);
 
@@ -404,6 +412,70 @@ public abstract class FloatMeasurementView extends MeasurementView {
     public void setExpand(boolean state) {
         final boolean show = state && isVisible() && evaluationResult != null;
         showEvaluatorRow(show);
+    }
+
+    @Override
+    public boolean hasExtraPreferences() { return true; }
+
+    @Override
+    public void prepareExtraPreferencesScreen(PreferenceScreen screen) {
+        MeasurementViewSettings settings = getSettings();
+
+        CheckBoxPreference overview = new CheckBoxPreference(screen.getContext());
+        overview.setKey(settings.getInOverviewGraphKey());
+        overview.setTitle(R.string.label_include_in_overview_graph);
+        overview.setPersistent(true);
+        overview.setDefaultValue(settings.isOnOverviewGraph());
+        screen.addPreference(overview);
+
+        if (canConvertPercentageToAbsoluteWeight()) {
+            SwitchPreference percentage = new SwitchPreference(screen.getContext());
+            percentage.setKey(settings.getPercentageEnabledKey());
+            percentage.setTitle(R.string.label_measurement_in_percent);
+            percentage.setPersistent(true);
+            percentage.setDefaultValue(settings.isPercentageEnabled());
+            screen.addPreference(percentage);
+        }
+
+        if (isEstimationSupported()) {
+            final CheckBoxPreference estimate = new CheckBoxPreference(screen.getContext());
+            estimate.setKey(settings.getEstimationEnabledKey());
+            estimate.setTitle(R.string.label_estimate_measurement);
+            estimate.setPersistent(true);
+            estimate.setDefaultValue(settings.isEstimationEnabled());
+            screen.addPreference(estimate);
+
+            final ListPreference formula = new ListPreference(screen.getContext());
+            formula.setKey(settings.getEstimationFormulaKey());
+            formula.setTitle(R.string.label_estimation_formula);
+            formula.setPersistent(true);
+            formula.setDefaultValue(settings.getEstimationFormula());
+            prepareEstimationFormulaPreference(formula);
+            formula.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    ListPreference list = (ListPreference) preference;
+                    int idx = list.findIndexOfValue((String) newValue);
+                    if (idx == -1) {
+                        return false;
+                    }
+                    preference.setSummary(list.getEntries()[idx]);
+                    return true;
+                }
+            });
+
+            final ListAdapter adapter = screen.getRootAdapter();
+            adapter.registerDataSetObserver(new DataSetObserver() {
+                @Override
+                public void onChanged() {
+                    adapter.unregisterDataSetObserver(this);
+
+                    formula.setDependency(estimate.getKey());
+                    formula.setSummary(formula.getEntry());
+                }
+            });
+            screen.addPreference(formula);
+        }
     }
 
     private float validateAndGetInput(View view) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -323,6 +323,11 @@ public abstract class FloatMeasurementView extends MeasurementView {
     }
 
     @Override
+    public void clearIn(ScaleMeasurement measurement) {
+        setMeasurementValue(0.0f, measurement);
+    }
+
+    @Override
     public void restoreState(Bundle state) {
         setValue(state.getFloat(getKey()), previousValue, true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/FloatMeasurementView.java
@@ -227,18 +227,20 @@ public abstract class FloatMeasurementView extends MeasurementView {
 
     public abstract int getColor();
 
-    protected boolean isEstimationEnabled() {
-        return false;
-    }
+    protected boolean isEstimationSupported() { return false; }
 
     protected abstract EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value);
 
     private boolean useAutoValue() {
-        return isEstimationEnabled() && getMeasurementMode() == MeasurementViewMode.ADD;
+        return isEstimationSupported()
+                && getSettings().isEstimationEnabled()
+                && getMeasurementMode() == MeasurementViewMode.ADD;
     }
 
+    protected boolean canConvertPercentageToAbsoluteWeight() { return false; }
     protected boolean shouldConvertPercentageToAbsoluteWeight() {
-        return false;
+        return canConvertPercentageToAbsoluteWeight()
+                && !getSettings().isPercentageEnabled();
     }
 
     private float makeAbsoluteWeight(float percentage) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class HipMeasurementView extends FloatMeasurementView {
-    public static String KEY = "hip";
+    public static final String KEY = "hip";
+    private static final String[] DEPENDENCY = {};
 
     public HipMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_hip), ContextCompat.getDrawable(context, R.drawable.ic_hip));
@@ -34,6 +35,11 @@ public class HipMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -35,11 +34,6 @@ public class HipMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("hipEnable", false));
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class HipMeasurementView extends FloatMeasurementView {
+    public static String KEY = "hip";
 
     public HipMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_hip), ContextCompat.getDrawable(context, R.drawable.ic_hip));
@@ -33,7 +34,7 @@ public class HipMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "hip";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/HipMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class HipMeasurementView extends FloatMeasurementView {
     public static final String KEY = "hip";
-    private static final String[] DEPENDENCY = {};
 
     public HipMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_hip), ContextCompat.getDrawable(context, R.drawable.ic_hip));
@@ -35,11 +34,6 @@ public class HipMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -17,9 +17,11 @@ package com.health.openscale.gui.views;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.preference.ListPreference;
 import android.support.v4.content.ContextCompat;
 
 import com.health.openscale.R;
+import com.health.openscale.core.bodymetric.EstimatedLBWMetric;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
@@ -69,6 +71,22 @@ public class LBWMeasurementView extends FloatMeasurementView {
 
     @Override
     protected boolean isEstimationSupported() { return true; }
+
+    @Override
+    protected void prepareEstimationFormulaPreference(ListPreference preference) {
+        String[] entries = new String[EstimatedLBWMetric.FORMULA.values().length];
+        String[] values = new String[entries.length];
+
+        int idx = 0;
+        for (EstimatedLBWMetric.FORMULA formula : EstimatedLBWMetric.FORMULA.values()) {
+            entries[idx] = EstimatedLBWMetric.getEstimatedMetric(formula).getName();
+            values[idx] = formula.name();
+            ++idx;
+        }
+
+        preference.setEntries(entries);
+        preference.setEntryValues(values);
+    }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -28,8 +27,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 public class LBWMeasurementView extends FloatMeasurementView {
     public static final String KEY = "lbw";
     private static final String[] DEPENDENCY = {};
-
-    private boolean estimateLBWEnable;
 
     public LBWMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_lbw), ContextCompat.getDrawable(context, R.drawable.ic_lbw));
@@ -43,12 +40,6 @@ public class LBWMeasurementView extends FloatMeasurementView {
     @Override
     public String[] getDependencyKeys() {
         return DEPENDENCY;
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        super.updatePreferences(preferences);
-        estimateLBWEnable = preferences.getBoolean("estimateLBWEnable", false);
     }
 
     @Override
@@ -77,9 +68,7 @@ public class LBWMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    protected boolean isEstimationEnabled() {
-        return estimateLBWEnable;
-    }
+    protected boolean isEstimationSupported() { return true; }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -41,7 +41,7 @@ public class LBWMeasurementView extends FloatMeasurementView {
 
     @Override
     public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("lbwEnable", false));
+        super.updatePreferences(preferences);
         estimateLBWEnable = preferences.getBoolean("estimateLBWEnable", false);
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -28,7 +28,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class LBWMeasurementView extends FloatMeasurementView {
     public static final String KEY = "lbw";
-    private static final String[] DEPENDENCY = {};
 
     public LBWMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_lbw), ContextCompat.getDrawable(context, R.drawable.ic_lbw));
@@ -37,11 +36,6 @@ public class LBWMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class LBWMeasurementView extends FloatMeasurementView {
-    public static String KEY = "lbw";
+    public static final String KEY = "lbw";
+    private static final String[] DEPENDENCY = {};
 
     private boolean estimateLBWEnable;
 
@@ -37,6 +38,11 @@ public class LBWMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/LBWMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class LBWMeasurementView extends FloatMeasurementView {
+    public static String KEY = "lbw";
 
     private boolean estimateLBWEnable;
 
@@ -35,7 +36,7 @@ public class LBWMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "lbw";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -24,7 +24,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
-import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -78,7 +77,6 @@ public abstract class MeasurementView extends TableLayout {
     private MeasurementViewUpdateListener updateListener = null;
     private MeasurementViewMode measurementMode = VIEW;
 
-    private boolean isDisabledByDependency = false;
     private boolean updateViews = true;
 
     public MeasurementView(Context context, String text, Drawable icon) {
@@ -150,7 +148,7 @@ public abstract class MeasurementView extends TableLayout {
         }
 
         for (MeasurementView measurement : sorted) {
-            measurement.updatePreferences(prefs);
+            measurement.setVisible(measurement.getSettings().isEnabled());
         }
 
         return sorted;
@@ -247,7 +245,6 @@ public abstract class MeasurementView extends TableLayout {
     }
 
     public abstract String getKey();
-    public abstract String[] getDependencyKeys();
 
     public MeasurementViewSettings getSettings() {
         if (settings ==  null) {
@@ -263,21 +260,6 @@ public abstract class MeasurementView extends TableLayout {
 
     public abstract void restoreState(Bundle state);
     public abstract void saveState(Bundle state);
-
-    @CallSuper
-    public void updatePreferences(SharedPreferences prefs) {
-        isDisabledByDependency = false;
-        for (String dep : getDependencyKeys()) {
-            MeasurementViewSettings depSettings = new MeasurementViewSettings(prefs, dep);
-            if (!depSettings.isEnabled()) {
-                isDisabledByDependency = true;
-                break;
-            }
-        }
-
-        boolean enable = !isDisabledByDependency && getSettings().isEnabled();
-        setVisible(enable);
-    }
 
     public CharSequence getName() { return nameView.getText(); }
     public abstract String getValueAsString();
@@ -357,11 +339,7 @@ public abstract class MeasurementView extends TableLayout {
         showEvaluatorRow(false);
     }
 
-    public boolean getIsDisabledByDependency() {
-        return isDisabledByDependency;
-    }
-
-    protected void setVisible(boolean isVisible) {
+    public void setVisible(boolean isVisible) {
         if (isVisible) {
             measurementRow.setVisibility(View.VISIBLE);
         } else {
@@ -515,4 +493,3 @@ public abstract class MeasurementView extends TableLayout {
         }
     }
 }
-

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -245,7 +245,7 @@ public abstract class MeasurementView extends TableLayout {
     }
 
     public abstract String getKey();
-    public String[] getDependencyKeys() { return new String[]{}; }
+    public abstract String[] getDependencyKeys();
 
     public static String getPreferenceKey(String key, String suffix) {
         return key + suffix;

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -23,6 +23,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -60,6 +61,8 @@ public abstract class MeasurementView extends TableLayout {
     public enum MeasurementViewMode {VIEW, EDIT, ADD, STATISTIC}
 
     public static String PREF_MEASUREMENT_ORDER = "measurementOrder";
+
+    private static String PREFERENCE_SUFFIX_ENABLE = "Enable";
 
     private TableRow measurementRow;
     private ImageView iconView;
@@ -242,6 +245,11 @@ public abstract class MeasurementView extends TableLayout {
     }
 
     public abstract String getKey();
+    public String[] getDependencyKeys() { return new String[]{}; }
+
+    public static String getPreferenceKey(String key, String suffix) {
+        return key + suffix;
+    }
 
     public abstract void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement);
     public abstract void saveTo(ScaleMeasurement measurement);
@@ -249,7 +257,23 @@ public abstract class MeasurementView extends TableLayout {
     public abstract void restoreState(Bundle state);
     public abstract void saveState(Bundle state);
 
-    public abstract void updatePreferences(SharedPreferences preferences);
+    @CallSuper
+    public void updatePreferences(SharedPreferences prefs) {
+        boolean enable = prefs.getBoolean(
+                getPreferenceKey(getKey(), PREFERENCE_SUFFIX_ENABLE), true);
+
+        if (enable) {
+            for (String dep : getDependencyKeys()) {
+                if (!prefs.getBoolean(
+                        getPreferenceKey(dep, PREFERENCE_SUFFIX_ENABLE), true)) {
+                    enable = false;
+                    break;
+                }
+            }
+        }
+
+        setVisible(enable);
+    }
 
     public CharSequence getName() { return nameView.getText(); }
     public abstract String getValueAsString();

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -31,7 +31,6 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -259,6 +259,7 @@ public abstract class MeasurementView extends TableLayout {
 
     public abstract void loadFrom(ScaleMeasurement measurement, ScaleMeasurement previousMeasurement);
     public abstract void saveTo(ScaleMeasurement measurement);
+    public abstract void clearIn(ScaleMeasurement measurement);
 
     public abstract void restoreState(Bundle state);
     public abstract void saveState(Bundle state);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementView.java
@@ -23,6 +23,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
 import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.text.SpannableStringBuilder;
@@ -410,6 +411,9 @@ public abstract class MeasurementView extends TableLayout {
 
         return openScale.getSelectedScaleUser();
     }
+
+    public boolean hasExtraPreferences() { return false; }
+    public void prepareExtraPreferencesScreen(PreferenceScreen screen) { };
 
     protected abstract View getInputView();
     protected abstract boolean validateAndSetInput(View view);

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
@@ -1,0 +1,136 @@
+/* Copyright (C) 2018 Erik Johansson <erik@ejohansson.se>
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package com.health.openscale.gui.views;
+
+import android.content.SharedPreferences;
+
+import com.health.openscale.core.bodymetric.EstimatedFatMetric;
+import com.health.openscale.core.bodymetric.EstimatedLBWMetric;
+import com.health.openscale.core.bodymetric.EstimatedWaterMetric;
+
+public class MeasurementViewSettings {
+    private SharedPreferences preferences;
+    private String key;
+
+    private static final String PREFERENCE_SUFFIX_ENABLE = "Enable";
+    private static final String PREFERENCE_SUFFIX_ON_OVERVIEW_GRAPH = "OnOverviewGraph";
+    private static final String PREFERENCE_SUFFIX_PERCENTAGE_ENABLE = "PercentageEnable";
+    private static final String PREFERENCE_SUFFIX_ESTIMATE_ENABLE = "EstimateEnable";
+    private static final String PREFERENCE_SUFFIX_ESTIMATE_FORMULA = "EstimateFormula";
+
+    public MeasurementViewSettings(SharedPreferences prefs, String key) {
+        preferences = prefs;
+        this.key = key;
+    }
+
+    private String getPreferenceKey(String suffix) {
+        return key + suffix;
+    }
+
+    public String getEnabledKey() {
+        return getPreferenceKey(PREFERENCE_SUFFIX_ENABLE);
+    }
+
+    public boolean isEnabled() {
+        boolean defaultValue;
+        switch (key) {
+            case LBWMeasurementView.KEY:
+            case BoneMeasurementView.KEY:
+            case WaistMeasurementView.KEY:
+            case HipMeasurementView.KEY:
+                defaultValue = false;
+                break;
+            default:
+                defaultValue = true;
+                break;
+        }
+        return preferences.getBoolean(getEnabledKey(), defaultValue);
+    }
+
+    public String getShowOnOverviewGraphKey() {
+        return getPreferenceKey(PREFERENCE_SUFFIX_ON_OVERVIEW_GRAPH);
+    }
+
+    public boolean shouldShowOnOverviewGraph() {
+        boolean defaultValue;
+        switch (key) {
+            case BMRMeasurementView.KEY:
+                defaultValue = false;
+                break;
+            default:
+                defaultValue = true;
+                break;
+        }
+        return preferences.getBoolean(getShowOnOverviewGraphKey(), defaultValue);
+    }
+
+    public String getPercentageEnabledKey() {
+        return getPreferenceKey(PREFERENCE_SUFFIX_PERCENTAGE_ENABLE);
+    }
+
+    public boolean isPercentageEnabled() {
+        return preferences.getBoolean(getPercentageEnabledKey(), true);
+    }
+
+    public String getEstimationEnabledKey() {
+        switch (key) {
+            case FatMeasurementView.KEY:
+                return "estimateFatEnable";
+            case LBWMeasurementView.KEY:
+                return "estimateLBWEnable";
+            case WaterMeasurementView.KEY:
+                return "estimateWaterEnable";
+        }
+        return getPreferenceKey(PREFERENCE_SUFFIX_ESTIMATE_ENABLE);
+    }
+
+    public boolean isEstimationEnabled() {
+        return preferences.getBoolean(getEstimationEnabledKey(), false);
+    }
+
+    public String getEstimationFormulaKey() {
+        switch (key) {
+            case FatMeasurementView.KEY:
+                return "estimateFatFormula";
+            case LBWMeasurementView.KEY:
+                return "estimateLBWFormula";
+            case WaterMeasurementView.KEY:
+                return "estimateWaterFormula";
+        }
+        return getPreferenceKey(PREFERENCE_SUFFIX_ESTIMATE_FORMULA);
+    }
+
+    public String getEstimationFormula() {
+        String defaultValue;
+        switch (key) {
+            case FatMeasurementView.KEY:
+                defaultValue = EstimatedFatMetric.FORMULA.BF_GALLAGHER.name();
+                break;
+            case LBWMeasurementView.KEY:
+                defaultValue = EstimatedLBWMetric.FORMULA.LBW_HUME.name();
+                break;
+            case WaterMeasurementView.KEY:
+                defaultValue = EstimatedWaterMetric.FORMULA.TBW_LEESONGKIM.name();
+                break;
+            default:
+                defaultValue = "";
+                break;
+        }
+
+        return preferences.getString(getEstimationFormulaKey(), defaultValue);
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
@@ -45,9 +45,12 @@ public class MeasurementViewSettings {
         return getPreferenceKey(PREFERENCE_SUFFIX_ENABLE);
     }
 
-    public boolean isEnabled() {
+    public boolean isEnabledIgnoringDependencies() {
         boolean defaultValue;
         switch (key) {
+            case WeightMeasurementView.KEY:
+                // Weight can't be disabled
+                return true;
             case LBWMeasurementView.KEY:
             case BoneMeasurementView.KEY:
             case WaistMeasurementView.KEY:
@@ -59,6 +62,41 @@ public class MeasurementViewSettings {
                 break;
         }
         return preferences.getBoolean(getEnabledKey(), defaultValue);
+    }
+
+    private boolean isDependencyEnabled(String dependencyKey) {
+        // Weight can't be disabled
+        if (dependencyKey.equals(WeightMeasurementView.KEY)) {
+            return true;
+        }
+
+        return (new MeasurementViewSettings(preferences, dependencyKey)).isEnabled();
+    }
+
+    public boolean areDependenciesEnabled() {
+        switch (key) {
+            case BMIMeasurementView.KEY:
+            case BMRMeasurementView.KEY:
+                return isDependencyEnabled(WeightMeasurementView.KEY);
+
+            // Requires weight as they are stored as percentage of it
+            case FatMeasurementView.KEY:
+            case MuscleMeasurementView.KEY:
+            case WaterMeasurementView.KEY:
+                return isDependencyEnabled(WeightMeasurementView.KEY);
+
+            case WHRMeasurementView.KEY:
+                return isDependencyEnabled(HipMeasurementView.KEY)
+                        && isDependencyEnabled(WaistMeasurementView.KEY);
+
+            case WHtRMeasurementView.KEY:
+                return isDependencyEnabled(WaistMeasurementView.KEY);
+        }
+        return true;
+    }
+
+    public boolean isEnabled() {
+        return isEnabledIgnoringDependencies() && areDependenciesEnabled();
     }
 
     public String getInOverviewGraphKey() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
@@ -28,6 +28,7 @@ public class MeasurementViewSettings {
 
     private static final String PREFERENCE_SUFFIX_ENABLE = "Enable";
     private static final String PREFERENCE_SUFFIX_IN_OVERVIEW_GRAPH = "InOverviewGraph";
+    private static final String PREFERENCE_SUFFIX_IN_GRAPH = "InGraph";
     private static final String PREFERENCE_SUFFIX_PERCENTAGE_ENABLE = "PercentageEnable";
     private static final String PREFERENCE_SUFFIX_ESTIMATE_ENABLE = "EstimateEnable";
     private static final String PREFERENCE_SUFFIX_ESTIMATE_FORMULA = "EstimateFormula";
@@ -103,7 +104,7 @@ public class MeasurementViewSettings {
         return getPreferenceKey(PREFERENCE_SUFFIX_IN_OVERVIEW_GRAPH);
     }
 
-    public boolean isOnOverviewGraph() {
+    public boolean isInOverviewGraph() {
         boolean defaultValue;
         switch (key) {
             case BMRMeasurementView.KEY:
@@ -114,6 +115,14 @@ public class MeasurementViewSettings {
                 break;
         }
         return preferences.getBoolean(getInOverviewGraphKey(), defaultValue);
+    }
+
+    public String getInGraphKey() {
+        return getPreferenceKey(PREFERENCE_SUFFIX_IN_GRAPH);
+    }
+
+    public boolean isInGraph() {
+        return preferences.getBoolean(getInGraphKey(), true);
     }
 
     public String getPercentageEnabledKey() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MeasurementViewSettings.java
@@ -27,7 +27,7 @@ public class MeasurementViewSettings {
     private String key;
 
     private static final String PREFERENCE_SUFFIX_ENABLE = "Enable";
-    private static final String PREFERENCE_SUFFIX_ON_OVERVIEW_GRAPH = "OnOverviewGraph";
+    private static final String PREFERENCE_SUFFIX_IN_OVERVIEW_GRAPH = "InOverviewGraph";
     private static final String PREFERENCE_SUFFIX_PERCENTAGE_ENABLE = "PercentageEnable";
     private static final String PREFERENCE_SUFFIX_ESTIMATE_ENABLE = "EstimateEnable";
     private static final String PREFERENCE_SUFFIX_ESTIMATE_FORMULA = "EstimateFormula";
@@ -61,11 +61,11 @@ public class MeasurementViewSettings {
         return preferences.getBoolean(getEnabledKey(), defaultValue);
     }
 
-    public String getShowOnOverviewGraphKey() {
-        return getPreferenceKey(PREFERENCE_SUFFIX_ON_OVERVIEW_GRAPH);
+    public String getInOverviewGraphKey() {
+        return getPreferenceKey(PREFERENCE_SUFFIX_IN_OVERVIEW_GRAPH);
     }
 
-    public boolean shouldShowOnOverviewGraph() {
+    public boolean isOnOverviewGraph() {
         boolean defaultValue;
         switch (key) {
             case BMRMeasurementView.KEY:
@@ -75,7 +75,7 @@ public class MeasurementViewSettings {
                 defaultValue = true;
                 break;
         }
-        return preferences.getBoolean(getShowOnOverviewGraphKey(), defaultValue);
+        return preferences.getBoolean(getInOverviewGraphKey(), defaultValue);
     }
 
     public String getPercentageEnabledKey() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -41,7 +41,7 @@ public class MuscleMeasurementView extends FloatMeasurementView {
 
     @Override
     public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("muscleEnable", true));
+        super.updatePreferences(preferences);
         percentageEnable = preferences.getBoolean("musclePercentageEnable", true);
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class MuscleMeasurementView extends FloatMeasurementView {
     public static final String KEY = "muscle";
-    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public MuscleMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_muscle), ContextCompat.getDrawable(context, R.drawable.ic_muscle));
@@ -35,11 +34,6 @@ public class MuscleMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -28,8 +27,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 public class MuscleMeasurementView extends FloatMeasurementView {
     public static final String KEY = "muscle";
     private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
-
-    private boolean percentageEnable;
 
     public MuscleMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_muscle), ContextCompat.getDrawable(context, R.drawable.ic_muscle));
@@ -46,14 +43,8 @@ public class MuscleMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        super.updatePreferences(preferences);
-        percentageEnable = preferences.getBoolean("musclePercentageEnable", true);
-    }
-
-    @Override
-    protected boolean shouldConvertPercentageToAbsoluteWeight() {
-        return !percentageEnable;
+    protected boolean canConvertPercentageToAbsoluteWeight() {
+        return true;
     }
 
     @Override
@@ -68,11 +59,11 @@ public class MuscleMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getUnit() {
-        if (percentageEnable) {
-            return "%";
+        if (shouldConvertPercentageToAbsoluteWeight()) {
+            return getScaleUser().getScaleUnit().toString();
         }
 
-        return getScaleUser().getScaleUnit().toString();
+        return "%";
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class MuscleMeasurementView extends FloatMeasurementView {
+    public static String KEY = "muscle";
 
     private boolean percentageEnable;
 
@@ -35,7 +36,7 @@ public class MuscleMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "muscle";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/MuscleMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class MuscleMeasurementView extends FloatMeasurementView {
-    public static String KEY = "muscle";
+    public static final String KEY = "muscle";
+    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     private boolean percentageEnable;
 
@@ -37,6 +38,11 @@ public class MuscleMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -81,6 +81,11 @@ public class TimeMeasurementView extends MeasurementView {
     }
 
     @Override
+    public void clearIn(ScaleMeasurement measurement) {
+        // Ignore
+    }
+
+    @Override
     public void restoreState(Bundle state) {
         setValue(new Date(state.getLong(getKey())), true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -29,7 +29,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class TimeMeasurementView extends MeasurementView {
-    public static String KEY = "time";
+    public static final String KEY = "time";
+    private static final String[] DEPENDENCY = {};
 
     private DateFormat timeFormat;
     private Date time;
@@ -42,6 +43,11 @@ public class TimeMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     private void setValue(Date newTime, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -30,7 +30,6 @@ import java.util.Date;
 
 public class TimeMeasurementView extends MeasurementView {
     public static final String KEY = "time";
-    private static final String[] DEPENDENCY = {};
 
     private DateFormat timeFormat;
     private Date time;
@@ -43,11 +42,6 @@ public class TimeMeasurementView extends MeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     private void setValue(Date newTime, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -30,6 +30,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class TimeMeasurementView extends MeasurementView {
+    public static String KEY = "time";
+
     private DateFormat timeFormat;
     private Date time;
 
@@ -40,7 +42,7 @@ public class TimeMeasurementView extends MeasurementView {
 
     @Override
     public String getKey() {
-        return "time";
+        return KEY;
     }
 
     private void setValue(Date newTime, boolean callListener) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/TimeMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
@@ -83,11 +82,6 @@ public class TimeMeasurementView extends MeasurementView {
     @Override
     public void saveState(Bundle state) {
         state.putLong(getKey(), time.getTime());
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        // Empty
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHRMeasurementView extends FloatMeasurementView {
+    public static String KEY = "whr";
 
     public WHRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whr), ContextCompat.getDrawable(context, R.drawable.ic_whr));
@@ -33,7 +34,7 @@ public class WHRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "whr";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHRMeasurementView extends FloatMeasurementView {
     public static final String KEY = "whr";
-    private static final String[] DEPENDENCY = {HipMeasurementView.KEY, WaistMeasurementView.KEY};
 
     public WHRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whr), ContextCompat.getDrawable(context, R.drawable.ic_whr));
@@ -35,11 +34,6 @@ public class WHRMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -38,9 +37,8 @@ public class WHRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("hipEnable", false)
-                && preferences.getBoolean("waistEnable", false));
+    public String[] getDependencyKeys() {
+        return new String[] {HipMeasurementView.KEY, WaistMeasurementView.KEY};
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHRMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHRMeasurementView extends FloatMeasurementView {
-    public static String KEY = "whr";
+    public static final String KEY = "whr";
+    private static final String[] DEPENDENCY = {HipMeasurementView.KEY, WaistMeasurementView.KEY};
 
     public WHRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whr), ContextCompat.getDrawable(context, R.drawable.ic_whr));
@@ -38,7 +39,7 @@ public class WHRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String[] getDependencyKeys() {
-        return new String[] {HipMeasurementView.KEY, WaistMeasurementView.KEY};
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHtRMeasurementView extends FloatMeasurementView {
-    public static String KEY = "whtr";
+    public static final String KEY = "whtr";
+    private static final String[] DEPENDENCY = {WaistMeasurementView.KEY};
 
     public WHtRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whtr), ContextCompat.getDrawable(context, R.drawable.ic_whtr));
@@ -38,7 +39,7 @@ public class WHtRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String[] getDependencyKeys() {
-        return new String[] {WaistMeasurementView.KEY};
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHtRMeasurementView extends FloatMeasurementView {
     public static final String KEY = "whtr";
-    private static final String[] DEPENDENCY = {WaistMeasurementView.KEY};
 
     public WHtRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whtr), ContextCompat.getDrawable(context, R.drawable.ic_whtr));
@@ -35,11 +34,6 @@ public class WHtRMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WHtRMeasurementView extends FloatMeasurementView {
+    public static String KEY = "whtr";
 
     public WHtRMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_whtr), ContextCompat.getDrawable(context, R.drawable.ic_whtr));
@@ -33,7 +34,7 @@ public class WHtRMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "whtr";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WHtRMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -38,8 +37,8 @@ public class WHtRMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("waistEnable", false));
+    public String[] getDependencyKeys() {
+        return new String[] {WaistMeasurementView.KEY};
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -35,11 +34,6 @@ public class WaistMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("waistEnable", false));
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -25,7 +25,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaistMeasurementView extends FloatMeasurementView {
-    public static String KEY = "waist";
+    public static final String KEY = "waist";
+    private static final String[] DEPENDENCY = {};
 
     public WaistMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_waist), ContextCompat.getDrawable(context, R.drawable.ic_waist));
@@ -34,6 +35,11 @@ public class WaistMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaistMeasurementView extends FloatMeasurementView {
+    public static String KEY = "waist";
 
     public WaistMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_waist), ContextCompat.getDrawable(context, R.drawable.ic_waist));
@@ -33,7 +34,7 @@ public class WaistMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "waist";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaistMeasurementView.java
@@ -26,7 +26,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaistMeasurementView extends FloatMeasurementView {
     public static final String KEY = "waist";
-    private static final String[] DEPENDENCY = {};
 
     public WaistMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_waist), ContextCompat.getDrawable(context, R.drawable.ic_waist));
@@ -35,11 +34,6 @@ public class WaistMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaterMeasurementView extends FloatMeasurementView {
-    public static String KEY = "water";
+    public static final String KEY = "water";
+    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     private boolean estimateWaterEnable;
     private boolean percentageEnable;
@@ -38,6 +39,11 @@ public class WaterMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -28,9 +27,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 public class WaterMeasurementView extends FloatMeasurementView {
     public static final String KEY = "water";
     private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
-
-    private boolean estimateWaterEnable;
-    private boolean percentageEnable;
 
     public WaterMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_water), ContextCompat.getDrawable(context, R.drawable.ic_water));
@@ -47,15 +43,8 @@ public class WaterMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        super.updatePreferences(preferences);
-        estimateWaterEnable = preferences.getBoolean("estimateWaterEnable", false);
-        percentageEnable = preferences.getBoolean("waterPercentageEnable", true);
-    }
-
-    @Override
-    protected boolean shouldConvertPercentageToAbsoluteWeight() {
-        return !percentageEnable;
+    protected boolean canConvertPercentageToAbsoluteWeight() {
+        return true;
     }
 
     @Override
@@ -70,11 +59,11 @@ public class WaterMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getUnit() {
-        if (percentageEnable) {
-            return "%";
+        if (shouldConvertPercentageToAbsoluteWeight()) {
+            return getScaleUser().getScaleUnit().toString();
         }
 
-        return getScaleUser().getScaleUnit().toString();
+        return "%";
     }
 
     @Override
@@ -88,9 +77,7 @@ public class WaterMeasurementView extends FloatMeasurementView {
     }
 
     @Override
-    protected boolean isEstimationEnabled() {
-        return estimateWaterEnable;
-    }
+    protected boolean isEstimationSupported() { return true; }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -28,7 +28,6 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaterMeasurementView extends FloatMeasurementView {
     public static final String KEY = "water";
-    private static final String[] DEPENDENCY = {WeightMeasurementView.KEY};
 
     public WaterMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_water), ContextCompat.getDrawable(context, R.drawable.ic_water));
@@ -37,11 +36,6 @@ public class WaterMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -17,9 +17,11 @@ package com.health.openscale.gui.views;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.preference.ListPreference;
 import android.support.v4.content.ContextCompat;
 
 import com.health.openscale.R;
+import com.health.openscale.core.bodymetric.EstimatedWaterMetric;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
@@ -78,6 +80,22 @@ public class WaterMeasurementView extends FloatMeasurementView {
 
     @Override
     protected boolean isEstimationSupported() { return true; }
+
+    @Override
+    protected void prepareEstimationFormulaPreference(ListPreference preference) {
+        String[] entries = new String[EstimatedWaterMetric.FORMULA.values().length];
+        String[] values = new String[entries.length];
+
+        int idx = 0;
+        for (EstimatedWaterMetric.FORMULA formula : EstimatedWaterMetric.FORMULA.values()) {
+            entries[idx] = EstimatedWaterMetric.getEstimatedMetric(formula).getName();
+            values[idx] = formula.name();
+            ++idx;
+        }
+
+        preference.setEntries(entries);
+        preference.setEntryValues(values);
+    }
 
     @Override
     protected EvaluationResult evaluateSheet(EvaluationSheet evalSheet, float value) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -26,6 +26,7 @@ import com.health.openscale.core.evaluation.EvaluationResult;
 import com.health.openscale.core.evaluation.EvaluationSheet;
 
 public class WaterMeasurementView extends FloatMeasurementView {
+    public static String KEY = "water";
 
     private boolean estimateWaterEnable;
     private boolean percentageEnable;
@@ -36,7 +37,7 @@ public class WaterMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "water";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WaterMeasurementView.java
@@ -42,7 +42,7 @@ public class WaterMeasurementView extends FloatMeasurementView {
 
     @Override
     public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("waterEnable", true));
+        super.updatePreferences(preferences);
         estimateWaterEnable = preferences.getBoolean("estimateWaterEnable", false);
         percentageEnable = preferences.getBoolean("waterPercentageEnable", true);
     }

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -27,7 +27,6 @@ import com.health.openscale.core.utils.Converters;
 
 public class WeightMeasurementView extends FloatMeasurementView {
     public static final String KEY = "weight";
-    private static final String[] DEPENDENCY = {};
 
     public WeightMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_weight), ContextCompat.getDrawable(context, R.drawable.ic_weight));
@@ -36,11 +35,6 @@ public class WeightMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public String[] getDependencyKeys() {
-        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -26,7 +26,8 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 import com.health.openscale.core.utils.Converters;
 
 public class WeightMeasurementView extends FloatMeasurementView {
-    public static String KEY = "weight";
+    public static final String KEY = "weight";
+    private static final String[] DEPENDENCY = {};
 
     public WeightMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_weight), ContextCompat.getDrawable(context, R.drawable.ic_weight));
@@ -35,6 +36,11 @@ public class WeightMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
+    }
+
+    @Override
+    public String[] getDependencyKeys() {
+        return DEPENDENCY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -27,6 +27,7 @@ import com.health.openscale.core.evaluation.EvaluationSheet;
 import com.health.openscale.core.utils.Converters;
 
 public class WeightMeasurementView extends FloatMeasurementView {
+    public static String KEY = "weight";
 
     public WeightMeasurementView(Context context) {
         super(context, context.getResources().getString(R.string.label_weight), ContextCompat.getDrawable(context, R.drawable.ic_weight));
@@ -34,7 +35,7 @@ public class WeightMeasurementView extends FloatMeasurementView {
 
     @Override
     public String getKey() {
-        return "weight";
+        return KEY;
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/views/WeightMeasurementView.java
@@ -16,7 +16,6 @@
 package com.health.openscale.gui.views;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.support.v4.content.ContextCompat;
 
@@ -36,11 +35,6 @@ public class WeightMeasurementView extends FloatMeasurementView {
     @Override
     public String getKey() {
         return KEY;
-    }
-
-    @Override
-    public void updatePreferences(SharedPreferences preferences) {
-        setVisible(preferences.getBoolean("weightEnable", true));
     }
 
     @Override

--- a/android_app/app/src/main/res/layout/measurement_preferences_widget_layout.xml
+++ b/android_app/app/src/main/res/layout/measurement_preferences_widget_layout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <View
+        android:id="@+id/measurement_switch_separator"
+        android:layout_width="1dp"
+        android:layout_height="match_parent"
+        android:background="?android:attr/listDivider" />
+
+    <Switch
+        android:id="@+id/measurement_switch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/android_app/app/src/main/res/values-ca/strings.xml
+++ b/android_app/app/src/main/res/values-ca/strings.xml
@@ -113,21 +113,12 @@
 
     <string name="label_delete_confirmation">Confirmació d\'eliminació</string>
 
-    <string name="label_estimate_water">Estimació d\'aigua corporal</string>
-    <string name="label_estimate_lbw">Estimació de massa corporal magra</string>
-    <string name="label_estimate_fat">Estimació de greix corporal</string>
-
-    <string name="label_category_display">Mostreu</string>
-    <string name="label_category_body_metrics_estimation">Estimació de mètriques corporals</string>
     <string name="label_category_measurement_database">Base de dades de mesures</string>
 
     <string name="label_maintainer">Responsable</string>
     <string name="label_website">Pàgina Web</string>
     <string name="label_license">Llicència</string>
 
-    <string name="label_estimate_water_formula">Fórmula d\'aigua corporal</string>
-    <string name="label_estimate_lbw_formula">Fórmula de massa corporal magra</string>
-    <string name="label_estimate_fat_formula">Fórmula de greix corporal</string>
     <string name="label_automatic">automàtic</string>
 
     <string name="label_reminder">Recordatori</string>

--- a/android_app/app/src/main/res/values-cs/strings.xml
+++ b/android_app/app/src/main/res/values-cs/strings.xml
@@ -29,10 +29,6 @@
     <string name="label_comment">Komentář</string>
     <string name="label_smartUserAssign">Chytré přiřazení uživatele</string>
 
-    <string name="label_fat_percentage">Tělesný tuk v %</string>
-    <string name="label_water_percentage">Tělesná voda v %</string>
-    <string name="label_muscle_percentage">Svalová hmota v %</string>
-
     <plurals name="label_days">
 	<item quantity="one">%d den</item>
 	<item quantity="few">%d dny</item>
@@ -100,10 +96,6 @@
 
     <string name="label_delete_confirmation">Potvrzení smazání</string>
 
-    <string name="label_estimate_water">Odhadnout vodu v těle</string>
-    <string name="label_estimate_fat">Odhadnout tělesný tuk</string>
-
-    <string name="label_category_display">Zobrazit</string>
     <string name="label_maintainer">Správce</string>
     <string name="label_website">Webové stránky</string>
     <string name="label_license">Licence</string>

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -122,15 +122,7 @@
     <string name="error_max_scale_users">Maximale Anzahl gleichzeitiger Benutzer erreicht</string>
     <string name="info_step_on_scale">Bitte steigen Sie barfuß auf die Waage zur Referenzmessung</string>
     <string name="label_automatic">auto</string>
-    <string name="label_category_body_metrics_estimation">Körpermetriken abschätzen</string>
-    <string name="label_category_display">Anzeige</string>
     <string name="label_category_measurement_database">Messwertedatenbank</string>
-    <string name="label_estimate_fat">Körperfettschätzung</string>
-    <string name="label_estimate_fat_formula">Körperfettformel</string>
-    <string name="label_estimate_water">Körperwasserschätzung</string>
-    <string name="label_estimate_water_formula">Körperwasserformel</string>
-    <string name="label_estimate_lbw">Fettfreie Körpermassenschätzung</string>
-    <string name="label_estimate_lbw_formula">Fettfreie Körpermassenformel</string>
     <string name="label_lbw">Fettfreie Körpermasse</string>
     <string name="label_license">Lizenz</string>
     <string name="label_maintainer">Hauptentwickler</string>
@@ -140,9 +132,6 @@
     <string name="close_drawer">schließen</string>
     <string name="info_bluetooth_no_device_set">Kein Bluetooth Gerät ausgewählt</string>
     <string name="info_new_data_duplicated">Messung mit gleichen Datum und Uhrzeit exisitiert bereits</string>
-    <string name="label_fat_percentage">Körperfett in %</string>
-    <string name="label_water_percentage">Wasseranteil in %</string>
-    <string name="label_muscle_percentage">Muskelanteil in %</string>
     <string name="label_feedback_message_enjoying">Gefällt Dir openScale?</string>
     <string name="label_feedback_message_rate_app">Wie wäre es dann mit einer Bewertung bei GooglePlay oder bei GitHub?</string>
     <string name="label_feedback_message_yes">Ja!</string>
@@ -174,7 +163,6 @@
     <string name="permission_bluetooth_info">openScale benötigt die Erlaubnis, auf den ungefähren Standort zuzugreifen, um nach Bluetooth-Geräten suchen zu können.</string>
     <string name="permission_bluetooth_info_title">Information</string>
     <string name="label_next">Weiter</string>
-    <string name="label_measurement_order">Messwert Reihenfolge</string>
     <string name="label_press_hold_reorder">Halten Sie die Taste gedrückt, um die Reihenfolge zu ändern</string>
     <string name="label_set_default_order">Default Reihenfolge wiederherstellen</string>
     <string name="label_share_subject">openScale CSV Datenexport (%s)</string>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -113,21 +113,12 @@
 
     <string name="label_delete_confirmation">Confirmación de borrado</string>
 
-    <string name="label_estimate_water">Estimación de agua corporal</string>
-    <string name="label_estimate_lbw">Estimación de masa corporal magra</string>
-    <string name="label_estimate_fat">Estimación de grasa coporal</string>
-
-    <string name="label_category_display">Mostrar</string>
-    <string name="label_category_body_metrics_estimation">Estimación de métricas corporales</string>
     <string name="label_category_measurement_database">Base de datos de mediciones</string>
 
     <string name="label_maintainer">Responsable</string>
     <string name="label_website">Página Web</string>
     <string name="label_license">Licencia</string>
 
-    <string name="label_estimate_water_formula">Fórmula de agua corporal</string>
-    <string name="label_estimate_lbw_formula">Fórmula de masa corporal magra</string>
-    <string name="label_estimate_fat_formula">Fórmula de grasa corporal</string>
     <string name="label_automatic">automático</string>
 
     <string name="label_reminder">Recordatorio</string>
@@ -168,10 +159,6 @@
     <string name="close_drawer">cerrar</string>
 
     <string name="label_share">Compartir</string>
-
-    <string name="label_fat_percentage">Grasa corporal en %</string>
-    <string name="label_water_percentage">Porcentaje de agua en %</string>
-    <string name="label_muscle_percentage">Porcentaje muscular en %</string>
 
     <string name="error_user_name_too_short">Error: el nombre de usuario tiene que tener al menos 3 carácteres</string>
     <string name="info_bluetooth_no_device_set">"No hay dispositivo Bluetooth seleccionado "</string>

--- a/android_app/app/src/main/res/values-nl/strings.xml
+++ b/android_app/app/src/main/res/values-nl/strings.xml
@@ -115,21 +115,12 @@
 
     <string name="label_delete_confirmation">Bevestiging verwijderen</string>
 
-    <string name="label_estimate_water">Geschat vochtmassa</string>
-    <string name="label_estimate_lbw">Geschat vetvrije massa</string>
-    <string name="label_estimate_fat">Geschat vetmassa</string>
-
-    <string name="label_category_display">Scherm</string>
-    <string name="label_category_body_metrics_estimation">Schatting Lichaamssamenstelling</string>
     <string name="label_category_measurement_database">Metingen database</string>
 
     <string name="label_maintainer">Beheerder</string>
     <string name="label_website">Website</string>
     <string name="label_license">Licentie</string>
 
-    <string name="label_estimate_water_formula">Formule vochtmassa</string>
-    <string name="label_estimate_lbw_formula">Formule vetvrije massa</string>
-    <string name="label_estimate_fat_formula">Formule vetmassa</string>
     <string name="label_automatic">auto</string>
 
     <string name="label_reminder">Herinnering</string>
@@ -168,10 +159,6 @@
 
     <string name="label_share">Delen</string>
     <string name="label_share_subject">openScale CSV data exporteren (%s)</string>
-
-    <string name="label_fat_percentage">Lichaamsvet in %</string>
-    <string name="label_water_percentage">Lichaamsvocht in %</string>
-    <string name="label_muscle_percentage">Spiermassa in %</string>
 
     <string name="error_user_name_too_short">Fout: Gebruikersnaam dient minimaal 3 karakters lang te zijn</string>
     <string name="info_bluetooth_no_device_set">Geen Bluetooth apparaat geselecteerd</string>
@@ -214,7 +201,6 @@
     <string name="permission_bluetooth_info">openScale heeft toestemming nodig tot uw locatie om te kunnen zoeken naar Bluetooth apparaten</string>
     <string name="permission_bluetooth_info_title">Informatie</string>
     <string name="label_next">Volgende</string>
-    <string name="label_measurement_order">Meting volgorde</string>
     <string name="label_press_hold_reorder">Indrukken en vasthouden om opnieuw in te delen</string>
     <string name="label_set_default_order">Stel standaard volgorde in</string>
     <string name="label_export_overwrite">Vorige export \"%s\" overschrijven?</string>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -38,11 +38,7 @@
     <string name="label_whr">Stosunek obwodu talii do obwodu bioder</string>
     <string name="label_bone">Masa kostna</string>
     <string name="label_smartUserAssign">Inteligente przypisywanie użytkowników</string>
-    
-    <string name="label_fat_percentage">Tkanka tłusczowa w %</string>
-    <string name="label_water_percentage">Woda w organizmie w %</string>
-    <string name="label_muscle_percentage">Masa mięśniowa w %</string>
-    
+
     <plurals name="label_days">
         <item quantity="other">%d dni</item>
     </plurals>
@@ -126,21 +122,12 @@
 
     <string name="label_delete_confirmation">Potwierdzenie usnięcia</string>
 
-    <string name="label_estimate_water">Wznaczaj procent wody w organizmie</string>
-    <string name="label_estimate_lbw">Wyznaczaj beztłuszczową masę ciała</string>
-    <string name="label_estimate_fat">Wyznaczaj procent tkanki tłuszczowej</string>
-   
-    <string name="label_category_display">Wyświetl</string>
-    <string name="label_category_body_metrics_estimation">Wyznaczanie wskaźników dla ciała</string>
     <string name="label_category_measurement_database">Baza pomiarów</string>
 
     <string name="label_maintainer">Opiekun</string>
     <string name="label_website">Strona internetowa</string>
     <string name="label_license">Licencja</string>
-    
-    <string name="label_estimate_water_formula">Formuła wyznaczania wody w organizmie</string>
-    <string name="label_estimate_lbw_formula">Formuła wyznaczania beztłuszczowej masy ciała</string>
-    <string name="label_estimate_fat_formula">Formuła wyznaczania tkanki tłuszczowej</string>
+
     <string name="label_automatic">auto</string>
     
     <string name="label_theme">Motyw</string>
@@ -205,7 +192,6 @@
     <string name="permission_bluetooth_info">openScale requires permission to access the coarse location to search for Bluetooth devices</string>
     <string name="permission_bluetooth_info_title">Informacje</string>
     <string name="label_next">Następny</string>
-    <string name="label_measurement_order">Kolejność pomiarów</string>
     <string name="label_press_hold_reorder">Naciśnij i przytrzymaj by zmienić kolejność</string>
     <string name="label_set_default_order">Ustaw domyślną kolejność</string>
     <string name="label_export_overwrite">Nadpisać poprzedni eksport \"%s\"?</string>

--- a/android_app/app/src/main/res/values-sk/strings.xml
+++ b/android_app/app/src/main/res/values-sk/strings.xml
@@ -129,20 +129,13 @@
     <string name="label_share">Zdieľať</string>
     <string name="label_share_subject">openScale CSV export údajov (%s)</string>
 
-    <string name="label_fat_percentage">Telesný tuk v %</string>
-    <string name="label_water_percentage">Voda v tele v %</string>
-    <string name="label_muscle_percentage">Svalstvo v %</string>
-
     <string name="error_user_name_too_short">Chyba: používateľské meno musí obsahovať minimálne 3 znaky</string>
     <string name="info_bluetooth_no_device_set">Nevybrali ste žiadne bluetooth zariadenie</string>
     <string name="info_new_data_duplicated">meranie s rovnakým dátumom a časom už existuje</string>
 
     <string name="label_mergeWithLastMeasurement">Zlúčiť s posledným meraním</string>
     <string name="label_bluetooth_searching_finished">Hľadanie bluetooth váh sa dokončilo</string>
-    <string name="label_estimate_water">Odhadnúť vodu v tele</string>
-    <string name="label_estimate_fat">Odhadnúť telesný tuk</string>
 
-    <string name="label_category_display">Zobraziť</string>
     <string name="label_category_measurement_database">Databáza meraní</string>
 
     <string name="label_maintainer">Správca</string>
@@ -185,7 +178,6 @@
     <string name="permission_bluetooth_info">openScale vyžaduje povolenie prístupu k približnej polohe na vyhľadávanie bluetooth zariadení</string>
     <string name="permission_bluetooth_info_title">Informácie</string>
     <string name="label_next">Ďalej</string>
-    <string name="label_measurement_order">Radenie meraní</string>
     <string name="label_press_hold_reorder">Stlačte a podržte pre zmenu radenia</string>
     <string name="label_set_default_order">Nastaviť predvolené radenie</string>
     <string name="label_export_overwrite">Prepísať predchádzajúci export \"%s\"?</string>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -109,16 +109,8 @@
     <string name="label_enable_labels">Etikett på datapunkt</string>
     <string name="label_enable_points">Punkt på datapunkt</string>
     <string name="label_delete_confirmation">Borttagningsbekräftelse</string>
-    <string name="label_estimate_water">Estimera kroppsvatten</string>
-    <string name="label_estimate_lbw">Estimera fettfri kroppsvikt</string>
-    <string name="label_estimate_fat">Estimera kroppsfett</string>
-    <string name="label_category_display">Visa</string>
-    <string name="label_category_body_metrics_estimation">Uppskatta mätvärden</string>
     <string name="label_category_measurement_database">Mätningsdatabas</string>
     <string name="label_maintainer">Utvecklare</string>
-    <string name="label_estimate_water_formula">Formel för kroppsvatten</string>
-    <string name="label_estimate_lbw_formula">Formel för fettfri kroppsvikt</string>
-    <string name="label_estimate_fat_formula">Formel för kroppsfett</string>
     <string name="label_automatic">auto</string>
     <string name="label_reminder">Påminnelse</string>
     <string name="label_reminder_notify_text">Meddelandetext</string>
@@ -138,9 +130,6 @@
     <string name="info_measuring">Mäter vikt: %.2f</string>
     <string name="open_drawer">öppna</string>
     <string name="close_drawer">stäng</string>
-    <string name="label_fat_percentage">Kroppsfett i %</string>
-    <string name="label_muscle_percentage">Muskler i %</string>
-    <string name="label_water_percentage">Kroppsvatten i %</string>
     <string name="info_bluetooth_no_device_set">Ingen Bluetooth-enhet vald</string>
     <string name="info_new_data_duplicated">mätning med samma datum och tid existerar redan</string>
     <string name="title_general">Allmänt</string>
@@ -180,7 +169,6 @@
     <string name="label_share_subject">openScale CSV dataexport (%s)</string>
 
     <string name="label_next">Nästa</string>
-    <string name="label_measurement_order">Mätordning</string>
     <string name="label_press_hold_reorder">Tryck och håll för att ändra ordning</string>
     <string name="label_set_default_order">Ställ in standardordning</string>
 

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -111,21 +111,12 @@
 
     <string name="label_delete_confirmation">Delete confirmation</string>
 
-    <string name="label_estimate_water">Tahmini Vücüt suyu oraný</string>
-    <string name="label_estimate_lbw">Tahmini Yaðsýz vücüt oraný</string>
-    <string name="label_estimate_fat">Tahmini Vücüt yað oraný</string>
-
-    <string name="label_category_display">Display</string>
-    <string name="label_category_body_metrics_estimation">Vücüt ölçütleri tahmini</string>
     <string name="label_category_measurement_database">Ölçüm veritabaný</string>
 
     <string name="label_maintainer">Maintainer</string>
     <string name="label_website">Websitesi</string>
     <string name="label_license">Lisan</string>
 
-    <string name="label_estimate_water_formula">Vücüt oraný hesaplama formulü</string>
-    <string name="label_estimate_lbw_formula">Yað oraný hesaplama formulü</string>
-    <string name="label_estimate_fat_formula">Vücut yaðý formülü</string>
     <string name="label_automatic">otomatik</string>
 
     <string name="label_reminder">Hatýrlatma</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -40,10 +40,6 @@
     <string name="label_bone">Bone mass</string>
     <string name="label_smartUserAssign">Smart User assignment</string>
 
-    <string name="label_fat_percentage">Body fat in %</string>
-    <string name="label_water_percentage">Body water in %</string>
-    <string name="label_muscle_percentage">Muscle in %</string>
-
     <plurals name="label_days">
         <item quantity="one">%d day</item>
         <item quantity="other">%d days</item>
@@ -127,21 +123,12 @@
 
     <string name="label_delete_confirmation">Delete confirmation</string>
 
-    <string name="label_estimate_water">Estimate body water</string>
-    <string name="label_estimate_lbw">Estimate lean body weight</string>
-    <string name="label_estimate_fat">Estimate body fat</string>
-
-    <string name="label_category_display">Display</string>
-    <string name="label_category_body_metrics_estimation">Body metrics estimation</string>
     <string name="label_category_measurement_database">Measurement database</string>
 
     <string name="label_maintainer">Maintainer</string>
     <string name="label_website">Website</string>
     <string name="label_license">License</string>
 
-    <string name="label_estimate_water_formula">Body water formula</string>
-    <string name="label_estimate_lbw_formula">Lean body weight formula</string>
-    <string name="label_estimate_fat_formula">Body fat formula</string>
     <string name="label_automatic">auto</string>
 
     <string name="label_theme">Theme</string>
@@ -206,10 +193,11 @@
     <string name="permission_bluetooth_info">openScale requires permission to access the coarse location to search for Bluetooth devices</string>
     <string name="permission_bluetooth_info_title">Information</string>
     <string name="label_next">Next</string>
-    <string name="label_measurement_order">Measurement order</string>
     <string name="label_press_hold_reorder">Press and hold to reorder</string>
     <string name="label_set_default_order">Set default order</string>
     <string name="label_export_overwrite">Overwrite previous export \"%s\"?</string>
-
-
+    <string name="label_include_in_overview_graph">Include in overview graph</string>
+    <string name="label_measurement_in_percent">Measurement in %</string>
+    <string name="label_estimate_measurement">Estimate measurement</string>
+    <string name="label_estimation_formula">Estimation formula</string>
 </resources>

--- a/android_app/app/src/main/res/xml/measurement_preferences.xml
+++ b/android_app/app/src/main/res/xml/measurement_preferences.xml
@@ -1,29 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory android:title="@string/label_category_display">
-        <PreferenceScreen android:title="@string/label_measurement_order">
-            <Preference android:key="resetOrder" android:title="@string/label_set_default_order"/>
-            <PreferenceCategory android:key="orderCategory" android:title="@string/label_press_hold_reorder"/>
-        </PreferenceScreen>
-        <CheckBoxPreference android:title="@string/label_fat" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key="fatEnable" android:defaultValue="true"/>
-        <SwitchPreference android:title="@string/label_fat_percentage" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key ="fatPercentageEnable" android:defaultValue="true"/>
-        <CheckBoxPreference android:title="@string/label_water" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"   android:key="waterEnable" android:defaultValue="true"/>
-        <SwitchPreference android:title="@string/label_water_percentage" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key ="waterPercentageEnable" android:defaultValue="true"/>
-        <CheckBoxPreference android:title="@string/label_muscle" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="muscleEnable" android:defaultValue="true"/>
-        <SwitchPreference android:title="@string/label_muscle_percentage" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable" android:key ="musclePercentageEnable" android:defaultValue="true"/>
-        <CheckBoxPreference android:title="@string/label_lbw" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="lbwEnable" android:defaultValue="false"/>
-        <CheckBoxPreference android:title="@string/label_bone" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="boneEnable" android:defaultValue="false"/>
-        <CheckBoxPreference android:title="@string/label_waist" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="waistEnable" android:defaultValue="false"/>
-        <CheckBoxPreference android:title="@string/label_hip" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="hipEnable" android:defaultValue="false"/>
-    </PreferenceCategory>
-    <PreferenceCategory android:title="@string/label_category_body_metrics_estimation">
-        <CheckBoxPreference android:title="@string/label_estimate_water" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="estimateWaterEnable" android:defaultValue="false"/>
-        <ListPreference android:title="@string/label_estimate_water_formula" android:key="estimateWaterFormula" android:defaultValue="TBW_LEESONGKIM"/>
-        <CheckBoxPreference android:title="@string/label_estimate_lbw" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="estimateLBWEnable" android:defaultValue="false"/>
-        <ListPreference android:title="@string/label_estimate_lbw_formula" android:key="estimateLBWFormula" android:defaultValue="LBW_HUME"/>
-        <CheckBoxPreference android:title="@string/label_estimate_fat" android:summaryOn="@string/info_is_enable" android:summaryOff="@string/info_is_not_enable"  android:key="estimateFatEnable" android:defaultValue="false"/>
-        <ListPreference android:title="@string/label_estimate_fat_formula" android:key="estimateFatFormula" android:defaultValue="BF_GALLAGHER"/>
-    </PreferenceCategory>
+    <Preference android:key="resetOrder" android:title="@string/label_set_default_order"/>
+    <PreferenceCategory android:title="@string/label_press_hold_reorder" android:key="measurements" />
     <PreferenceCategory android:title="@string/label_category_measurement_database">
         <Preference android:title="@string/label_delete_all" android:key="deleteAll"></Preference>
     </PreferenceCategory>

--- a/android_app/app/src/main/res/xml/measurement_preferences.xml
+++ b/android_app/app/src/main/res/xml/measurement_preferences.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/label_category_display">
-        <PreferenceScreen android:title="@string/label_measurement_order" android:key="measurementOrder">
+        <PreferenceScreen android:title="@string/label_measurement_order">
             <Preference android:key="resetOrder" android:title="@string/label_set_default_order"/>
             <PreferenceCategory android:key="orderCategory" android:title="@string/label_press_hold_reorder"/>
         </PreferenceScreen>


### PR DESCRIPTION
- Make it possible to disable all measurements (except weight). Fixes #226 and fixes #224.

- Add separate preference screens to all measurements to configure e.g. if the measurement should be displayed in the overview graph (this fixes #225 in a different way compared to previously), if relative or absolute weight should be used etc.

- Include reordering of measurements in the main measurement preference screen.

+ some other fixes.

@oliexdev: if you have time, please take a look and let me know what you think.