### PR TITLE
Added support for Libra-W

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -34,7 +34,8 @@ public class BluetoothFactory {
                 || name.startsWith("BEURER BF800".toLowerCase(Locale.US))
                 || name.startsWith("BF-800".toLowerCase(Locale.US))
                 || name.startsWith("BF-700".toLowerCase(Locale.US))
-                || name.startsWith("RT-Libra-B".toLowerCase(Locale.US))) {
+                || name.startsWith("RT-Libra-B".toLowerCase(Locale.US))
+                || name.startsWith("Libra-W".toLowerCase(Locale.US))) {
             return new BluetoothBeurerSanitas(context, BluetoothBeurerSanitas.DeviceType.BEURER_BF700_800_RT_LIBRA);
         }
         if (name.startsWith("BEURER BF710".toLowerCase(Locale.US))


### PR DESCRIPTION
My Runtastic/Adidas Libra shows as "Libra-W", and was marked as non-supported in openScale. I tried using this tiny patch and everything is working great now!