### PR TITLE
update bmi agebands

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
@@ -145,7 +145,7 @@ object EvaluationReferenceTables {
             AgeBand(16, 16, 18.9f, 24.3f),
             AgeBand(17, 17, 19.5f, 25f),
             AgeBand(18, 18, 20f, 25.5f),
-            AgeBand(20, 64, 18.5f, 25f),
+            AgeBand(19, 64, 18.5f, 25f),
 	        AgeBand(65, 120, 18.5f, 25f), //should be higher but is not defined
         )
     )


### PR DESCRIPTION
source for kids:
  since ageband does not allow for months, i took the lowest and highest value for that year
  https://www.who.int/tools/growth-reference-data-for-5to19-years/indicators/bmi-for-age

definition for adults:
  https://www.cdc.gov/bmi/adult-calculator/bmi-categories.html