### PR TITLE
Fix #1038 dark mode dialog text color issue

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -273,7 +273,7 @@ public class MainActivity extends AppCompatActivity
 
                 // ask the user once for feedback on the 15th app launch
                 if(launchCount == 15){
-                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
                     builder.setMessage(R.string.label_feedback_message_enjoying)
                             .setPositiveButton(R.string.label_feedback_message_yes, new DialogInterface.OnClickListener() {
@@ -324,7 +324,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void positiveFeedbackDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
         builder.setMessage(R.string.label_feedback_message_rate_app)
                 .setPositiveButton(R.string.label_feedback_message_positive, new DialogInterface.OnClickListener() {
@@ -355,7 +355,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void negativeFeedbackDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
         builder.setMessage(R.string.label_feedback_message_issue)
                 .setPositiveButton(R.string.label_feedback_message_positive, new DialogInterface.OnClickListener() {
@@ -375,7 +375,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void showNoSelectedUserDialog() {
-        AlertDialog.Builder infoDialog = new AlertDialog.Builder(this);
+        AlertDialog.Builder infoDialog = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
         infoDialog.setMessage(getResources().getString(R.string.info_no_selected_user));
         infoDialog.setPositiveButton(getResources().getString(R.string.label_ok), null);
@@ -435,7 +435,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void showAssistedWeighingDialog(boolean manuelEntry) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
         LinearLayout linearLayout = new LinearLayout(this);
         linearLayout.setOrientation(LinearLayout.VERTICAL);
@@ -556,7 +556,7 @@ public class MainActivity extends AppCompatActivity
 
     private void invokeConnectToBluetoothDevice() {
         if (BuildConfig.BUILD_TYPE == "light") {
-            AlertDialog infoDialog = new AlertDialog.Builder(this)
+            AlertDialog infoDialog = new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
                 .setMessage(Html.fromHtml(getResources().getString(R.string.label_upgrade_to_openScale_pro) + "<br><br> <a href=\"https://play.google.com/store/apps/details?id=com.health.openscale.pro\">Install openScale pro version</a>"))
                 .setPositiveButton(getResources().getString(R.string.label_ok), null)
                 .setIcon(R.drawable.ic_launcher_openscale_light)
@@ -605,7 +605,7 @@ public class MainActivity extends AppCompatActivity
         if (!(locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER))) {
             Timber.d("No GPS or Network location service is enabled, ask user for permission");
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
             builder.setTitle(R.string.permission_bluetooth_info_title);
             builder.setIcon(R.drawable.ic_preferences_about);
             builder.setMessage(R.string.permission_location_service_info);
@@ -652,7 +652,7 @@ public class MainActivity extends AppCompatActivity
         if (hasPermissions(requiredPermissions)) {
             connectToBluetooth();
         } else if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
             Timber.d("No access fine location permission granted");
 
             builder.setMessage(R.string.permission_bluetooth_info)
@@ -669,7 +669,7 @@ public class MainActivity extends AppCompatActivity
             alertDialog.setCanceledOnTouchOutside(false);
             alertDialog.show();
         } else if (shouldShowRequestPermissionRationale(Manifest.permission.BLUETOOTH_SCAN)) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
             Timber.d("No access Bluetooth scan permission granted");
 
             builder.setMessage(R.string.permission_bluetooth_info)
@@ -782,7 +782,7 @@ public class MainActivity extends AppCompatActivity
     };
 
     private void chooseScaleUser(Message msg) {
-        AlertDialog.Builder mBuilder = new AlertDialog.Builder(MainActivity.this);
+        AlertDialog.Builder mBuilder = new AlertDialog.Builder(MainActivity.this, R.style.AppTheme_Dialog);
         Pair<CharSequence[], int[]> choices = (Pair<CharSequence[], int[]>)msg.obj;
 
         mBuilder.setTitle(getResources().getString(R.string.info_select_scale_user));
@@ -808,7 +808,7 @@ public class MainActivity extends AppCompatActivity
         final int scaleUserIndex = msg.arg2;
         final int[] consentCode = {-1};
 
-        AlertDialog.Builder mBuilder = new AlertDialog.Builder(MainActivity.this);
+        AlertDialog.Builder mBuilder = new AlertDialog.Builder(MainActivity.this, R.style.AppTheme_Dialog);
         mBuilder.setTitle(getResources().getString(R.string.info_enter_consent_code_for_scale_user, Integer.toString(scaleUserIndex)));
 
         final EditText input = new EditText(this);
@@ -866,7 +866,7 @@ public class MainActivity extends AppCompatActivity
         int selectedUserId = OpenScale.getInstance().getSelectedScaleUserId();
 
         if (selectedUserId == -1) {
-            AlertDialog.Builder infoDialog = new AlertDialog.Builder(this);
+            AlertDialog.Builder infoDialog = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
 
             infoDialog.setMessage(getResources().getString(R.string.info_no_selected_user));
             infoDialog.setPositiveButton(getResources().getString(R.string.label_ok), null);
@@ -938,7 +938,7 @@ public class MainActivity extends AppCompatActivity
             return;
         }
 
-        AlertDialog.Builder exportDialog = new AlertDialog.Builder(this);
+        AlertDialog.Builder exportDialog = new AlertDialog.Builder(this, R.style.AppTheme_Dialog);
         exportDialog.setTitle(R.string.label_export);
         exportDialog.setMessage(getResources().getString(R.string.label_export_overwrite,
                 openScale.getFilenameFromUri(uri)));

--- a/android_app/app/src/main/java/com/health/openscale/gui/graph/GraphFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/graph/GraphFragment.java
@@ -437,7 +437,7 @@ public class GraphFragment extends Fragment {
         boolean deleteConfirmationEnable = prefs.getBoolean("deleteConfirmationEnable", true);
 
         if (deleteConfirmationEnable) {
-            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(graphView.getContext());
+            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(graphView.getContext(), R.style.AppTheme_Dialog);
             deleteAllDialog.setMessage(getResources().getString(R.string.question_really_delete));
 
             deleteAllDialog.setPositiveButton(getResources().getString(R.string.label_yes), new DialogInterface.OnClickListener() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/MeasurementEntryFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/MeasurementEntryFragment.java
@@ -357,7 +357,7 @@ public class MeasurementEntryFragment extends Fragment {
         boolean deleteConfirmationEnable = prefs.getBoolean("deleteConfirmationEnable", true);
 
         if (deleteConfirmationEnable) {
-            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(context);
+            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(context, R.style.AppTheme_Dialog);
             deleteAllDialog.setMessage(getResources().getString(R.string.question_really_delete));
 
             deleteAllDialog.setPositiveButton(getResources().getString(R.string.label_yes), new DialogInterface.OnClickListener() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/measurement/MeasurementEntryFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/measurement/MeasurementEntryFragment.java
@@ -42,6 +42,7 @@ import androidx.navigation.Navigation;
 import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleMeasurement;
+import com.health.openscale.gui.utils.ColorUtil;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -159,13 +160,13 @@ public class MeasurementEntryFragment extends Fragment {
             final Drawable wrapped = DrawableCompat.wrap(drawable.mutate());
 
             if (item.getItemId() == R.id.saveButton) {
-                DrawableCompat.setTint(wrapped, Color.parseColor("#FFFFFF"));
+                DrawableCompat.setTint(wrapped, ColorUtil.getPrimaryColor(context));
             } else if (item.getItemId() == R.id.editButton) {
-                DrawableCompat.setTint(wrapped, Color.parseColor("#99CC00"));
+                DrawableCompat.setTint(wrapped, ColorUtil.COLOR_GREEN);
             } else if (item.getItemId() == R.id.expandButton) {
-                DrawableCompat.setTint(wrapped, Color.parseColor("#FFBB33"));
+                DrawableCompat.setTint(wrapped, ColorUtil.COLOR_ORANGE);
             } else if (item.getItemId() == R.id.deleteButton) {
-                DrawableCompat.setTint(wrapped, Color.parseColor("#FF4444"));
+                DrawableCompat.setTint(wrapped, ColorUtil.COLOR_RED);
             }
 
             item.setIcon(wrapped);

--- a/android_app/app/src/main/java/com/health/openscale/gui/overview/OverviewAdapter.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/overview/OverviewAdapter.java
@@ -62,7 +62,7 @@ class OverviewAdapter extends RecyclerView.Adapter<OverviewAdapter.ViewHolder> {
         boolean deleteConfirmationEnable = prefs.getBoolean("deleteConfirmationEnable", true);
 
         if (deleteConfirmationEnable) {
-            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(activity);
+            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(activity, R.style.AppTheme_Dialog);
             deleteAllDialog.setMessage(activity.getResources().getString(R.string.question_really_delete));
 
             deleteAllDialog.setPositiveButton(activity.getResources().getString(R.string.label_yes), new DialogInterface.OnClickListener() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/BluetoothSettingsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/BluetoothSettingsFragment.java
@@ -142,7 +142,7 @@ public class BluetoothSettingsFragment extends Fragment {
         if (!(locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER))) {
             Timber.d("No GPS or Network location service is enabled, ask user for permission");
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+            AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.AppTheme_Dialog);
             builder.setTitle(R.string.permission_bluetooth_info_title);
             builder.setIcon(R.drawable.ic_preferences_about);
             builder.setMessage(R.string.permission_location_service_info);
@@ -182,7 +182,7 @@ public class BluetoothSettingsFragment extends Fragment {
         if (hasPermissions(requiredPermissions)) {
             startBluetoothDiscovery();
         } else if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+            AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.AppTheme_Dialog);
             Timber.d("No access fine location permission granted");
 
             builder.setMessage(R.string.permission_bluetooth_info)
@@ -200,7 +200,7 @@ public class BluetoothSettingsFragment extends Fragment {
             alertDialog.show();
 
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && targetSdkVersion >= Build.VERSION_CODES.S && shouldShowRequestPermissionRationale(Manifest.permission.BLUETOOTH_SCAN)) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.AppTheme_Dialog);
         Timber.d("No access Bluetooth scan permission granted");
 
         builder.setMessage(R.string.permission_bluetooth_info)
@@ -352,7 +352,7 @@ public class BluetoothSettingsFragment extends Fragment {
     }
 
     private void getDebugInfo(final BluetoothDevice device) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext());
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext(), R.style.AppTheme_Dialog);
         builder.setTitle("Fetching info")
                 .setMessage("Please wait while we fetch extended info from your scale...")
                 .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/MeasurementPreferences.java
@@ -102,7 +102,7 @@ public class MeasurementPreferences extends PreferenceFragmentCompat {
         @Override
         public boolean onPreferenceClick(Preference preference) {
 
-            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(getActivity());
+            AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog);
 
             deleteAllDialog.setMessage(getResources().getString(R.string.question_really_delete_all));
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/ReminderPreferences.java
@@ -165,7 +165,7 @@ public class ReminderPreferences extends PreferenceFragmentCompat
                 if (!isGranted) {
                     if (Build.VERSION.SDK_INT >= 33) {
                         if (shouldShowRequestPermissionRationale(android.Manifest.permission.POST_NOTIFICATIONS)) {
-                            AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+                            AlertDialog.Builder builder = new AlertDialog.Builder(getContext(), R.style.AppTheme_Dialog);
                             builder.setTitle(R.string.permission_bluetooth_info_title);
                             builder.setIcon(R.drawable.ic_preferences_about);
                             builder.setMessage(R.string.permission_notification_info);
@@ -179,7 +179,7 @@ public class ReminderPreferences extends PreferenceFragmentCompat
                             alertDialog.setCanceledOnTouchOutside(false);
                             alertDialog.show();
                         } else {
-                            AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+                            AlertDialog.Builder builder = new AlertDialog.Builder(getContext(), R.style.AppTheme_Dialog);
                             builder.setTitle(R.string.permission_bluetooth_info_title);
                             builder.setIcon(R.drawable.ic_preferences_about);
                             builder.setMessage(R.string.permission_notification_info);

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/UserSettingsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/UserSettingsFragment.java
@@ -48,6 +48,7 @@ import com.health.openscale.R;
 import com.health.openscale.core.OpenScale;
 import com.health.openscale.core.datatypes.ScaleUser;
 import com.health.openscale.core.utils.Converters;
+import com.health.openscale.gui.utils.ColorUtil;
 
 import java.text.DateFormat;
 import java.util.Calendar;
@@ -105,9 +106,9 @@ public class UserSettingsFragment extends Fragment {
                     final Drawable wrapped = DrawableCompat.wrap(drawable.mutate());
 
                     if (item.getItemId() == R.id.saveButton) {
-                        DrawableCompat.setTint(wrapped, Color.parseColor("#FFFFFF"));
+                        DrawableCompat.setTint(wrapped, ColorUtil.getPrimaryColor(context));
                     } else if (item.getItemId() == R.id.deleteButton) {
-                        DrawableCompat.setTint(wrapped, Color.parseColor("#FF4444"));
+                        DrawableCompat.setTint(wrapped, ColorUtil.getTintColor(context));
                     }
 
                     item.setIcon(wrapped);

--- a/android_app/app/src/main/java/com/health/openscale/gui/preferences/UserSettingsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/preferences/UserSettingsFragment.java
@@ -391,7 +391,7 @@ public class UserSettingsFragment extends Fragment {
     };
 
     private void deleteUser() {
-        AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(context);
+        AlertDialog.Builder deleteAllDialog = new AlertDialog.Builder(context, R.style.AppTheme_Dialog);
 
         deleteAllDialog.setMessage(getResources().getString(R.string.question_really_delete_user));
 

--- a/android_app/app/src/main/java/com/health/openscale/gui/statistic/StatisticsFragment.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/statistic/StatisticsFragment.java
@@ -74,7 +74,7 @@ public class StatisticsFragment extends Fragment {
         datePickerView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog);
                     builder.setTitle(R.string.label_time_period)
                             .setItems(R.array.range_options_entries, new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int which) {

--- a/android_app/app/src/main/res/values-night/themes.xml
+++ b/android_app/app/src/main/res/values-night/themes.xml
@@ -37,6 +37,17 @@
 
     <style name="AppTheme.Dialog" parent="Theme.MaterialComponents.DayNight.Dialog">
         <item name="colorPrimary">@color/md_theme_dark_onBackground</item>
+        <item name="colorAccent">@color/md_theme_dark_onPrimary</item>
+        <item name="android:background">@color/md_theme_dark_background</item>
+        <item name="android:buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
+        <item name="android:buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+    </style>
+    <style name="NegativeButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/md_theme_dark_error</item>
+    </style>
+
+    <style name="PositiveButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/md_theme_dark_onBackground</item>
     </style>
 
     <style name="AppTheme.RadioButton" parent="Widget.Material3.CompoundButton.RadioButton">


### PR DESCRIPTION
Fixed two places where the button colors are hard-coded. Also changed `AlertDialog`'s style so that the positive and negative buttons have proper text colors, instead of black.

Closes #1038.