### PR TITLE
Reminder day preference fix

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
@@ -32,6 +32,9 @@ import com.health.openscale.R;
 import com.health.openscale.core.alarm.AlarmHandler;
 import com.health.openscale.core.alarm.ReminderBootReceiver;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class ReminderPreferences extends PreferenceFragmentCompat
         implements SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -55,7 +58,9 @@ public class ReminderPreferences extends PreferenceFragmentCompat
         prefDays.setSummaryProvider(new Preference.SummaryProvider<MultiSelectListPreference>() {
             @Override
             public CharSequence provideSummary(MultiSelectListPreference preference) {
-                return preference.getValues().toString();
+                return Arrays.stream(getResources().getStringArray(R.array.weekdays_values))
+                    .filter(preference.getValues()::contains)
+                    .collect(Collectors.joining(", "));
             }
         });
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
@@ -19,6 +19,7 @@ import android.content.ComponentName;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.util.Pair;
 import android.view.Menu;
 import android.view.MenuInflater;
 
@@ -32,8 +33,8 @@ import com.health.openscale.R;
 import com.health.openscale.core.alarm.AlarmHandler;
 import com.health.openscale.core.alarm.ReminderBootReceiver;
 
-import java.util.Arrays;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ReminderPreferences extends PreferenceFragmentCompat
         implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -58,8 +59,13 @@ public class ReminderPreferences extends PreferenceFragmentCompat
         prefDays.setSummaryProvider(new Preference.SummaryProvider<MultiSelectListPreference>() {
             @Override
             public CharSequence provideSummary(MultiSelectListPreference preference) {
-                return Arrays.stream(getResources().getStringArray(R.array.weekdays_values))
-                    .filter(preference.getValues()::contains)
+                final String[] values = getResources().getStringArray(R.array.weekdays_values);
+                final String[] translated = getResources().getStringArray(R.array.weekdays_entries);
+
+                return IntStream.range(0, values.length)
+                    .mapToObj(i -> new Pair<>(values[i], translated[i]))
+                    .filter(p -> preference.getValues().contains(p.first))
+                    .map(p -> p.second)
                     .collect(Collectors.joining(", "));
             }
         });


### PR DESCRIPTION
The reminder day preference summary was listing the days out of order, and also always using the english text of the values. I've also removed the square brackets around the list, I thought it made it look a bit like debug output.

Before:

![Screenshot_1609194427](https://user-images.githubusercontent.com/75810211/103246638-23b7d080-495c-11eb-8142-84300f95c2a7.png)

After:
![Screenshot_1609194522](https://user-images.githubusercontent.com/75810211/103246639-24506700-495c-11eb-9356-a848fcece9bf.png)
![Screenshot_1609194539](https://user-images.githubusercontent.com/75810211/103246640-24506700-495c-11eb-8b19-36bfb507f5eb.png)
