### PR TITLE
Added preference to vibrate when receiving data from scale

### DIFF
--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <!-- Permission to allow read of data from the database through a ContentProvider.
          Marked "dangerous" so that explicit user approval is required to read this data, not

--- a/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
+++ b/android_app/app/src/main/java/com/health/openscale/gui/MainActivity.java
@@ -35,6 +35,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.text.Editable;
@@ -115,6 +117,7 @@ public class MainActivity extends AppCompatActivity
     private NavController navController;
     private NavigationView navigationView;
     private BottomNavigationView navigationBottomView;
+
 
     private boolean settingsActivityRunning = false;
 
@@ -715,13 +718,29 @@ public class MainActivity extends AppCompatActivity
                 case RETRIEVE_SCALE_DATA:
                     setBluetoothStatusIcon(R.drawable.ic_bluetooth_connection_success);
                     ScaleMeasurement scaleBtData = (ScaleMeasurement) msg.obj;
-
+                    Toast.makeText(getApplicationContext(), getResources().getString(R.string.info_bluetooth_retrieve_data_successful), Toast.LENGTH_SHORT).show();
                     OpenScale openScale = OpenScale.getInstance();
 
                     if (prefs.getBoolean("mergeWithLastMeasurement", true)) {
                         if (!openScale.isScaleMeasurementListEmpty()) {
                             ScaleMeasurement lastMeasurement = openScale.getLastScaleMeasurement();
                             scaleBtData.merge(lastMeasurement);
+                        }
+                    }
+
+
+                    if (prefs.getBoolean("vibrateOnMeasurement", true)) {
+                        Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+                        if (vibrator != null && vibrator.hasVibrator()) {
+                            // Check Android version
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                // New vibrate method for API 26 and above
+                                VibrationEffect effect = VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE);
+                                vibrator.vibrate(effect);
+                            } else {
+                                // Deprecated vibrate method for API 25 and below
+                                vibrator.vibrate(500);
+                            }
                         }
                     }
 

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="info_bluetooth_connection_lost">Bluetooth connection lost</string>
     <string name="info_bluetooth_no_device">No Bluetooth device found</string>
     <string name="info_bluetooth_no_device_retrying">Could not establish connection, retrying…</string>
+    <string name="info_bluetooth_retrieve_data_successful">Successfully retrieved data from scale</string>">
     <string name="info_bluetooth_no_device_set">Select a Bluetooth device</string>
     <string name="info_bluetooth_connection_successful">Connected</string>
     <string name="info_bluetooth_init">Initialize Bluetooth device</string>
@@ -114,6 +115,7 @@
     <string name="question_really_delete_user">Delete user?</string>
     <string name="label_bluetooth_title">Bluetooth</string>
     <string name="label_bluetooth_enable">Connect to scale on startup</string>
+    <string name="label_vibrate_on_measurement">Vibrate on Measurement</string>
     <string name="label_mergeWithLastMeasurement">Merge with last measurement</string>
     <string name="label_bluetooth_searching">Searching for your Bluetooth scale</string>
     <string name="label_bluetooth_searching_finished">Search finished</string>

--- a/android_app/app/src/main/res/xml/general_preferences.xml
+++ b/android_app/app/src/main/res/xml/general_preferences.xml
@@ -26,4 +26,10 @@
         android:summaryOff="@string/info_is_not_enable"
         android:summaryOn="@string/info_is_enable"
         android:title="@string/label_delete_confirmation" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="vibrateOnMeasurement"
+        android:summaryOff="@string/info_is_not_enable"
+        android:summaryOn="@string/info_is_enable"
+        android:title="@string/label_vibrate_on_measurement" />
 </PreferenceScreen>


### PR DESCRIPTION
Defaults to true
User configurable in general preferences
Added 2 strings info_bluetooth_retrieve_data_successful and label_vibrate_on_measurement
Added permission android.permission.VIBRATE
Fixes #1097 