### PR TITLE
SBF70: Make BeurerSanitas state machine more robust

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerSanitas.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerSanitas.java
@@ -308,6 +308,7 @@ public class BluetoothBeurerSanitas extends BluetoothCommunication {
             Timber.d("Received user %d/%d: %s (%d)", current, count, name, year);
         }
 
+        Timber.d("Sending ack for User Info");
         sendAck(data);
 
         if (current != count) {
@@ -359,6 +360,7 @@ public class BluetoothBeurerSanitas extends BluetoothCommunication {
 
         processMeasurementData(data, 4, current % 2 == 1);
 
+        Timber.d("Sending ack for Saved Measurements");
         sendAck(data);
 
         if (current == count) {
@@ -402,12 +404,17 @@ public class BluetoothBeurerSanitas extends BluetoothCommunication {
             }
         }
         else {
-            processMeasurementData(data, 4, current == 2);
+            // Process data, but only when we were able to identify the remote user on the first message
+            if( currentRemoteUser != null ) processMeasurementData(data, 4, current == 2);
+            else Timber.i("Discarded measurement, because no matching remote user found in first part.");
         }
 
+        // Even if we did not process the data, always ack the message
+        Timber.d("Sending ack for Measurement");
         sendAck(data);
 
-        if (current == count) {
+        // Delete saved measurement, but only when we processed it before
+        if (current == count && currentRemoteUser != null) {
             sendCommand(CMD_DELETE_SAVED_MEASUREMENTS, encodeUserId(currentRemoteUser));
         }
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
@@ -212,6 +212,16 @@ public abstract class BluetoothCommunication {
     }
 
     /**
+     * Call this function to decrement the current step counter of the state machine by one.
+     * Usually, if you call this function followed by resumeMachineState(), the current step will be repeated.
+     * Call multiple times to actually go back in time to previous steps.
+     */
+    protected synchronized void jumpBackOneStep() {
+        stepNr--;
+        Timber.d("Jumped back one step to " + stepNr);
+    }
+
+    /**
      * Write a byte array to a Bluetooth device.
      *
      * @param characteristic the Bluetooth UUID characteristic

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
@@ -173,9 +173,40 @@ public abstract class BluetoothCommunication {
         nextMachineStep();
     }
 
+    /**
+     * This function only resumes the state machine if the current step equals curStep,
+     * i.e. if the next step (stepNr) is 1 above curStep.
+     */
+    protected synchronized boolean resumeMachineState( int curStep ) {
+        if( curStep == stepNr-1 ) {
+            Timber.d("curStep " + curStep + " matches stepNr " + stepNr + "-1, resume state machine.");
+            stopped = false;
+            nextMachineStep();
+            return true;
+        }
+        else {
+            Timber.d("curStep " + curStep + " does not match stepNr " + stepNr + "-1, not resuming state machine.");
+            return false;
+        }
+    }
+
     protected synchronized void jumpNextToStepNr(int nr) {
         Timber.d("Jump next to step nr " + nr);
         stepNr = nr;
+    }
+
+    /**
+     * This function jumps to the step newStepNr only if the current step equals curStepNr,
+     * i.e. if the next step (stepNr) is 1 above curStepNr
+     */
+    protected synchronized void jumpNextToStepNr( int curStepNr, int newStepNr ) {
+        if( curStepNr == stepNr-1 ) {
+            Timber.d("curStepNr " + curStepNr + " matches stepNr " + stepNr + "-1, jumping next to step nr " + newStepNr);
+            stepNr = newStepNr;
+        }
+        else {
+            Timber.d("curStepNr " + curStepNr + " does not match stepNr " + stepNr + "-1, keeping next at step nr " + stepNr);
+        }
     }
 
     /**

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothCommunication.java
@@ -199,13 +199,15 @@ public abstract class BluetoothCommunication {
      * This function jumps to the step newStepNr only if the current step equals curStepNr,
      * i.e. if the next step (stepNr) is 1 above curStepNr
      */
-    protected synchronized void jumpNextToStepNr( int curStepNr, int newStepNr ) {
+    protected synchronized boolean jumpNextToStepNr( int curStepNr, int newStepNr ) {
         if( curStepNr == stepNr-1 ) {
             Timber.d("curStepNr " + curStepNr + " matches stepNr " + stepNr + "-1, jumping next to step nr " + newStepNr);
             stepNr = newStepNr;
+            return true;
         }
         else {
             Timber.d("curStepNr " + curStepNr + " does not match stepNr " + stepNr + "-1, keeping next at step nr " + stepNr);
+            return false;
         }
     }
 


### PR DESCRIPTION
The SBF70 has three bad habits:
- It sends the scale status reply multiple times (three, as it seems).
- When the user is standing on the scale, measurement are sent out unrequested.
- In both situations the scale ignores other commands.

Previously, the BeurerSanitas state machine was not robust against those effects:
- When it received messages that didn't not match the current state, it sometimes still advanced to the next state. This caused missing information and undefined behavior in later steps.
- When it sent out a request while the scale was busy with something other, the request got lost, the state machine never received the required answer and it got stuck in a state.
- When a measurement message was received before the user list was compiled, a null dereference cause an unhandled exception and the state machine stopped working.

With the attached patches the state machine will:
- Ignore / discard measurement messages before the user list is compiled.
- Retries at least some states when unexpected messages are received.

I think there will still be a lot of corner cases and timing problems that may cause unexpected behavior, crashes or stuck state machines, but it should happen a lot less frequently now.

I do not think that it will break other BeurerSanitas scales, but I cannot test this. So if there are reports, notify me and I'll try to take care about it.

This should fix #717.