### PR TITLE
Sets scale unit during initialisation

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMGB.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMGB.java
@@ -113,7 +113,7 @@ public class BluetoothMGB extends BluetoothCommunication {
                 break;
 
             case 6:
-                writeCfg(0xFE, 6, 1, 0);
+                writeCfg(0xFE, 6, user.getScaleUnit().toInt(), 0);
                 break;
 
             default:


### PR DESCRIPTION
Use user preferences to set correct unit.
Lbs is currently hardcoded.

Tested with Easy Home 64050 (support added #258) which appears to be a clone of the MGB scale.

Probably worth testing with the original MGB scale, but works fine with the Easy Home unit