### PR TITLE
add app ID suffix for the debug build

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -97,6 +97,7 @@ android {
                     }
                 }
             }
+            applicationIdSuffix '.debug'
         }
         release {
             archivesBaseName = "openScale-"+defaultConfig.versionName


### PR DESCRIPTION
With this change it is possible to have the debug version of the app installed in parallel to the release version from an app store.

I hope this does not interfere with any CI like travis.