### PR TITLE
Support Yunmai Mini 2 China version

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -88,7 +88,7 @@ public class BluetoothFactory {
         if (name.startsWith("SANITAS SBF70".toLowerCase(Locale.US)) || name.startsWith("sbf75")) {
             return new BluetoothBeurerSanitas(context, BluetoothBeurerSanitas.DeviceType.SANITAS_SBF70_70);
         }
-        if (deviceName.startsWith("YUNMAI-SIGNAL-") || deviceName.startsWith("YUNMAI-ISM2-")) {
+        if (deviceName.startsWith("YUNMAI-SIGNAL-") || deviceName.startsWith("YUNMAI-ISM2")) {
             return new BluetoothYunmaiSE_Mini(context, true);
         }
         if (deviceName.startsWith("YUNMAI-ISSE")) {


### PR DESCRIPTION
Since Yunmai Mini 2 China version uses bluetooth name "YUNMAI-ISM2T", the current matching rules does not work. This patch makes it work.