### PR TITLE
Update to SENSSUN scale Bluetooth code

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSenssun.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSenssun.java
@@ -115,7 +115,7 @@ public class BluetoothSenssun extends BluetoothCommunication {
         switch(data[5]) {
             case (byte)0xAA:
             case (byte)0xA0:
-                if (weightStabilized) {
+                if (values > 1) {
                     return;
                 }
                 if (!stepMessageDisplayed) {


### PR DESCRIPTION
I was having an issue with a SENSSUN scale and the openScale app where the app would only write a new record about 20% of the time. 

The scale seemed to ignore the user synchronization message and the app would sit waiting for the measurement data (fat/water...) which never arrived. 

This change resends the userSynchronisation message to the scale (after stabilization) until it responds with the other metrics. 

This change has my scale responding correctly without fail since I changed the code.