### PR TITLE
Add support for Easy Home (Aldi) 64050

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -59,7 +59,7 @@ public class BluetoothFactory {
         if (deviceName.startsWith("013197")) {
             return new BluetoothMedisanaBS444(context);
         }
-        if (deviceName.startsWith("SWAN")) {
+        if (deviceName.startsWith("SWAN") || name.equals("icomon".toLowerCase(Locale.US))) {
             return new BluetoothMGB(context);
         }
         if (name.equals("MI_SCALE".toLowerCase(Locale.US))) {


### PR DESCRIPTION
Appears to be a clone of the MGB scale with a different device name and appearance

Image:
![easyhome-64050](https://user-images.githubusercontent.com/39024736/39672796-43ffb0c4-5170-11e8-8ec0-287fa5f5f697.jpg)
