### PR TITLE
Support for Beurer BF915 (based on Sanitas SBF72).

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothFactory.java
@@ -127,8 +127,8 @@ public class BluetoothFactory {
         if (deviceName.equals("SBF77") || deviceName.equals("SBF76") || deviceName.equals("BF950")) {
             return new BluetoothBeurerBF950(context, deviceName);
         }
-        if (deviceName.equals("SBF72")) {
-            return new BluetoothSanitasSBF72(context);
+        if (deviceName.equals("SBF72") || deviceName.equals("BF915")) {
+            return new BluetoothSanitasSBF72(context, deviceName);
         }
         if (deviceName.equals("Weight Scale")){
             return new BluetoothSinocare(context);

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSBF72.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothSanitasSBF72.java
@@ -32,7 +32,7 @@ import timber.log.Timber;
 import static com.welie.blessed.BluetoothBytesParser.FORMAT_UINT8;
 
 public class BluetoothSanitasSBF72 extends BluetoothStandardWeightProfile {
-    private String deviceName = "SBF72";
+    private String deviceName;
 
     private static final UUID SERVICE_SBF72_CUSTOM = BluetoothGattUuid.fromShortCode(0xffff);
 
@@ -42,8 +42,9 @@ public class BluetoothSanitasSBF72 extends BluetoothStandardWeightProfile {
     private static final UUID CHARACTERISTIC_REFER_WEIGHT_BF = BluetoothGattUuid.fromShortCode(0x000b);
     private static final UUID CHARACTERISTIC_TAKE_MEASUREMENT = BluetoothGattUuid.fromShortCode(0x0006);
 
-    public BluetoothSanitasSBF72(Context context) {
+    public BluetoothSanitasSBF72(Context context, String name) {
         super(context);
+        deviceName = name;
     }
 
     @Override


### PR DESCRIPTION
The Beurer BF915 seems to work just like the Sanitas SBF72. I just had to add a constructor parameter for the device name.

I have successfully tested the following functions:

- Connection and initial setup
- Using users who have already been created on the scale (with pin confirmation)
- Data transmission (including history data)
- User auto detection