### PR TITLE
bugfix #603: make app resizable on android desktops

### DIFF
--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-configuration  android:reqTouchScreen="finger" />
+    <uses-feature  android:name="android.hardware.touchscreen"  android:required="true" />
 
     <!-- Permission to allow read of data from the database through a ContentProvider.
          Marked "dangerous" so that explicit user approval is required to read this data, not
@@ -27,6 +29,7 @@
         android:roundIcon="${appIconRound}"
         android:label="@string/app_name"
         android:name=".core.Application"
+        android:resizeableActivity="true"
         android:theme="@style/AppTheme" >
         <activity
             android:name=".gui.MainActivity"


### PR DESCRIPTION
Hi @oliexdev,

This PR fixes #603.

I admit that setting up the Android development environmet was pretty terrible.
Nothing worked out of the box, Android Studio got stuck twice on the openScale project and all that just for adding three lines and testing whether it worked.

Here's the bugfix for making openScale working properly on Android Desktops like Samsung DeX.
I was able to resize everything.

**PS:** If you're going to merge this: would you be so kind and add the [`hacktoberfest-accepted`](https://hacktoberfest.digitalocean.com/hacktoberfest-update) label to this PR? Thank you in advance!