### PR TITLE
Replace %i format specifier with %d

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothStandardWeightProfile.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothStandardWeightProfile.java
@@ -184,7 +184,7 @@ public class BluetoothStandardWeightProfile extends BluetoothCommunication {
 
         if(userIDPresent) {
             int userID = parser.getIntValue(BluetoothBytesParser.FORMAT_UINT8);
-            Timber.d(String.format("User id: %i", userID));
+            Timber.d(String.format("User id: %d", userID));
         }
 
         if(bmiAndHeightPresent) {
@@ -228,7 +228,7 @@ public class BluetoothStandardWeightProfile extends BluetoothCommunication {
         // Read userID if present
         if (userIDPresent) {
             int userID = parser.getIntValue(BluetoothBytesParser.FORMAT_UINT8);
-            Timber.d(String.format("user id: %i", userID));
+            Timber.d(String.format("user id: %d", userID));
         }
 
         // Read bmr if present


### PR DESCRIPTION
`%i` is not a valid format specifier in Java and if this code is executed creates an exception. Use `%d` instead.

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>