### PR TITLE
(fix) StickyHeaderTableView: crash on certain strings

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/gui/table/StickyHeaderTableView.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/table/StickyHeaderTableView.java
@@ -608,7 +608,8 @@ public class StickyHeaderTableView extends View implements NestedScrollingChild 
                         if (str.indexOf("\n") != -1) {
                             String[] split = str.split("\n");
 
-                            if (split[0].length() >= split[1].length()) {
+                            // split.length == 1 handle the case when str has only 1 \n and it is at the end.
+                            if (split.length == 1 || split[0].length() >= split[1].length()) {
                                 str = split[0];
                             } else {
                                 str = split[1];


### PR DESCRIPTION
This PR handle the case where some text ends by an `\n` (ex: 'something\n'). From `String.split` docs, ` trailing empty strings will be discarded.`. That cause the exception since there are less element than expected in the resulting array. 

From this screenshot, you can see the bug in action.
![Screenshot from 2024-05-08 07-44-44](https://github.com/oliexdev/openScale/assets/1142322/087a608f-1085-4892-872c-34a7a62e952f)

Thanks for the app oliexdev :)

Fix #935 