### PR TITLE
Save body water as percentage instead of kg on BF105

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerBF105.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothBeurerBF105.java
@@ -25,6 +25,7 @@ import static com.welie.blessed.BluetoothBytesParser.FORMAT_UINT8;
 
 import android.content.Context;
 
+import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.welie.blessed.BluetoothBytesParser;
 
 import java.util.UUID;
@@ -80,6 +81,20 @@ public class BluetoothBeurerBF105 extends BluetoothStandardWeightProfile {
         else {
             super.onBluetoothNotify(characteristic, value);
         }
+    }
+
+    @Override
+    protected ScaleMeasurement bodyCompositionMeasurementToScaleMeasurement(byte[] value) {
+        ScaleMeasurement measurement = super.bodyCompositionMeasurementToScaleMeasurement(value);
+        float weight = measurement.getWeight();
+        if (weight == 0.f && previousMeasurement != null) {
+            weight = previousMeasurement.getWeight();
+        }
+        if (weight != 0.f) {
+            float water = Math.round(((measurement.getWater() / weight) * 10000.f))/100.f;
+            measurement.setWater(water);
+        }
+        return measurement;
     }
 
     @Override


### PR DESCRIPTION
The BF105 reports the body water in kg while the app (and the scale) displays body water as percentage.
This pull request converts the received value so that it is displayed correctly.
As I was unsure if this issue also applies to the other Beurer scales that inherit from the BluetoothStandardWeightProfile I put the fix into the BF105 specific class.