### PR TITLE
Support old Yunmai premium 1

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -96,7 +96,7 @@ public class BluetoothFactory {
         if (name.startsWith("SANITAS SBF70".toLowerCase(Locale.US)) || name.startsWith("sbf75")) {
             return new BluetoothBeurerSanitas(context, BluetoothBeurerSanitas.DeviceType.SANITAS_SBF70_70);
         }
-        if (deviceName.startsWith("YUNMAI-SIGNAL-") || deviceName.startsWith("YUNMAI-ISM")) {
+        if (deviceName.startsWith("YUNMAI-SIGNAL") || deviceName.startsWith("YUNMAI-ISM")) {
             return new BluetoothYunmaiSE_Mini(context, true);
         }
         if (deviceName.startsWith("YUNMAI-ISSE")) {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
@@ -133,8 +133,10 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
             float bodyFat;
             int resistance = Converters.fromUnsignedInt16Be(weightBytes, 15);
             if (weightBytes[1] >= (byte)0x1E) {
+                Timber.d("Extract the fat value from received bytes");
                 bodyFat = Converters.fromUnsignedInt16Be(weightBytes, 17) / 100.0f;
             } else {
+                Timber.d("Calculate the fat value using the Yunmai lib");
                 bodyFat = yunmaiLib.getFat(scaleUser.getAge(), weight, resistance);
             }
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
@@ -132,7 +132,7 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
             YunmaiLib yunmaiLib = new YunmaiLib(sex, scaleUser.getBodyHeight());
             float bodyFat;
             int resistance = Converters.fromUnsignedInt16Be(weightBytes, 15);
-            if (weightBytes[1] >= 0x1E) {
+            if (weightBytes[1] >= (byte)0x1E) {
                 bodyFat = Converters.fromUnsignedInt16Be(weightBytes, 17) / 100.0f;
             } else {
                 bodyFat = yunmaiLib.getFat(scaleUser.getAge(), weight, resistance);

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
@@ -130,8 +130,13 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
             }
 
             YunmaiLib yunmaiLib = new YunmaiLib(sex, scaleUser.getBodyHeight());
-            float bodyFat = Converters.fromUnsignedInt16Be(weightBytes, 17) / 100.0f;
+            float bodyFat;
             int resistance = Converters.fromUnsignedInt16Be(weightBytes, 15);
+            if (weightBytes[1] >= 0x1E) {
+                bodyFat = Converters.fromUnsignedInt16Be(weightBytes, 17) / 100.0f;
+            } else {
+                bodyFat = yunmaiLib.getFat(scaleUser.getAge(), weight, resistance);
+            }
 
             if (bodyFat != 0) {
                 scaleBtData.setFat(bodyFat);

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/YunmaiLib.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/lib/YunmaiLib.java
@@ -29,6 +29,24 @@ public class YunmaiLib {
         return ((100.0f - bodyFat) * 0.726f * 100.0f + 0.5f) / 100.0f;
     }
 
+    public float getFat(int age, float weight, int resistance) {
+        // for < 0x1e version devices
+        float fat;
+
+        float r = (resistance - 100.0f) / 100.0f;
+        float h = height / 100.0f;
+
+        if (this.sex == 1) {
+            fat = (weight * 1.5f / h / h) + (age * 0.08f) - 10.8f;
+        } else {
+            fat = (weight * 1.5f / h / h) + (age * 0.08f);
+        }
+
+        fat = (fat - 7.4f) + r;
+
+        return fat;
+    }
+
     public float getMuscle(float bodyFat) {
         float muscle;
         muscle = (100.0f - bodyFat) * 0.67f;


### PR DESCRIPTION
1. this device name is just `YUNMAI-SIGNAL`
2. a packet sample is `0D 13 12 02 00 5D DD 67 22 00 00 AB A5 1C 00 00 EA 3E`;
    only contains resistance value without fat.

I try to reverse `getFat` funtion of the `libconfig.so`
but return value could be little different.