### PR TITLE
Fix for Yunmai scales

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/BluetoothYunmaiSE_Mini.java
@@ -70,6 +70,11 @@ public class BluetoothYunmaiSE_Mini extends BluetoothCommunication {
                 user_add_or_query[user_add_or_query.length - 1] =
                         xorChecksum(user_add_or_query, 1, user_add_or_query.length - 1);
                 writeBytes(WEIGHT_CMD_SERVICE, WEIGHT_CMD_CHARACTERISTIC, user_add_or_query);
+                try {
+                    Thread.sleep(300);
+                }
+                catch (InterruptedException e)
+                {}
                 break;
             case 1:
                 byte[] unixTime = Converters.toInt32Be(new Date().getTime() / 1000);


### PR DESCRIPTION
This fixes issue #926 at least for the Yunmai scales.

300 ms delay added to step 0 of the bluetooth connection. 