### PR TITLE
Increase the offset so that Y-axis labels with decimals places fit

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -296,7 +296,7 @@ public class ChartMeasurementView extends LineChart {
 
         // add one symbol worth of offset to avoid cutting decimal places
         float additionalWidth = (float) Utils.calcTextWidth(mAxisRendererLeft
-                .getPaintAxisLabels(), "1") * 2f;
+                .getPaintAxisLabels(), "1");
 
         if (mAxisLeft.needsOffset()) {
             offsetLeft += mAxisLeft.getRequiredWidthSpace(mAxisRendererLeft

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -284,7 +284,7 @@ public class ChartMeasurementView extends LineChart {
     private void setCustomViewPortOffsets() {
         float offsetLeft = 0f, offsetRight = 0f, offsetTop = 0f, offsetBottom = 0f;
 
-        final float OFFSET_MULTIPLIER = 1.2f;
+        final float OFFSET_MULTIPLIER = 1.1f;
 
         RectF mOffsetsBuffer = new RectF();
         calculateLegendOffsets(mOffsetsBuffer);
@@ -295,14 +295,19 @@ public class ChartMeasurementView extends LineChart {
         offsetBottom += Math.max(70f, mOffsetsBuffer.bottom);
 
         // offsets for y-labels
+
+        // add one symbol worth of offset to avoid cutting decimal places
+        float additionalWidth = (float) Utils.calcTextWidth(mAxisRendererLeft
+                .getPaintAxisLabels(), "1") * 2f;
+
         if (mAxisLeft.needsOffset()) {
             offsetLeft += mAxisLeft.getRequiredWidthSpace(mAxisRendererLeft
-                    .getPaintAxisLabels()) * OFFSET_MULTIPLIER;
+                    .getPaintAxisLabels()) + additionalWidth;
         }
 
         if (mAxisRight.needsOffset()) {
             offsetRight += mAxisRight.getRequiredWidthSpace(mAxisRendererRight
-                    .getPaintAxisLabels()) * OFFSET_MULTIPLIER;
+                    .getPaintAxisLabels()) + additionalWidth;
         }
 
         if (mXAxis.isEnabled() && mXAxis.isDrawLabelsEnabled()) {

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -284,8 +284,6 @@ public class ChartMeasurementView extends LineChart {
     private void setCustomViewPortOffsets() {
         float offsetLeft = 0f, offsetRight = 0f, offsetTop = 0f, offsetBottom = 0f;
 
-        final float OFFSET_MULTIPLIER = 1.1f;
-
         RectF mOffsetsBuffer = new RectF();
         calculateLegendOffsets(mOffsetsBuffer);
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/ChartMeasurementView.java
@@ -284,6 +284,8 @@ public class ChartMeasurementView extends LineChart {
     private void setCustomViewPortOffsets() {
         float offsetLeft = 0f, offsetRight = 0f, offsetTop = 0f, offsetBottom = 0f;
 
+        final float OFFSET_MULTIPLIER = 1.2f;
+
         RectF mOffsetsBuffer = new RectF();
         calculateLegendOffsets(mOffsetsBuffer);
 
@@ -295,12 +297,12 @@ public class ChartMeasurementView extends LineChart {
         // offsets for y-labels
         if (mAxisLeft.needsOffset()) {
             offsetLeft += mAxisLeft.getRequiredWidthSpace(mAxisRendererLeft
-                    .getPaintAxisLabels());
+                    .getPaintAxisLabels()) * OFFSET_MULTIPLIER;
         }
 
         if (mAxisRight.needsOffset()) {
             offsetRight += mAxisRight.getRequiredWidthSpace(mAxisRendererRight
-                    .getPaintAxisLabels());
+                    .getPaintAxisLabels()) * OFFSET_MULTIPLIER;
         }
 
         if (mXAxis.isEnabled() && mXAxis.isDrawLabelsEnabled()) {


### PR DESCRIPTION
I don't really know how to properly fix this, but experimentally I have found the value of the offset multiplier which fixes the issue of labels being cut out. It eats a little bit more space when no decimal places are present, but at least it works fine otherwise. I understand that this is a dirty hack, so no hard feelings from my side if it doesn't make it upstream.

Screenshot before:
![2023-07-22_12-40_1](https://github.com/oliexdev/openScale/assets/221355/cb56780f-41c6-4b4c-98e9-80f0c97a5747)

Screenshots after:
![2023-07-22_12-39](https://github.com/oliexdev/openScale/assets/221355/93a706a8-a56f-4054-b918-7e81383528f2)
![2023-07-22_12-40](https://github.com/oliexdev/openScale/assets/221355/bef6086b-fb2f-460b-b182-769678ffb29b)

