### PR TITLE
Fix force QN-Scale to KG

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
@@ -426,6 +426,14 @@ public abstract class BluetoothCommunication {
         return checksum;
     }
 
+    protected byte sumChecksum(byte[] data, int offset, int length) {
+        byte checksum = 0;
+        for (int i = offset; i < offset + length; ++i) {
+            checksum += data[i];
+        }
+        return checksum;
+    }
+
     /**
      * Test in a byte if a bit is set (1) or not (0)
      *

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
@@ -85,6 +85,13 @@ public class BluetoothQNScale extends BluetoothCommunication {
 
     @Override
     protected boolean onNextStep(int stepNr) {
+    final ScaleUser scaleUser = OpenScale.getInstance().getSelectedScaleUser();
+    final Converters.WeightUnit scaleUserWeightUnit = scaleUser.getScaleUnit();
+    // Default weight unit KG. 0x01 weight byte = KG. 0x02 weight byte = LB.
+    byte weightUnitByte = (byte) 0x01;
+    if (scaleUserWeightUnit == Converters.WeightUnit.LB){
+        weightUnitByte = (byte) 0x02;
+    }
         switch (stepNr) {
             case 0:
                 // set notification on for custom characteristic 1 (weight, time, and others)
@@ -95,8 +102,9 @@ public class BluetoothQNScale extends BluetoothCommunication {
                 setIndicationOn(CUSTOM2_MEASUREMENT_CHARACTERISTIC);
                 break;
             case 2:
-                // write magicnumber 0x130915011000000042 to 0xffe3
-                byte[] ffe3magicBytes = new byte[]{(byte) 0x13, (byte) 0x09, (byte) 0x15, (byte) 0x01, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x42};
+                // write magicnumber 0x130915[WEIGHT_BYTE]1000000042 to 0xffe3
+                // 0x01 weight byte = KG. 0x02 weight byte = LB.
+                byte[] ffe3magicBytes = new byte[]{(byte) 0x13, (byte) 0x09, (byte) 0x15, weightUnitByte, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x42};
                 writeBytes(CUSTOM3_MEASUREMENT_CHARACTERISTIC, ffe3magicBytes);
                 break;
             case 3:

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
@@ -91,7 +91,6 @@ public class BluetoothQNScale extends BluetoothCommunication {
     byte weightUnitByte = (byte) 0x01;
     // Checksum at end of message. For now, simply switching based on weight unit only
     byte weightRequestChecksum = (byte) 0x42;
-    Timber.e("Weight byte 1 %d", weightUnitByte);
     if (scaleUserWeightUnit == Converters.WeightUnit.LB){
         weightUnitByte = (byte) 0x02;
         weightRequestChecksum = (byte) 0x43;

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
@@ -99,8 +99,8 @@ public class BluetoothQNScale extends BluetoothCommunication {
                 final Converters.WeightUnit scaleUserWeightUnit = scaleUser.getScaleUnit();
                 // Value of 0x01 = KG. 0x02 = LB. Requests with stones unit are sent as LB, with post-processing in vendor app.
                 byte weightUnitByte = (byte) 0x01;
-                // Checksum at end of message. For now, simply switching based on weight unit only
-                if (scaleUserWeightUnit == Converters.WeightUnit.LB){
+                // Default weight unit KG. If user config set to LB or ST, scale will show LB units, consistent with vendor app
+                if (scaleUserWeightUnit == Converters.WeightUnit.LB || scaleUserWeightUnit == Converters.WeightUnit.ST){
                     weightUnitByte = (byte) 0x02;
                 }
                 // write magicnumber 0x130915[WEIGHT_BYTE]10000000[CHECK_SUM] to 0xffe3

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothQNScale.java
@@ -87,10 +87,14 @@ public class BluetoothQNScale extends BluetoothCommunication {
     protected boolean onNextStep(int stepNr) {
     final ScaleUser scaleUser = OpenScale.getInstance().getSelectedScaleUser();
     final Converters.WeightUnit scaleUserWeightUnit = scaleUser.getScaleUnit();
-    // Default weight unit KG. 0x01 weight byte = KG. 0x02 weight byte = LB.
+    // Value of 0x01 = KG. 0x02 = LB. Requests with stones unit are sent as LB, with post-processing in vendor app.
     byte weightUnitByte = (byte) 0x01;
+    // Checksum at end of message. For now, simply switching based on weight unit only
+    byte weightRequestChecksum = (byte) 0x42;
+    Timber.e("Weight byte 1 %d", weightUnitByte);
     if (scaleUserWeightUnit == Converters.WeightUnit.LB){
         weightUnitByte = (byte) 0x02;
+        weightRequestChecksum = (byte) 0x43;
     }
         switch (stepNr) {
             case 0:
@@ -104,7 +108,7 @@ public class BluetoothQNScale extends BluetoothCommunication {
             case 2:
                 // write magicnumber 0x130915[WEIGHT_BYTE]1000000042 to 0xffe3
                 // 0x01 weight byte = KG. 0x02 weight byte = LB.
-                byte[] ffe3magicBytes = new byte[]{(byte) 0x13, (byte) 0x09, (byte) 0x15, weightUnitByte, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x42};
+                byte[] ffe3magicBytes = new byte[]{(byte) 0x13, (byte) 0x09, (byte) 0x15, weightUnitByte, (byte) 0x10, (byte) 0x00, (byte) 0x00, (byte) 0x00, weightRequestChecksum};
                 writeBytes(CUSTOM3_MEASUREMENT_CHARACTERISTIC, ffe3magicBytes);
                 break;
             case 3:


### PR DESCRIPTION
Fixes #428. The magic number sent to initiate weight readings contains a byte describing which units the scale should be set to. The previous implementation hard coded this as 0x01 for KG. This PR switches the unit (either LB or KG) to be based on the value retrieved by `OpenScale.getInstance().getSelectedScaleUser().getScaleUnit()`

Please note that my ability to build the apk is currently down and I am unable to test this (although the code is extremely simple, I don't think it should be a problem). Hoping Travis will accomplish this.