### PR TITLE
Support for Silvercrest SBF76 (Same as Beurer BF105, BF600, BF850, BF950 and Silvercrest SBF77)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -124,7 +124,7 @@ public class BluetoothFactory {
         if (deviceName.equals("BF600") || deviceName.equals("BF850")) {
             return new BluetoothBeurerBF600(context, deviceName);
         }
-        if (deviceName.equals("SBF77") || deviceName.equals("BF950")) {
+        if (deviceName.equals("SBF77") || deviceName.equals("SBF76") || deviceName.equals("BF950")) {
             return new BluetoothBeurerBF950(context, deviceName);
         }
         if (deviceName.equals("SBF72")) {


### PR DESCRIPTION
The support of Silvercrest SBF76 is the same as for Beurer BF105, BF600, BF850, BF950 and Silvercrest SBF77 (see https://github.com/oliexdev/openScale/pull/753). I just had to insert the deviceName and everything works. I tested the following functions:
- After resetting the scale I could successfully connect via Bluetooth (PIN exchange)
- The Users were also created (only the first letter is shown in the scale display)
- There is support for auto detecting a user. 
- All sensor values are transmitted and synced (weight, water, muscle, fat, bones)
- Multiple users are also supported and synced successfully

The following issue and pull request indicate also that the protocol should be the same overall the devices:
- https://github.com/oliexdev/openScale/pull/753
- https://github.com/oliexdev/openScale/issues/550

A picture of the scale:

![silvercrest-sbf76](https://user-images.githubusercontent.com/12826261/181081202-78eeebe5-bf4a-4127-a8b4-dd0e0e083510.png)