### PR TITLE
Support Sinocare CW286 bluetooth bathroom scales

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -130,6 +130,9 @@ public class BluetoothFactory {
         if (deviceName.equals("SBF72")) {
             return new BluetoothSanitasSBF72(context);
         }
+        if (deviceName.equals("Weight Scale")){
+            return new BluetoothSinocare(context);
+        }
         return null;
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -24,6 +24,15 @@ public class BluetoothSinocare extends BluetoothCommunication {
 
     private static final int WEIGHT_MSB = 10;
     private static final int WEIGHT_LSB = 9;
+
+    // the number of consecutive times the same weight should be seen before it is considered "final"
+    private static final int WEIGHT_TRIGGER_THRESHOLD = 9;
+
+    //these values are used to check for whether the scale's weight reading has leveled out since
+    // the scale doesnt appear to communicate when it has a solid reading.
+    private static int last_seen_weight = 0;
+    private static int last_wait_repeat_count = 0;
+
     private BluetoothCentralManager central;
     private final BluetoothCentralManagerCallback btCallback = new BluetoothCentralManagerCallback() {
         @Override

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -38,7 +38,7 @@ public class BluetoothSinocare extends BluetoothCommunication {
         @Override
         public void onDiscoveredPeripheral(@NotNull BluetoothPeripheral peripheral, @NotNull ScanResult scanResult) {
         SparseArray<byte[]> manufacturerSpecificData = scanResult.getScanRecord().getManufacturerSpecificData();
-            byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID);//maybe FF64? 64FF?
+            byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID);
             float divider = 100.0f;
             int weight = data[WEIGHT_MSB] & 0xff;
             weight = weight << 8 | (data[WEIGHT_LSB] & 0xff);

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -25,6 +25,8 @@ public class BluetoothSinocare extends BluetoothCommunication {
     private static final int WEIGHT_MSB = 10;
     private static final int WEIGHT_LSB = 9;
 
+    private static final int CHECKSUM_INDEX = 16;
+
     // the number of consecutive times the same weight should be seen before it is considered "final"
     private static final int WEIGHT_TRIGGER_THRESHOLD = 9;
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -42,6 +42,22 @@ public class BluetoothSinocare extends BluetoothCommunication {
             float divider = 100.0f;
             int weight = data[WEIGHT_MSB] & 0xff;
             weight = weight << 8 | (data[WEIGHT_LSB] & 0xff);
+            if (weight > 0){
+                if (weight != last_seen_weight) {
+                    //record the current weight and reset the count for mow many times that value has been seen
+                    last_seen_weight = weight;
+                    last_wait_repeat_count = 1;
+                } else if (weight == last_seen_weight && last_wait_repeat_count >= WEIGHT_TRIGGER_THRESHOLD){
+                    // record the weight
+                    ScaleMeasurement entry = new ScaleMeasurement();
+                    entry.setWeight(last_seen_weight / divider);
+                    addScaleMeasurement(entry);
+                    disconnect();
+                } else {
+                    //increment the counter for the number of times this weight value has been seen
+                    last_wait_repeat_count += 1;
+                }
+            }
         }
     };
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -20,7 +20,7 @@ import java.util.List;
 import timber.log.Timber;
 
 public class BluetoothSinocare extends BluetoothCommunication {
-    private static final int MANUFACTURER_DATA_ID = 0xe5ec; // 16-bit little endian "header"
+    private static final int MANUFACTURER_DATA_ID = 0xff64; // 16-bit little endian "header"
 
     private BluetoothCentralManager central;
     private final BluetoothCentralManagerCallback btCallback = new BluetoothCentralManagerCallback() {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -49,13 +49,6 @@ public class BluetoothSinocare extends BluetoothCommunication {
         ScanFilter.Builder b = new ScanFilter.Builder();
         b.setDeviceAddress(macAddress);
 
-        b.setDeviceName("ADV");
-        b.setManufacturerData(MANUFACTURER_DATA_ID_V20, null, null);
-        filters.add(b.build());
-
-        b.setDeviceName("Chipsea-BLE");
-        b.setManufacturerData(MANUFACTURER_DATA_ID_V11, null, null);
-        filters.add(b.build());
 
         central.scanForPeripheralsUsingFilters(filters);
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -1,0 +1,164 @@
+package com.health.openscale.core.bluetooth;
+
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanResult;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.SparseArray;
+
+import com.health.openscale.core.datatypes.ScaleMeasurement;
+import com.welie.blessed.BluetoothCentralManager;
+import com.welie.blessed.BluetoothCentralManagerCallback;
+import com.welie.blessed.BluetoothPeripheral;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import timber.log.Timber;
+
+public class BluetoothOKOK extends BluetoothCommunication {
+    private static final int MANUFACTURER_DATA_ID_V20 = 0x20ca; // 16-bit little endian "header" 0xca 0x20
+    private static final int MANUFACTURER_DATA_ID_V11 = 0x11ca; // 16-bit little endian "header" 0xca 0x11
+    private static final int IDX_V20_FINAL = 6;
+    private static final int IDX_V20_WEIGHT_MSB = 8;
+    private static final int IDX_V20_WEIGHT_LSB = 9;
+    private static final int IDX_V20_IMPEDANCE_MSB = 10;
+    private static final int IDX_V20_IMPEDANCE_LSB = 11;
+    private static final int IDX_V20_CHECKSUM = 12;
+
+    private static final int IDX_V11_WEIGHT_MSB = 3;
+    private static final int IDX_V11_WEIGHT_LSB = 4;
+    private static final int IDX_V11_BODY_PROPERTIES = 9;
+    private static final int IDX_V11_CHECKSUM = 16;
+
+    private BluetoothCentralManager central;
+    private final BluetoothCentralManagerCallback btCallback = new BluetoothCentralManagerCallback() {
+        @Override
+        public void onDiscoveredPeripheral(@NotNull BluetoothPeripheral peripheral, @NotNull ScanResult scanResult) {
+        SparseArray<byte[]> manufacturerSpecificData = scanResult.getScanRecord().getManufacturerSpecificData();
+	    if (manufacturerSpecificData.indexOfKey(MANUFACTURER_DATA_ID_V20) > -1) {
+                byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID_V20);
+                float divider = 10.0f;
+                byte checksum = 0x20; // Version field is part of the checksum, but not in array
+                if (data == null || data.length != 19)
+                    return;
+                if ((data[IDX_V20_FINAL] & 1) == 0)
+                    return;
+                for (int i = 0; i < IDX_V20_CHECKSUM; i++)
+                    checksum ^= data[i];
+                if (data[IDX_V20_CHECKSUM] != checksum) {
+                    Timber.d("Checksum error, got %x, expected %x", data[IDX_V20_CHECKSUM] & 0xff, checksum & 0xff);
+                    return;
+                }
+                if ((data[IDX_V20_FINAL] & 4) == 4)
+                    divider = 100.0f;
+                int weight = data[IDX_V20_WEIGHT_MSB] & 0xff;
+                weight = weight << 8 | (data[IDX_V20_WEIGHT_LSB] & 0xff);
+                int impedance = data[IDX_V20_IMPEDANCE_MSB] & 0xff;
+                impedance = impedance << 8 | (data[IDX_V20_IMPEDANCE_LSB] & 0xff);
+                Timber.d("Got weight: %f and impedance %f", weight / divider, impedance / 10f);
+                ScaleMeasurement entry = new ScaleMeasurement();
+                entry.setWeight(weight / divider);
+                addScaleMeasurement(entry);
+                disconnect();
+            } else if (manufacturerSpecificData.indexOfKey(MANUFACTURER_DATA_ID_V11) > -1) {
+                byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID_V11);
+                float divider = 10.0f;
+                float extraWeight = 0;
+                byte checksum = (byte)0xca ^ (byte)0x11; // Version and magic fields are part of the checksum, but not in array
+                if (data == null || data.length != IDX_V11_CHECKSUM + 6 + 1)
+                    return;
+                for (int i = 0; i < IDX_V11_CHECKSUM; i++)
+                    checksum ^= data[i];
+                if (data[IDX_V11_CHECKSUM] != checksum) {
+                    Timber.d("Checksum error, got %x, expected %x", data[IDX_V11_CHECKSUM] & 0xff, checksum & 0xff);
+                    return;
+                }
+
+                int weight = data[IDX_V11_WEIGHT_MSB] & 0xff;
+                weight = weight << 8 | (data[IDX_V11_WEIGHT_LSB] & 0xff);
+
+                switch ((data[IDX_V11_BODY_PROPERTIES] >> 1) & 3) {
+                default:
+                    Timber.w("Invalid weight scale received, assuming 1 decimal");
+                    /* fall-through */
+                case 0:
+                    divider = 10.0f;
+                    break;
+                case 1:
+                    divider = 1.0f;
+                    break;
+                case 2:
+                    divider = 100.0f;
+                    break;
+                }
+
+                switch ((data[IDX_V11_BODY_PROPERTIES] >> 3) & 3) {
+                case 0: // kg
+                    break;
+                case 1: // Jin
+                    divider *= 2;
+                    break;
+                case 3: // st & lb
+                    extraWeight = (weight >> 8) * 6.350293f;
+                    weight &= 0xff;
+                    /* fall-through */
+                case 2: // lb
+                    divider *= 2.204623;
+                    break;
+                }
+                Timber.d("Got weight: %f", weight / divider);
+                ScaleMeasurement entry = new ScaleMeasurement();
+                entry.setWeight(extraWeight + weight / divider);
+                addScaleMeasurement(entry);
+                disconnect();
+            }
+        }
+    };
+
+    public BluetoothOKOK(Context context)
+    {
+        super(context);
+        central = new BluetoothCentralManager(context, btCallback, new Handler(Looper.getMainLooper()));
+    }
+
+    @Override
+    public String driverName() {
+        return "OKOK";
+    }
+
+    @Override
+    public void connect(String macAddress) {
+        Timber.d("Mac address: %s", macAddress);
+        List<ScanFilter> filters = new LinkedList<ScanFilter>();
+
+        ScanFilter.Builder b = new ScanFilter.Builder();
+        b.setDeviceAddress(macAddress);
+
+        b.setDeviceName("ADV");
+        b.setManufacturerData(MANUFACTURER_DATA_ID_V20, null, null);
+        filters.add(b.build());
+
+        b.setDeviceName("Chipsea-BLE");
+        b.setManufacturerData(MANUFACTURER_DATA_ID_V11, null, null);
+        filters.add(b.build());
+
+        central.scanForPeripheralsUsingFilters(filters);
+    }
+
+    @Override
+    public void disconnect() {
+        if (central != null)
+            central.stopScan();
+        central = null;
+        super.disconnect();
+    }
+
+    @Override
+    protected boolean onNextStep(int stepNr) {
+        return false;
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -22,11 +22,17 @@ import timber.log.Timber;
 public class BluetoothSinocare extends BluetoothCommunication {
     private static final int MANUFACTURER_DATA_ID = 0xff64; // 16-bit little endian "header"
 
+    private static final int WEIGHT_MSB = 10;
+    private static final int WEIGHT_LSB = 9;
     private BluetoothCentralManager central;
     private final BluetoothCentralManagerCallback btCallback = new BluetoothCentralManagerCallback() {
         @Override
         public void onDiscoveredPeripheral(@NotNull BluetoothPeripheral peripheral, @NotNull ScanResult scanResult) {
         SparseArray<byte[]> manufacturerSpecificData = scanResult.getScanRecord().getManufacturerSpecificData();
+            byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID);//maybe FF64? 64FF?
+            float divider = 100.0f;
+            int weight = data[WEIGHT_MSB] & 0xff;
+            weight = weight << 8 | (data[WEIGHT_LSB] & 0xff);
         }
     };
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -55,6 +55,9 @@ public class BluetoothSinocare extends BluetoothCommunication {
         ScanFilter.Builder b = new ScanFilter.Builder();
         b.setDeviceAddress(macAddress);
 
+        b.setDeviceName("Weight Scale");
+        b.setManufacturerData(MANUFACTURER_DATA_ID, null, null);
+        filters.add(b.build());
 
         central.scanForPeripheralsUsingFilters(filters);
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -51,6 +51,12 @@ public class BluetoothSinocare extends BluetoothCommunication {
                 Timber.d("Checksum error, got %x, expected %x", data[CHECKSUM_INDEX] & 0xff, checksum & 0xff);
                 return;
             }
+            // mac address is first 6 bytes, might be helpful if this needs to be capable of handling
+            // multiple scales at once. Is this a priority?
+//            byte[] macAddress = ;
+
+            //this is the "raw" weight as an integer number of dekagrams (1 dekagram is 0.01kg or 10 grams),
+            // regardless of what unit the scale is set to
             int weight = data[WEIGHT_MSB] & 0xff;
             weight = weight << 8 | (data[WEIGHT_LSB] & 0xff);
             if (weight > 0){

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import timber.log.Timber;
 
-public class BluetoothOKOK extends BluetoothCommunication {
+public class BluetoothSinocare extends BluetoothCommunication {
     private static final int MANUFACTURER_DATA_ID_V20 = 0x20ca; // 16-bit little endian "header" 0xca 0x20
     private static final int MANUFACTURER_DATA_ID_V11 = 0x11ca; // 16-bit little endian "header" 0xca 0x11
     private static final int IDX_V20_FINAL = 6;
@@ -119,7 +119,7 @@ public class BluetoothOKOK extends BluetoothCommunication {
         }
     };
 
-    public BluetoothOKOK(Context context)
+    public BluetoothSinocare(Context context)
     {
         super(context);
         central = new BluetoothCentralManager(context, btCallback, new Handler(Looper.getMainLooper()));
@@ -127,7 +127,7 @@ public class BluetoothOKOK extends BluetoothCommunication {
 
     @Override
     public String driverName() {
-        return "OKOK";
+        return "Sinocare";
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -20,102 +20,13 @@ import java.util.List;
 import timber.log.Timber;
 
 public class BluetoothSinocare extends BluetoothCommunication {
-    private static final int MANUFACTURER_DATA_ID_V20 = 0x20ca; // 16-bit little endian "header" 0xca 0x20
-    private static final int MANUFACTURER_DATA_ID_V11 = 0x11ca; // 16-bit little endian "header" 0xca 0x11
-    private static final int IDX_V20_FINAL = 6;
-    private static final int IDX_V20_WEIGHT_MSB = 8;
-    private static final int IDX_V20_WEIGHT_LSB = 9;
-    private static final int IDX_V20_IMPEDANCE_MSB = 10;
-    private static final int IDX_V20_IMPEDANCE_LSB = 11;
-    private static final int IDX_V20_CHECKSUM = 12;
-
-    private static final int IDX_V11_WEIGHT_MSB = 3;
-    private static final int IDX_V11_WEIGHT_LSB = 4;
-    private static final int IDX_V11_BODY_PROPERTIES = 9;
-    private static final int IDX_V11_CHECKSUM = 16;
+    private static final int MANUFACTURER_DATA_ID = 0xe5ec; // 16-bit little endian "header"
 
     private BluetoothCentralManager central;
     private final BluetoothCentralManagerCallback btCallback = new BluetoothCentralManagerCallback() {
         @Override
         public void onDiscoveredPeripheral(@NotNull BluetoothPeripheral peripheral, @NotNull ScanResult scanResult) {
         SparseArray<byte[]> manufacturerSpecificData = scanResult.getScanRecord().getManufacturerSpecificData();
-	    if (manufacturerSpecificData.indexOfKey(MANUFACTURER_DATA_ID_V20) > -1) {
-                byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID_V20);
-                float divider = 10.0f;
-                byte checksum = 0x20; // Version field is part of the checksum, but not in array
-                if (data == null || data.length != 19)
-                    return;
-                if ((data[IDX_V20_FINAL] & 1) == 0)
-                    return;
-                for (int i = 0; i < IDX_V20_CHECKSUM; i++)
-                    checksum ^= data[i];
-                if (data[IDX_V20_CHECKSUM] != checksum) {
-                    Timber.d("Checksum error, got %x, expected %x", data[IDX_V20_CHECKSUM] & 0xff, checksum & 0xff);
-                    return;
-                }
-                if ((data[IDX_V20_FINAL] & 4) == 4)
-                    divider = 100.0f;
-                int weight = data[IDX_V20_WEIGHT_MSB] & 0xff;
-                weight = weight << 8 | (data[IDX_V20_WEIGHT_LSB] & 0xff);
-                int impedance = data[IDX_V20_IMPEDANCE_MSB] & 0xff;
-                impedance = impedance << 8 | (data[IDX_V20_IMPEDANCE_LSB] & 0xff);
-                Timber.d("Got weight: %f and impedance %f", weight / divider, impedance / 10f);
-                ScaleMeasurement entry = new ScaleMeasurement();
-                entry.setWeight(weight / divider);
-                addScaleMeasurement(entry);
-                disconnect();
-            } else if (manufacturerSpecificData.indexOfKey(MANUFACTURER_DATA_ID_V11) > -1) {
-                byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID_V11);
-                float divider = 10.0f;
-                float extraWeight = 0;
-                byte checksum = (byte)0xca ^ (byte)0x11; // Version and magic fields are part of the checksum, but not in array
-                if (data == null || data.length != IDX_V11_CHECKSUM + 6 + 1)
-                    return;
-                for (int i = 0; i < IDX_V11_CHECKSUM; i++)
-                    checksum ^= data[i];
-                if (data[IDX_V11_CHECKSUM] != checksum) {
-                    Timber.d("Checksum error, got %x, expected %x", data[IDX_V11_CHECKSUM] & 0xff, checksum & 0xff);
-                    return;
-                }
-
-                int weight = data[IDX_V11_WEIGHT_MSB] & 0xff;
-                weight = weight << 8 | (data[IDX_V11_WEIGHT_LSB] & 0xff);
-
-                switch ((data[IDX_V11_BODY_PROPERTIES] >> 1) & 3) {
-                default:
-                    Timber.w("Invalid weight scale received, assuming 1 decimal");
-                    /* fall-through */
-                case 0:
-                    divider = 10.0f;
-                    break;
-                case 1:
-                    divider = 1.0f;
-                    break;
-                case 2:
-                    divider = 100.0f;
-                    break;
-                }
-
-                switch ((data[IDX_V11_BODY_PROPERTIES] >> 3) & 3) {
-                case 0: // kg
-                    break;
-                case 1: // Jin
-                    divider *= 2;
-                    break;
-                case 3: // st & lb
-                    extraWeight = (weight >> 8) * 6.350293f;
-                    weight &= 0xff;
-                    /* fall-through */
-                case 2: // lb
-                    divider *= 2.204623;
-                    break;
-                }
-                Timber.d("Got weight: %f", weight / divider);
-                ScaleMeasurement entry = new ScaleMeasurement();
-                entry.setWeight(extraWeight + weight / divider);
-                addScaleMeasurement(entry);
-                disconnect();
-            }
         }
     };
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSinocare.java
@@ -40,6 +40,15 @@ public class BluetoothSinocare extends BluetoothCommunication {
         SparseArray<byte[]> manufacturerSpecificData = scanResult.getScanRecord().getManufacturerSpecificData();
             byte[] data = manufacturerSpecificData.get(MANUFACTURER_DATA_ID);
             float divider = 100.0f;
+            byte checksum = 0x00;
+            //the checksum here only covers the data that is between the MAC address and the checksum
+            //this should be bytes at indices 6-15 (both inclusive)
+            for (int i = 6; i < CHECKSUM_INDEX; i++)
+                checksum ^= data[i];
+            if (data[CHECKSUM_INDEX] != checksum) {
+                Timber.d("Checksum error, got %x, expected %x", data[CHECKSUM_INDEX] & 0xff, checksum & 0xff);
+                return;
+            }
             int weight = data[WEIGHT_MSB] & 0xff;
             weight = weight << 8 | (data[WEIGHT_LSB] & 0xff);
             if (weight > 0){


### PR DESCRIPTION
This PR adds support for the Sinocare [CW266 Digital bluetooth bathroom scale](https://en.sinocare.com/products/sinocare-digital-bathroom-scales-weighing-scale-high-precision-sensors-bluetooth-health-analyzer-with-smart-app-body-weight-scale).

This scale appears to be similar in operation to the scale added in #706 with regard to the contents of [this](https://github.com/oliexdev/openScale/pull/706#issuecomment-790393142) comment which basically says the scale only uses the manufacturer data field to broadcast data using bluetooth's Advertising mechanism and does not offer a proper service for accessing these values. The same is true for this scale and I suspect the reason for this is that this sinocare scale has a rather short timeout of about 10 seconds before it turns off, making it hard for a user to connect and get the data before it turns itself off.

Also from that thread it appears that this is the second scale to operate this way
> ok that would be the first scale without an Bluetooth service but if its works I will merge it.


To my knowledge and the best of my wireshark/deduction skills based on the wiki (which to me seems like it may be a little out of date regarding the process of getting the bluetooth packet capture) this scale only supports advertising weight values. Because i couldnt find any solid evidence for the data format, this (and a checksum) is all i have implemented, but my limited testing seems to suggest that it works well enough.

Because of a lack of reliable indication that the scale is "done" measuring (i.e. users weight has stabilized) this implementation checks for this based on receiving a sequence of many identical weight values in a row. I admit this is not ideal and should be updated once better information about the operation of this scale is known.


Hopefully this explains the bulk of how this scale operates, let me know if you have questions or need me to make any changes!