### PR TITLE
Simple moving average on the chart

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: "androidx.navigation.safeargs"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.health.openscale"
         testApplicationId "com.health.openscale.test"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 63
         versionName "2.5.1"
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -698,7 +698,7 @@ public class ChartMeasurementView extends LineChart {
 
 
     private void addMeasurementLineSimpleMovingAverage(List<ILineDataSet> lineDataSets, List<Entry> lineEntries, FloatMeasurementView measurementView) {
-        LineDataSet measurementLine = new LineDataSet(lineEntries, measurementView.getName().toString() + "-" + getContext().getString(R.string.label_simple_moving_average));
+        LineDataSet measurementLine = new LineDataSet(lineEntries, "");
         measurementLine.setLineWidth(1.5f);
         measurementLine.setValueTextSize(10.0f);
         measurementLine.setColor(measurementView.getColor());
@@ -713,6 +713,7 @@ public class ChartMeasurementView extends LineChart {
         measurementLine.setHighLightColor(Color.RED);
         measurementLine.setDrawCircles(false);//prefs.getBoolean("pointsEnable", true));
         measurementLine.setDrawValues(prefs.getBoolean("labelsEnable", false));
+        measurementLine.setForm(Legend.LegendForm.NONE);
 
         if (measurementView.isVisible()) {
             if (isInGraphKey) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -698,7 +698,7 @@ public class ChartMeasurementView extends LineChart {
 
 
     private void addMeasurementLineSimpleMovingAverage(List<ILineDataSet> lineDataSets, List<Entry> lineEntries, FloatMeasurementView measurementView) {
-        LineDataSet measurementLine = new LineDataSet(lineEntries, "");
+        LineDataSet measurementLine = new LineDataSet(lineEntries, measurementView.getName().toString() + "-" + getContext().getString(R.string.label_simple_moving_average));
         measurementLine.setLineWidth(1.5f);
         measurementLine.setValueTextSize(10.0f);
         measurementLine.setColor(measurementView.getColor());
@@ -713,7 +713,6 @@ public class ChartMeasurementView extends LineChart {
         measurementLine.setHighLightColor(Color.RED);
         measurementLine.setDrawCircles(false);//prefs.getBoolean("pointsEnable", true));
         measurementLine.setDrawValues(prefs.getBoolean("labelsEnable", false));
-        measurementLine.setForm(Legend.LegendForm.NONE);
 
         if (measurementView.isVisible()) {
             if (isInGraphKey) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -452,7 +452,7 @@ public class ChartMeasurementView extends LineChart {
         measurementLine.setDrawCircles(prefs.getBoolean("pointsEnable", true));
         measurementLine.setDrawValues(prefs.getBoolean("labelsEnable", false));
         measurementLine.setMode(LineDataSet.Mode.HORIZONTAL_BEZIER);
-        if (prefs.getBoolean("trendLine", false) || prefs.getBoolean("simpleMovingAverage", false)) {
+        if (prefs.getBoolean("trendLine", false)) {
             // show only data points if trend line or simple moving average is enabled
             measurementLine.enableDashedLine(0, 1, 0);
         }

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -16,7 +16,6 @@
 
 package com.health.openscale.gui.measurement;
 
-import static com.health.openscale.gui.preferences.utils.TrendlineComputationMethod.*;
 import static java.time.temporal.ChronoUnit.DAYS;
 
 import android.content.Context;
@@ -57,6 +56,9 @@ import java.util.List;
 import java.util.Stack;
 
 public class ChartMeasurementView extends LineChart {
+    public static final String COMPUTATION_METHOD_SIMPLE_MOVING_AVERAGE = "SimpleMovingAverage";
+    public static final String COMPUTATION_METHOD_EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE = "ExponentiallySmoothedMovingAverage";
+
     public enum ViewMode {
         DAY_OF_MONTH,
         WEEK_OF_MONTH,
@@ -400,12 +402,12 @@ public class ChartMeasurementView extends LineChart {
         }
 
         if (prefs.getBoolean("trendLine", false)) {
-            String selectedTrendLineComputationMethod = prefs.getString("trendlineComputationMethod", EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE);
+            String selectedTrendLineComputationMethod = prefs.getString("trendlineComputationMethod", COMPUTATION_METHOD_EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE);
             switch (selectedTrendLineComputationMethod) {
-                case EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE:
+                case COMPUTATION_METHOD_EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE:
                     addExponentiallySmoothedMovingAverage(lineDataSets);
                     break;
-                case SIMPLE_MOVING_AVERAGE:
+                case COMPUTATION_METHOD_SIMPLE_MOVING_AVERAGE:
                     addSimpleMovingAverage(lineDataSets);
                     break;
                 default:

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -550,7 +550,7 @@ public class ChartMeasurementView extends LineChart {
                     continue;
                 }
 
-                // calculate the trendline from the non-zero scale measurement list with interpolated missing days
+                // calculate the trendline from the non-zero scale measurement list
                 List<ScaleMeasurement> scaleMeasurementsAsTrendlineList = getScaleMeasurementsAsTrendline(nonZeroScaleMeasurementList);
 
                 final List<Entry> lineEntries = convertMeasurementsToLineEntries(measurementView, scaleMeasurementsAsTrendlineList);
@@ -594,7 +594,7 @@ public class ChartMeasurementView extends LineChart {
                     continue;
                 }
 
-                // calculate the simple moving average from the non-zero scale measurement list with interpolated missing days
+                // calculate the simple moving average from the non-zero scale measurement list
                 List<ScaleMeasurement> scaleMeasurementsAsMovingAverageList = getMovingAverageOfScaleMeasurements(nonZeroScaleMeasurementList);
 
                 final List<Entry> lineEntries = convertMeasurementsToLineEntries(measurementView, scaleMeasurementsAsMovingAverageList);

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -16,6 +16,7 @@
 
 package com.health.openscale.gui.measurement;
 
+import static com.health.openscale.gui.preferences.utils.TrendlineComputationMethod.*;
 import static java.time.temporal.ChronoUnit.DAYS;
 
 import android.content.Context;
@@ -43,6 +44,8 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
 import com.health.openscale.core.utils.PolynomialFitter;
+import com.health.openscale.gui.preferences.GraphPreferences;
+import com.health.openscale.gui.preferences.utils.TrendlineComputationMethod;
 import com.health.openscale.gui.utils.ColorUtil;
 
 import java.time.LocalDate;
@@ -77,7 +80,7 @@ public class ChartMeasurementView extends LineChart {
     private ProgressBar progressBar;
 
     private interface TrendlineComputationInterface {
-        public List<ScaleMeasurement> operation(List<ScaleMeasurement> measurementList);
+        public List<ScaleMeasurement> processMeasurements(List<ScaleMeasurement> measurementList);
     }
 
     public ChartMeasurementView(Context context) {
@@ -399,16 +402,17 @@ public class ChartMeasurementView extends LineChart {
         }
 
         if (prefs.getBoolean("trendLine", false)) {
-            switch (prefs.getString("trendlineComputationMethod", "Exponentially Smoothed Moving Average")) {
-                case "Exponentially Smoothed Moving Average":
+            String selectedTrendLineComputationMethod = prefs.getString("trendlineComputationMethod", EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE);
+            switch (selectedTrendLineComputationMethod) {
+                case EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE:
                     addExponentiallySmoothedMovingAverage(lineDataSets);
                     break;
-                case "Simple Moving Average":
+                case SIMPLE_MOVING_AVERAGE:
                     addSimpleMovingAverage(lineDataSets);
                     break;
                 default:
-                    addExponentiallySmoothedMovingAverage(lineDataSets); // by default fall back to exponentially smoothed in case the setting is magically set to something different
-                    break;
+                    addExponentiallySmoothedMovingAverage(lineDataSets);
+                    break; // by default fall back to exponentially smoothed moving average
             }
 
         }
@@ -570,7 +574,7 @@ public class ChartMeasurementView extends LineChart {
                 }
 
                 // calculate the trendline from the non-zero scale measurement list
-                List<ScaleMeasurement> scaleMeasurementsAsTrendlineList = trendlineComputation.operation(nonZeroScaleMeasurementList);
+                List<ScaleMeasurement> scaleMeasurementsAsTrendlineList = trendlineComputation.processMeasurements(nonZeroScaleMeasurementList);
 
                 final List<Entry> lineEntries = convertMeasurementsToLineEntries(measurementView, scaleMeasurementsAsTrendlineList);
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -44,8 +44,6 @@ import com.health.openscale.core.datatypes.ScaleMeasurement;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
 import com.health.openscale.core.utils.PolynomialFitter;
-import com.health.openscale.gui.preferences.GraphPreferences;
-import com.health.openscale.gui.preferences.utils.TrendlineComputationMethod;
 import com.health.openscale.gui.utils.ColorUtil;
 
 import java.time.LocalDate;

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
@@ -19,8 +19,6 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 
-import androidx.navigation.NavDirections;
-import androidx.navigation.Navigation;
 import androidx.preference.DropDownPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
@@ -25,7 +25,7 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SeekBarPreference;
 
 import com.health.openscale.R;
-import com.health.openscale.gui.preferences.utils.TrendlineComputationMethod;
+import com.health.openscale.gui.measurement.ChartMeasurementView;
 
 public class GraphPreferences extends PreferenceFragmentCompat {
     @Override
@@ -39,7 +39,7 @@ public class GraphPreferences extends PreferenceFragmentCompat {
 
         simpleMovingAveragePreference.setVisible(
                 trendlinePreference.getValue().equals(
-                        TrendlineComputationMethod.SIMPLE_MOVING_AVERAGE
+                        ChartMeasurementView.COMPUTATION_METHOD_SIMPLE_MOVING_AVERAGE
                 )
         );
 
@@ -48,7 +48,7 @@ public class GraphPreferences extends PreferenceFragmentCompat {
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 String selectedValue = (String) newValue;
                 boolean simpleMovingAverageEnabled = selectedValue.equals(
-                        TrendlineComputationMethod.SIMPLE_MOVING_AVERAGE
+                        ChartMeasurementView.COMPUTATION_METHOD_SIMPLE_MOVING_AVERAGE
                 );
 
                 // hide selector of the number of days when simple moving average is not selected

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
@@ -19,7 +19,12 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 
+import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
+import androidx.preference.DropDownPreference;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SeekBarPreference;
 
 import com.health.openscale.R;
 
@@ -29,6 +34,24 @@ public class GraphPreferences extends PreferenceFragmentCompat {
         setPreferencesFromResource(R.xml.graph_preferences, rootKey);
 
         setHasOptionsMenu(true);
+
+        DropDownPreference trendlinePreference = findPreference("trendlineComputationMethod");
+        SeekBarPreference simpleMovingAveragePreference = findPreference("simpleMovingAverageNumDays");
+
+        simpleMovingAveragePreference.setVisible(trendlinePreference.getValue().equals("Simple Moving Average"));
+
+        trendlinePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                String selectedValue = (String) newValue;
+                boolean simpleMovingAverageEnabled = selectedValue.equals("Simple Moving Average");
+
+                // Enable or disable the simpleMovingAveragePreference based on the selected value
+                simpleMovingAveragePreference.setVisible(simpleMovingAverageEnabled);
+
+                return true;
+            }
+        });
     }
 
     @Override

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
@@ -27,6 +27,7 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SeekBarPreference;
 
 import com.health.openscale.R;
+import com.health.openscale.gui.preferences.utils.TrendlineComputationMethod;
 
 public class GraphPreferences extends PreferenceFragmentCompat {
     @Override
@@ -38,15 +39,21 @@ public class GraphPreferences extends PreferenceFragmentCompat {
         DropDownPreference trendlinePreference = findPreference("trendlineComputationMethod");
         SeekBarPreference simpleMovingAveragePreference = findPreference("simpleMovingAverageNumDays");
 
-        simpleMovingAveragePreference.setVisible(trendlinePreference.getValue().equals("Simple Moving Average"));
+        simpleMovingAveragePreference.setVisible(
+                trendlinePreference.getValue().equals(
+                        TrendlineComputationMethod.SIMPLE_MOVING_AVERAGE
+                )
+        );
 
         trendlinePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 String selectedValue = (String) newValue;
-                boolean simpleMovingAverageEnabled = selectedValue.equals("Simple Moving Average");
+                boolean simpleMovingAverageEnabled = selectedValue.equals(
+                        TrendlineComputationMethod.SIMPLE_MOVING_AVERAGE
+                );
 
-                // Enable or disable the simpleMovingAveragePreference based on the selected value
+                // hide selector of the number of days when simple moving average is not selected
                 simpleMovingAveragePreference.setVisible(simpleMovingAverageEnabled);
 
                 return true;

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/GraphPreferences.java
@@ -53,6 +53,8 @@ public class GraphPreferences extends PreferenceFragmentCompat {
 
                 // hide selector of the number of days when simple moving average is not selected
                 simpleMovingAveragePreference.setVisible(simpleMovingAverageEnabled);
+                // scroll to the bottom to show the new preference to the user
+                getListView().scrollToPosition(getListView().getChildCount());
 
                 return true;
             }

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
@@ -1,0 +1,8 @@
+package com.health.openscale.gui.preferences.utils;
+
+import androidx.annotation.NonNull;
+
+public class TrendlineComputationMethod{
+    public static final String SIMPLE_MOVING_AVERAGE = "SimpleMovingAverage";
+    public static final String EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE = "ExponentiallySmoothedMovingAverage";
+}

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
@@ -1,7 +1,5 @@
 package com.health.openscale.gui.preferences.utils;
 
-import androidx.annotation.NonNull;
-
 public class TrendlineComputationMethod{
     public static final String SIMPLE_MOVING_AVERAGE = "SimpleMovingAverage";
     public static final String EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE = "ExponentiallySmoothedMovingAverage";

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/utils/TrendlineComputationMethod.java
@@ -1,6 +1,0 @@
-package com.health.openscale.gui.preferences.utils;
-
-public class TrendlineComputationMethod{
-    public static final String SIMPLE_MOVING_AVERAGE = "SimpleMovingAverage";
-    public static final String EXPONENTIALLY_SMOOTHED_MOVING_AVERAGE = "ExponentiallySmoothedMovingAverage";
-}

--- a/android_app/app/src/main/res/values/arrays.xml
+++ b/android_app/app/src/main/res/values/arrays.xml
@@ -120,8 +120,8 @@
     </string-array>
 
     <string-array name="trendline_computation_methods_entries">
-        <item>@string/simple_moving_average</item>
-        <item>@string/exponentially_smoothed_moving_average</item>
+        <item>@string/label_simple_moving_average</item>
+        <item>@string/label_exponentially_smoothed_moving_average</item>
     </string-array>
 
     <string-array name="trendline_computation_methods_values">

--- a/android_app/app/src/main/res/values/arrays.xml
+++ b/android_app/app/src/main/res/values/arrays.xml
@@ -125,7 +125,7 @@
     </string-array>
 
     <string-array name="trendline_computation_methods_values">
-        <item>Simple Moving Average</item>
-        <item>Exponentially Smoothed Moving Average</item>
+        <item>SimpleMovingAverage</item>
+        <item>ExponentiallySmoothedMovingAverage</item>
     </string-array>
 </resources>

--- a/android_app/app/src/main/res/values/arrays.xml
+++ b/android_app/app/src/main/res/values/arrays.xml
@@ -118,4 +118,14 @@
         <item>@string/label_time_period_set_reference_day</item>
         <item>@string/label_time_period_set_custom_range</item>
     </string-array>
+
+    <string-array name="trendline_computation_methods_entries">
+        <item>@string/simple_moving_average</item>
+        <item>@string/exponentially_smoothed_moving_average</item>
+    </string-array>
+
+    <string-array name="trendline_computation_methods_values">
+        <item>Simple Moving Average</item>
+        <item>Exponentially Smoothed Moving Average</item>
+    </string-array>
 </resources>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -139,6 +139,10 @@
     <string name="Friday">Friday</string>
     <string name="Saturday">Saturday</string>
     <string name="Sunday">Sunday</string>
+    <string name="label_simple_moving_average">Simple Moving Average</string>
+    <string name="label_exponentially_smoothed_moving_average">Exponentially Smoothed Moving Average</string>
+    <string name="label_trendline_computation_method">Trendline computation method</string>
+    <string name="label_trendline_future">Future trend</string>
     <string name="label_bt_device_no_support">device not supported</string>
     <string name="label_exportBackup">Export backup</string>
     <string name="label_importBackup">Import backup</string>
@@ -288,8 +292,4 @@
     <string name="app_intro_back_button">Back</string>
     <string name="app_intro_done_button">Done</string>
     <string name="info_create_new_user_on_scale">Create new user on scale.</string>
-    <string name="simple_moving_average">Simple Moving Average</string>
-    <string name="exponentially_smoothed_moving_average">Exponentially Smoothed Moving Average</string>
-    <string name="label_trendline_computation_method">Trendline computation method</string>
-    <string name="trendline_future">Future trend</string>
 </resources>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -148,8 +148,7 @@
     <string name="label_initial_weight">Initial weight</string>
     <string name="label_goal_line">Goal line</string>
     <string name="label_trend_line">Trendline</string>
-    <string name="label_simple_moving_average">Simple moving average</string>
-    <string name="label_simple_moving_average_num_days">Number of days for simple moving average</string>
+    <string name="label_simple_moving_average_num_days">Number of days to average over</string>
     <string name="label_prediction">Prediction</string>
     <string name="label_trend">Trend</string>
     <string name="label_help">Help</string>
@@ -289,4 +288,8 @@
     <string name="app_intro_back_button">Back</string>
     <string name="app_intro_done_button">Done</string>
     <string name="info_create_new_user_on_scale">Create new user on scale.</string>
+    <string name="simple_moving_average">Simple Moving Average</string>
+    <string name="exponentially_smoothed_moving_average">Exponentially Smoothed Moving Average</string>
+    <string name="label_trendline_computation_method">Trendline computation method</string>
+    <string name="trendline_future">Future trend</string>
 </resources>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -148,6 +148,8 @@
     <string name="label_initial_weight">Initial weight</string>
     <string name="label_goal_line">Goal line</string>
     <string name="label_trend_line">Trendline</string>
+    <string name="label_simple_moving_average">Simple moving average</string>
+    <string name="label_simple_moving_average_num_days">Number of days for simple moving average</string>
     <string name="label_prediction">Prediction</string>
     <string name="label_trend">Trend</string>
     <string name="label_help">Help</string>

--- a/android_app/app/src/main/res/xml/graph_preferences.xml
+++ b/android_app/app/src/main/res/xml/graph_preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="legendEnable"
@@ -30,4 +31,18 @@
         android:summaryOff="@string/info_is_not_enable"
         android:summaryOn="@string/info_is_enable"
         android:title="@string/label_trend_line" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="simpleMovingAverage"
+        android:summaryOff="@string/info_is_not_enable"
+        android:summaryOn="@string/info_is_enable"
+        android:title="@string/label_simple_moving_average" />
+    <SeekBarPreference
+        android:defaultValue="7"
+        android:key="simpleMovingAverageNumDays"
+        android:dependency="simpleMovingAverage"
+        android:max="30"
+        app:min="2"
+        app:showSeekBarValue="true"
+        android:title="@string/label_simple_moving_average_num_days" />
 </PreferenceScreen>

--- a/android_app/app/src/main/res/xml/graph_preferences.xml
+++ b/android_app/app/src/main/res/xml/graph_preferences.xml
@@ -41,7 +41,7 @@
             android:dependency="trendLine"
             android:summaryOff="@string/info_is_not_enable"
             android:summaryOn="@string/info_is_enable"
-            android:title="@string/trendline_future" />
+            android:title="@string/label_trendline_future" />
         <DropDownPreference
             android:id="@+id/trendlineComputationMethodDropdown"
             android:defaultValue="Exponentially Smoothed Moving Average"

--- a/android_app/app/src/main/res/xml/graph_preferences.xml
+++ b/android_app/app/src/main/res/xml/graph_preferences.xml
@@ -25,24 +25,41 @@
         android:summaryOff="@string/info_is_not_visible"
         android:summaryOn="@string/info_is_visible"
         android:title="@string/label_goal_line" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="trendLine"
-        android:summaryOff="@string/info_is_not_enable"
-        android:summaryOn="@string/info_is_enable"
-        android:title="@string/label_trend_line" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="simpleMovingAverage"
-        android:summaryOff="@string/info_is_not_enable"
-        android:summaryOn="@string/info_is_enable"
-        android:title="@string/label_simple_moving_average" />
-    <SeekBarPreference
-        android:defaultValue="7"
-        android:key="simpleMovingAverageNumDays"
-        android:dependency="simpleMovingAverage"
-        android:max="30"
-        app:min="2"
-        app:showSeekBarValue="true"
-        android:title="@string/label_simple_moving_average_num_days" />
+    <PreferenceCategory
+        app:key="trendlineCategory"
+        app:title="@string/label_trend_line">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="trendLine"
+            android:summaryOff="@string/info_is_not_enable"
+            android:summaryOn="@string/info_is_enable"
+            android:title="@string/label_trend_line" />
+        <DropDownPreference
+            android:id="@+id/trendlineComputationMethodDropdown"
+            android:defaultValue="Exponentially Smoothed Moving Average"
+            android:key="trendlineComputationMethod"
+            android:dependency="trendLine"
+            android:entries="@array/trendline_computation_methods_entries"
+            android:entryValues="@array/trendline_computation_methods_values"
+            app:useSimpleSummaryProvider="true"
+            android:title="@string/label_trendline_computation_method"
+            />
+        <SeekBarPreference
+            android:id="@+id/simpleMovingAverageNumDaysSeekbar"
+            android:defaultValue="7"
+            android:key="simpleMovingAverageNumDays"
+            android:dependency="trendLine"
+            android:max="30"
+            app:min="2"
+            app:showSeekBarValue="true"
+            android:title="@string/label_simple_moving_average_num_days" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="trendlineFuture"
+            android:dependency="trendLine"
+            android:summaryOff="@string/info_is_not_enable"
+            android:summaryOn="@string/info_is_enable"
+            android:title="@string/trendline_future" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/android_app/app/src/main/res/xml/graph_preferences.xml
+++ b/android_app/app/src/main/res/xml/graph_preferences.xml
@@ -35,6 +35,13 @@
             android:summaryOff="@string/info_is_not_enable"
             android:summaryOn="@string/info_is_enable"
             android:title="@string/label_trend_line" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="trendlineFuture"
+            android:dependency="trendLine"
+            android:summaryOff="@string/info_is_not_enable"
+            android:summaryOn="@string/info_is_enable"
+            android:title="@string/trendline_future" />
         <DropDownPreference
             android:id="@+id/trendlineComputationMethodDropdown"
             android:defaultValue="Exponentially Smoothed Moving Average"
@@ -54,12 +61,5 @@
             app:min="2"
             app:showSeekBarValue="true"
             android:title="@string/label_simple_moving_average_num_days" />
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="trendlineFuture"
-            android:dependency="trendLine"
-            android:summaryOff="@string/info_is_not_enable"
-            android:summaryOn="@string/info_is_enable"
-            android:title="@string/trendline_future" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This code adds a simple moving average trend line with an option to select the time period over which the line should be averaged.

It is different from the currently implemented exponential smoothing because the simple moving average does not account for the old measurements: even though the old measurements are supposed to contribute little, they still contribute, and therefore the current state of things isn't represented properly (at least for me).

There are no future predictions in this implementation, only the moving average.

Also, my simple moving average should work properly with irregular measurements, while the current implementation of the exponential smoothing works incorrectly when there are long periods without data since it works measurement-wise, not time-wise. I.e., if I have the following list of measurements (an arbitrary example with random numbers)

January 1st 2022 - 100 kg
December 1st 2023 - 50 kg
December 2nd 2023 - 50 kg
...
December 29th 2023 - 50 kg

then the whole thing would be skewed by the January 1st 2022 measurement, even though technically it was more than a year ago compared to the December 1st 2023 measurement.

I tried locally implementing interpolation to fix exponential smoothing when there are gaps in data by filling all missing days with simple linear interpolation, it works better that way, but still looks different from the simple moving average. (It works slowly, so I decided to not put my attempt at the interpolation fix into this pull request)

Also, this code should somewhat address https://github.com/oliexdev/openScale/issues/716 although not directly.

I tried this code on my data and it looks fine to me.

Please let me know if something doesn't look good or needs to be done, I am not familiar with the rules on how one should contribute to this repository.
