### PR TITLE
Improve BluetoothTrisaBodyAnalyze

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerSanitas.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerSanitas.java
@@ -588,7 +588,7 @@ public class BluetoothBeurerSanitas extends BluetoothCommunication {
     private void updateDateTime() {
         // Update date/time of the scale
         long unixTime = System.currentTimeMillis() / 1000L;
-        byte[] unixTimeBytes = Converters.toUnsignedInt32Be(unixTime);
+        byte[] unixTimeBytes = Converters.toInt32Be(unixTime);
         Timber.d("Write new Date/Time: %d (%s)", unixTime, byteInHex(unixTimeBytes));
 
         writeBytes(new byte[]{(byte) getAlternativeStartByte(9),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMedisanaBS44x.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothMedisanaBS44x.java
@@ -73,7 +73,7 @@ public class BluetoothMedisanaBS44x extends BluetoothCommunication {
                 // send magic number to receive weight data
                 long timestamp = new Date().getTime() / 1000;
                 timestamp -= SCALE_UNIX_TIMESTAMP_OFFSET;
-                byte[] date = Converters.toUnsignedInt32Le(timestamp);
+                byte[] date = Converters.toInt32Le(timestamp);
 
                 byte[] magicBytes = new byte[] {(byte)0x02, date[0], date[1], date[2], date[3]};
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
@@ -23,7 +23,9 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 
 import com.health.openscale.R;
+import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
+import com.health.openscale.core.datatypes.ScaleUser;
 
 import java.util.UUID;
 
@@ -252,7 +254,8 @@ public class BluetoothTrisaBodyAnalyze extends BluetoothCommunication {
     }
 
     private void onScaleMeasurumentReceived(byte[] data) {
-        ScaleMeasurement scaleMeasurement = parseScaleMeasurementData(data);
+        ScaleUser user = OpenScale.getInstance().getSelectedScaleUser();
+        ScaleMeasurement scaleMeasurement = parseScaleMeasurementData(data, user);
         if (scaleMeasurement == null) {
             Timber.e("Failed to parse scale measure measurement data: %s", byteInHex(data));
             return;

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
@@ -26,6 +26,7 @@ import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
+import com.health.openscale.core.utils.Converters;
 
 import java.util.UUID;
 
@@ -275,13 +276,10 @@ public class BluetoothTrisaBodyAnalyze extends BluetoothCommunication {
      * encoded in little-endian byte order.</p>
      */
     private void writeCommand(byte commandByte, int argument) {
-        writeCommandBytes(new byte[]{
-                commandByte,
-                (byte) (argument >> 0),
-                (byte) (argument >> 8),
-                (byte) (argument >> 16),
-                (byte) (argument >> 24),
-        });
+        byte[] bytes = new byte[5];
+        bytes[0] = commandByte;
+        Converters.toInt32Le(bytes, 1, argument);
+        writeCommandBytes(bytes);
     }
 
     private void writeCommandBytes(byte[] bytes) {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothTrisaBodyAnalyze.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 import timber.log.Timber;
 
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.convertJavaTimestampToDevice;
-import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.getInt32;
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.parseScaleMeasurementData;
 
 /**
@@ -219,7 +218,7 @@ public class BluetoothTrisaBodyAnalyze extends BluetoothCommunication {
             Timber.e("Password data too short");
             return;
         }
-        password = getInt32(data, 1);
+        password = Converters.fromSignedInt32Le(data, 1);
         if (deviceId == null) {
             Timber.e("Can't save password: device id not set!");
         } else {
@@ -247,7 +246,7 @@ public class BluetoothTrisaBodyAnalyze extends BluetoothCommunication {
             disconnect(true);
             return;
         }
-        int challenge = getInt32(data, 1);
+        int challenge = Converters.fromSignedInt32Le(data, 1);
         int response = challenge ^ password;
         writeCommand(DOWNLOAD_INFORMATION_RESULT_COMMAND, response);
         int deviceTimestamp = convertJavaTimestampToDevice(System.currentTimeMillis());

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
@@ -58,7 +58,7 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
     protected boolean nextInitCmd(int stateNr) {
         switch (stateNr) {
             case 0:
-                byte[] userId = Converters.toUnsignedInt16Be(getUniqueNumber());
+                byte[] userId = Converters.toInt16Be(getUniqueNumber());
 
                 final ScaleUser selectedUser = OpenScale.getInstance().getSelectedScaleUser();
                 byte sex = selectedUser.getGender().isMale() ? (byte)0x01 : (byte)0x02;
@@ -74,7 +74,7 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
                 writeBytes(WEIGHT_CMD_SERVICE, WEIGHT_CMD_CHARACTERISTIC, user_add_or_query);
                 break;
             case 1:
-                byte[] unixTime = Converters.toUnsignedInt32Be(new Date().getTime() / 1000);
+                byte[] unixTime = Converters.toInt32Be(new Date().getTime() / 1000);
 
                 byte[] set_time = new byte[]{(byte)0x0d, (byte) 0x0d, (byte) 0x11,
                         unixTime[0], unixTime[1], unixTime[2], unixTime[3],

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/TrisaBodyAnalyzeLib.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/TrisaBodyAnalyzeLib.java
@@ -51,8 +51,7 @@ public class TrisaBodyAnalyzeLib {
      * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code offset + 4> data.length}
      */
     public static double getBase10Float(byte[] data, int offset) {
-        int mantissa = (data[offset] & 0xff) | ((data[offset + 1] & 0xff) << 8) |
-                ((data[offset + 2] & 0xff) << 16);
+        int mantissa = Converters.fromUnsignedInt24Le(data, offset);
         int exponent = data[offset + 3];  // note: byte is signed.
         return mantissa * Math.pow(10, exponent);
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/TrisaBodyAnalyzeLib.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/TrisaBodyAnalyzeLib.java
@@ -33,16 +33,6 @@ public class TrisaBodyAnalyzeLib {
     // Timestamp of 2010-01-01 00:00:00 UTC (or local time?)
     private static final long TIMESTAMP_OFFSET_SECONDS = 1262304000L;
 
-    /**
-     * Converts 4 little-endian bytes to a 32-bit integer, starting from {@code offset}.
-     *
-     * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code offset + 4> data.length}
-     */
-    public static int getInt32(byte[] data, int offset) {
-        return (data[offset] & 0xff) | ((data[offset + 1] & 0xff) << 8) |
-                ((data[offset + 2] & 0xff) << 16) | ((data[offset + 3] & 0xff) << 24);
-    }
-
     /** Converts 4 bytes to a floating point number, starting from  {@code offset}.
      *
      * <p>The first three little-endian bytes form the 24-bit mantissa. The last byte contains the
@@ -92,7 +82,7 @@ public class TrisaBodyAnalyzeLib {
             return null;
         }
         double weightKg = getBase10Float(data, 1);
-        int deviceTimestamp = getInt32(data, 5);
+        int deviceTimestamp = Converters.fromSignedInt32Le(data, 5);
 
         ScaleMeasurement measurement = new ScaleMeasurement();
         measurement.setDateTime(new Date(convertDeviceTimestampToJava(deviceTimestamp)));

--- a/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
@@ -235,16 +235,24 @@ public class Converters {
         return kg;
     }
 
-    public static int fromUnsignedInt16Le(byte[] data, int offset) {
-        int value = (data[offset + 1] & 0xFF) << 8;
+    public static int fromSignedInt16Le(byte[] data, int offset) {
+        int value = data[offset + 1] << 8;
         value += data[offset] & 0xFF;
         return value;
     }
 
-    public static int fromUnsignedInt16Be(byte[] data, int offset) {
-        int value = (data[offset] & 0xFF) << 8;
+    public static int fromSignedInt16Be(byte[] data, int offset) {
+        int value = data[offset] << 8;
         value += data[offset + 1] & 0xFF;
         return value;
+    }
+
+    public static int fromUnsignedInt16Le(byte[] data, int offset) {
+        return fromSignedInt16Le(data, offset) & 0xFFFF;
+    }
+
+    public static int fromUnsignedInt16Be(byte[] data, int offset) {
+        return fromSignedInt16Be(data, offset) & 0xFFFF;
     }
 
     public static void toInt16Le(byte[] data, int offset, int value) {
@@ -269,27 +277,39 @@ public class Converters {
         return data;
     }
 
-    public static int fromUnsignedInt24Le(byte[] data, int offset) {
-        int value = (data[offset + 2] & 0xFF) << 16;
+    public static int fromSignedInt24Le(byte[] data, int offset) {
+        int value = data[offset + 2] << 16;
         value += (data[offset + 1] & 0xFF) << 8;
         value += data[offset] & 0xFF;
         return value;
     }
 
-    public static long fromUnsignedInt32Le(byte[] data, int offset) {
-        long value = (long) (data[offset + 3] & 0xFF) << 24;
+    public static int fromUnsignedInt24Le(byte[] data, int offset) {
+        return fromSignedInt24Le(data, offset) & 0xFFFFFF;
+    }
+
+    public static int fromSignedInt32Le(byte[] data, int offset) {
+        int value = data[offset + 3] << 24;
         value += (data[offset + 2] & 0xFF) << 16;
         value += (data[offset + 1] & 0xFF) << 8;
         value += data[offset] & 0xFF;
         return value;
     }
 
-    public static long fromUnsignedInt32Be(byte[] data, int offset) {
-        long value = (long) (data[offset] & 0xFF) << 24;
+    public static int fromSignedInt32Be(byte[] data, int offset) {
+        int value = data[offset] << 24;
         value += (data[offset + 1] & 0xFF) << 16;
         value += (data[offset + 2] & 0xFF) << 8;
         value += data[offset + 3] & 0xFF;
         return value;
+    }
+
+    public static long fromUnsignedInt32Le(byte[] data, int offset) {
+        return (long) fromSignedInt32Le(data, offset) & 0xFFFFFFFFL;
+    }
+
+    public static long fromUnsignedInt32Be(byte[] data, int offset) {
+        return (long) fromSignedInt32Be(data, offset) & 0xFFFFFFFFL;
     }
 
     public static void toInt32Le(byte[] data, int offset, long value) {

--- a/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
@@ -247,7 +247,7 @@ public class Converters {
         return value;
     }
 
-    public static byte[] toUnsignedInt16Be(int value) {
+    public static byte[] toInt16Be(int value) {
         byte[] data = new byte[2];
         data[0] = (byte) ((value >> 8) & 0xFF);
         data[1] = (byte) (value & 0xFF);
@@ -277,7 +277,7 @@ public class Converters {
         return value;
     }
 
-    public static byte[] toUnsignedInt32Le(long value) {
+    public static byte[] toInt32Le(long value) {
         byte[] data = new byte[4];
         data[3] = (byte) ((value >> 24) & 0xFF);
         data[2] = (byte) ((value >> 16) & 0xFF);
@@ -286,7 +286,7 @@ public class Converters {
         return data;
     }
 
-    public static byte[] toUnsignedInt32Be(long value) {
+    public static byte[] toInt32Be(long value) {
         byte[] data = new byte[4];
         data[0] = (byte) ((value >> 24) & 0xFF);
         data[1] = (byte) ((value >> 16) & 0xFF);

--- a/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
@@ -247,6 +247,13 @@ public class Converters {
         return value;
     }
 
+    public static byte[] toInt16Le(int value) {
+        byte[] data = new byte[2];
+        data[0] = (byte) (value & 0xFF);
+        data[1] = (byte) ((value >> 8) & 0xFF);
+        return data;
+    }
+
     public static byte[] toInt16Be(int value) {
         byte[] data = new byte[2];
         data[0] = (byte) ((value >> 8) & 0xFF);

--- a/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/Converters.java
@@ -247,17 +247,25 @@ public class Converters {
         return value;
     }
 
+    public static void toInt16Le(byte[] data, int offset, int value) {
+        data[offset + 0] = (byte) (value & 0xFF);
+        data[offset + 1] = (byte) ((value >> 8) & 0xFF);
+    }
+
+    public static void toInt16Be(byte[] data, int offset, int value) {
+        data[offset + 0] = (byte) ((value >> 8) & 0xFF);
+        data[offset + 1] = (byte) (value & 0xFF);
+    }
+
     public static byte[] toInt16Le(int value) {
         byte[] data = new byte[2];
-        data[0] = (byte) (value & 0xFF);
-        data[1] = (byte) ((value >> 8) & 0xFF);
+        toInt16Le(data, 0, value);
         return data;
     }
 
     public static byte[] toInt16Be(int value) {
         byte[] data = new byte[2];
-        data[0] = (byte) ((value >> 8) & 0xFF);
-        data[1] = (byte) (value & 0xFF);
+        toInt16Be(data, 0, value);
         return data;
     }
 
@@ -284,21 +292,29 @@ public class Converters {
         return value;
     }
 
+    public static void toInt32Le(byte[] data, int offset, long value) {
+        data[offset + 3] = (byte) ((value >> 24) & 0xFF);
+        data[offset + 2] = (byte) ((value >> 16) & 0xFF);
+        data[offset + 1] = (byte) ((value >> 8) & 0xFF);
+        data[offset + 0] = (byte) (value & 0xFF);
+    }
+
+    public static void toInt32Be(byte[] data, int offset, long value) {
+        data[offset + 0] = (byte) ((value >> 24) & 0xFF);
+        data[offset + 1] = (byte) ((value >> 16) & 0xFF);
+        data[offset + 2] = (byte) ((value >> 8) & 0xFF);
+        data[offset + 3] = (byte) (value & 0xFF);
+    }
+
     public static byte[] toInt32Le(long value) {
         byte[] data = new byte[4];
-        data[3] = (byte) ((value >> 24) & 0xFF);
-        data[2] = (byte) ((value >> 16) & 0xFF);
-        data[1] = (byte) ((value >> 8) & 0xFF);
-        data[0] = (byte) (value & 0xFF);
+        toInt32Le(data, 0, value);
         return data;
     }
 
     public static byte[] toInt32Be(long value) {
         byte[] data = new byte[4];
-        data[0] = (byte) ((value >> 24) & 0xFF);
-        data[1] = (byte) ((value >> 16) & 0xFF);
-        data[2] = (byte) ((value >> 8) & 0xFF);
-        data[3] = (byte) (value & 0xFF);
+        toInt32Be(data, 0, value);
         return data;
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
@@ -96,10 +96,10 @@ public class ConvertersTest {
         assertEquals(0x107f, Converters.fromUnsignedInt16Be(data, 3));
 
         data = new byte[]{(byte) 0xff, (byte) 0xfe};
-        assertArrayEquals(data, Converters.toUnsignedInt16Be(0xfffe));
+        assertArrayEquals(data, Converters.toInt16Be(0xfffe));
         assertEquals(0xffff,
                 Converters.fromUnsignedInt16Be(
-                        Converters.toUnsignedInt16Be(0xffff), 0));
+                        Converters.toInt16Be(0xffff), 0));
     }
 
     @Test
@@ -130,13 +130,13 @@ public class ConvertersTest {
         assertEquals(0x1ff00L, Converters.fromUnsignedInt32Be(data, 1));
 
         data = new byte[]{(byte) 0xff, (byte) 0xfe, (byte) 0xfd, (byte) 0xfc};
-        assertArrayEquals(data, Converters.toUnsignedInt32Le(0xfcfdfeffL));
-        assertArrayEquals(data, Converters.toUnsignedInt32Be(0xfffefdfcL));
+        assertArrayEquals(data, Converters.toInt32Le(0xfcfdfeffL));
+        assertArrayEquals(data, Converters.toInt32Be(0xfffefdfcL));
         assertEquals(0xffffffffL,
                 Converters.fromUnsignedInt32Le(
-                        Converters.toUnsignedInt32Le(0xffffffffL), 0));
+                        Converters.toInt32Le(0xffffffffL), 0));
         assertEquals(0xffffffffL,
                 Converters.fromUnsignedInt32Be(
-                        Converters.toUnsignedInt32Be(0xffffffffL), 0));
+                        Converters.toInt32Be(0xffffffffL), 0));
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
@@ -20,6 +20,8 @@ import com.health.openscale.core.utils.Converters;
 
 import org.junit.Test;
 
+import javax.sql.ConnectionEvent;
+
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
@@ -102,6 +104,12 @@ public class ConvertersTest {
         assertArrayEquals(new byte[]{(byte) 0xff, (byte) 0xfe}, Converters.toInt16Be(0xfffe));
         assertArrayEquals(new byte[]{(byte) 0x34, (byte) 0x12}, Converters.toInt16Le(0x1234));
         assertArrayEquals(new byte[]{(byte) 0xfe, (byte) 0xff}, Converters.toInt16Le(0xfffe));
+
+        byte[] data = new byte[6];
+        Converters.toInt16Be(data, 1, 0x0102);
+        Converters.toInt16Be(data, 3, 0x0304);
+        Converters.toInt16Le(data, 2, 0x0506);
+        assertArrayEquals(new byte[]{ 0, 1, 6, 5, 4, 0}, data);
     }
 
     @Test
@@ -114,7 +122,7 @@ public class ConvertersTest {
     }
 
     @Test
-    public void unsignedInt32Converters() throws Exception {
+    public void fromUnsignedInt32Converters() throws Exception {
         byte[] data = new byte[]{(byte) 0xf1, (byte) 0xf2, (byte) 0xf3, (byte) 0x7f, (byte) 0x7e};
 
         assertEquals(0x7ff3f2f1, Converters.fromUnsignedInt32Le(data, 0));
@@ -130,8 +138,11 @@ public class ConvertersTest {
 
         assertEquals(0x800001ffL, Converters.fromUnsignedInt32Be(data, 0));
         assertEquals(0x1ff00L, Converters.fromUnsignedInt32Be(data, 1));
+    }
 
-        data = new byte[]{(byte) 0xff, (byte) 0xfe, (byte) 0xfd, (byte) 0xfc};
+    @Test
+    public void toInt32Converters() throws Exception {
+        byte[] data = new byte[]{(byte) 0xff, (byte) 0xfe, (byte) 0xfd, (byte) 0xfc};
         assertArrayEquals(data, Converters.toInt32Le(0xfcfdfeffL));
         assertArrayEquals(data, Converters.toInt32Be(0xfffefdfcL));
         assertEquals(0xffffffffL,
@@ -140,5 +151,11 @@ public class ConvertersTest {
         assertEquals(0xffffffffL,
                 Converters.fromUnsignedInt32Be(
                         Converters.toInt32Be(0xffffffffL), 0));
+
+        data = new byte[10];
+        Converters.toInt32Be(data, 1, 0x01020304);
+        Converters.toInt32Be(data, 6, 0x05060708);
+        Converters.toInt32Le(data, 3, 0x090a0b0c);
+        assertArrayEquals(new byte[]{ 0, 1, 2, 12, 11, 10, 9, 6, 7, 8}, data);
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
@@ -82,7 +82,7 @@ public class ConvertersTest {
     }
 
     @Test
-    public void unsignedInt16Converters() throws Exception {
+    public void fromUnsignedInt16Converters() throws Exception {
         byte[] data = new byte[]{(byte) 0xfd, (byte) 0xfe, (byte) 0xfc, (byte) 0x10, (byte) 0x7f};
 
         assertEquals(0xfefd, Converters.fromUnsignedInt16Le(data, 0));
@@ -94,12 +94,14 @@ public class ConvertersTest {
         assertEquals(0xfefc, Converters.fromUnsignedInt16Be(data, 1));
         assertEquals(0xfc10, Converters.fromUnsignedInt16Be(data, 2));
         assertEquals(0x107f, Converters.fromUnsignedInt16Be(data, 3));
+    }
 
-        data = new byte[]{(byte) 0xff, (byte) 0xfe};
-        assertArrayEquals(data, Converters.toInt16Be(0xfffe));
-        assertEquals(0xffff,
-                Converters.fromUnsignedInt16Be(
-                        Converters.toInt16Be(0xffff), 0));
+    @Test
+    public void toInt16Converters() throws Exception {
+        assertArrayEquals(new byte[]{(byte) 0x12, (byte) 0x34}, Converters.toInt16Be(0x1234));
+        assertArrayEquals(new byte[]{(byte) 0xff, (byte) 0xfe}, Converters.toInt16Be(0xfffe));
+        assertArrayEquals(new byte[]{(byte) 0x34, (byte) 0x12}, Converters.toInt16Le(0x1234));
+        assertArrayEquals(new byte[]{(byte) 0xfe, (byte) 0xff}, Converters.toInt16Le(0xfffe));
     }
 
     @Test

--- a/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/ConvertersTest.java
@@ -84,18 +84,33 @@ public class ConvertersTest {
     }
 
     @Test
-    public void fromUnsignedInt16Converters() throws Exception {
+    public void fromInt16Converters() throws Exception {
         byte[] data = new byte[]{(byte) 0xfd, (byte) 0xfe, (byte) 0xfc, (byte) 0x10, (byte) 0x7f};
+
+        assertEquals(0xfffffefd, Converters.fromSignedInt16Le(data, 0));
+        assertEquals(0xfffffcfe, Converters.fromSignedInt16Le(data, 1));
+        assertEquals(0x000010fc, Converters.fromSignedInt16Le(data, 2));
+        assertEquals(0x00007f10, Converters.fromSignedInt16Le(data, 3));
 
         assertEquals(0xfefd, Converters.fromUnsignedInt16Le(data, 0));
         assertEquals(0xfcfe, Converters.fromUnsignedInt16Le(data, 1));
         assertEquals(0x10fc, Converters.fromUnsignedInt16Le(data, 2));
         assertEquals(0x7f10, Converters.fromUnsignedInt16Le(data, 3));
 
+        assertEquals(0xfffffdfe, Converters.fromSignedInt16Be(data, 0));
+        assertEquals(0xfffffefc, Converters.fromSignedInt16Be(data, 1));
+        assertEquals(0xfffffc10, Converters.fromSignedInt16Be(data, 2));
+        assertEquals(0x0000107f, Converters.fromSignedInt16Be(data, 3));
+
         assertEquals(0xfdfe, Converters.fromUnsignedInt16Be(data, 0));
         assertEquals(0xfefc, Converters.fromUnsignedInt16Be(data, 1));
         assertEquals(0xfc10, Converters.fromUnsignedInt16Be(data, 2));
         assertEquals(0x107f, Converters.fromUnsignedInt16Be(data, 3));
+
+        assertEquals(-12345,
+                Converters.fromSignedInt16Le(Converters.toInt16Le(-12345), 0));
+        assertEquals(-12345,
+                Converters.fromSignedInt16Be(Converters.toInt16Be(-12345), 0));
     }
 
     @Test
@@ -113,31 +128,55 @@ public class ConvertersTest {
     }
 
     @Test
-    public void unsignedInt24Converters() throws Exception {
+    public void fromInt24Converters() throws Exception {
         byte[] data = new byte[]{(byte) 0xfd, (byte) 0xfe, (byte) 0xfc, (byte) 0x10, (byte) 0x7f};
+
+        assertEquals(0xfffcfefd, Converters.fromSignedInt24Le(data, 0));
+        assertEquals(0x0010fcfe, Converters.fromSignedInt24Le(data, 1));
+        assertEquals(0x007f10fc, Converters.fromSignedInt24Le(data, 2));
 
         assertEquals(0xfcfefd, Converters.fromUnsignedInt24Le(data, 0));
         assertEquals(0x10fcfe, Converters.fromUnsignedInt24Le(data, 1));
         assertEquals(0x7f10fc, Converters.fromUnsignedInt24Le(data, 2));
+
+        assertEquals(-1234567,
+                Converters.fromSignedInt24Le(Converters.toInt32Le(-1234567), 0));
     }
 
     @Test
-    public void fromUnsignedInt32Converters() throws Exception {
+    public void fromInt32Converters() throws Exception {
         byte[] data = new byte[]{(byte) 0xf1, (byte) 0xf2, (byte) 0xf3, (byte) 0x7f, (byte) 0x7e};
+
+        assertEquals(0x7ff3f2f1, Converters.fromSignedInt32Le(data, 0));
+        assertEquals(0x7e7ff3f2, Converters.fromSignedInt32Le(data, 1));
 
         assertEquals(0x7ff3f2f1, Converters.fromUnsignedInt32Le(data, 0));
         assertEquals(0x7e7ff3f2, Converters.fromUnsignedInt32Le(data, 1));
+
+        assertEquals(0xf1f2f37f, Converters.fromSignedInt32Be(data, 0));
+        assertEquals(0xf2f37f7e, Converters.fromSignedInt32Be(data, 1));
 
         assertEquals(0xf1f2f37fL, Converters.fromUnsignedInt32Be(data, 0));
         assertEquals(0xf2f37f7eL, Converters.fromUnsignedInt32Be(data, 1));
 
         data = new byte[]{(byte) 0x80, (byte) 0x00, (byte) 0x01, (byte) 0xff, (byte) 0x00};
 
+        assertEquals(0xff010080, Converters.fromSignedInt32Le(data, 0));
+        assertEquals(0xff0100, Converters.fromSignedInt32Le(data, 1));
+
         assertEquals(0xff010080L, Converters.fromUnsignedInt32Le(data, 0));
         assertEquals(0xff0100, Converters.fromUnsignedInt32Le(data, 1));
 
+        assertEquals(0x800001ff, Converters.fromSignedInt32Be(data, 0));
+        assertEquals(0x1ff00, Converters.fromSignedInt32Be(data, 1));
+
         assertEquals(0x800001ffL, Converters.fromUnsignedInt32Be(data, 0));
         assertEquals(0x1ff00L, Converters.fromUnsignedInt32Be(data, 1));
+
+        assertEquals(-1234567890,
+                Converters.fromSignedInt32Le(Converters.toInt32Le(-1234567890), 0));
+        assertEquals(-1234567890,
+                Converters.fromSignedInt32Be(Converters.toInt32Be(-1234567890), 0));
     }
 
     @Test

--- a/android_app/app/src/test/java/com/health/openscale/TrisaBodyAnalyzeLibTest.java
+++ b/android_app/app/src/test/java/com/health/openscale/TrisaBodyAnalyzeLibTest.java
@@ -15,26 +15,11 @@ import java.util.GregorianCalendar;
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.convertDeviceTimestampToJava;
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.convertJavaTimestampToDevice;
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.getBase10Float;
-import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.getInt32;
 import static com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib.parseScaleMeasurementData;
 import static junit.framework.Assert.assertEquals;
 
 /** Unit tests for {@link com.health.openscale.core.bluetooth.lib.TrisaBodyAnalyzeLib}.*/
 public class TrisaBodyAnalyzeLibTest {
-
-    @Test
-    public void getInt32Tests() {
-        byte[] data = new byte[]{1, 2, 3, 4, 5, 6};
-        assertEquals(0x04030201, getInt32(data, 0));
-        assertEquals(0x05040302, getInt32(data, 1));
-        assertEquals(0x06050403, getInt32(data, 2));
-
-        assertEquals(0xa7bdd385, getInt32(new byte[]{-123, -45, -67, -89}, 0));
-
-        assertThrows(IndexOutOfBoundsException.class, getInt32Runnable(data, -1));
-        assertThrows(IndexOutOfBoundsException.class, getInt32Runnable(data, 5));
-        assertThrows(IndexOutOfBoundsException.class, getInt32Runnable(new byte[]{1,2,3}, 0));
-    }
 
     @Test
     public void getBase10FloatTests() {
@@ -115,19 +100,6 @@ public class TrisaBodyAnalyzeLibTest {
         assertEquals(76.1f, measurement.getWeight(), 1e-3f);
         assertEquals(new Date(expected_timestamp_seconds * 1000), measurement.getDateTime());
         assertEquals(0f, measurement.getFat());
-    }
-
-    /**
-     * Creates a {@link Runnable} that will call getInt32(). In Java 8, this can be done more
-     * easily with a lambda expression at the call site, but we are using Java 7.
-     */
-    private static Runnable getInt32Runnable(final byte[] data, final int offset) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                getInt32(data, offset);
-            }
-        };
     }
 
     /**


### PR DESCRIPTION
This pull request covers two changes:

  1. I added calculation of body composition data for the Trisa Body Analyzer scale, based on logic from the reverse-engineered Trisa Vital Bluetooth app. The reliability of these figures is questionable, but it's better than nothing.

  2. I expanded Converters.java, adding support for decoding signed integers, and encoding to an existing byte array. Using these functions in the Trisa Body Analyze driver allowed me to remove some of the custom encoding/decoding logic there.