### PR TITLE
Fix Mi Scale v1 measurments

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleHandler.kt
@@ -245,6 +245,11 @@ class MiScaleHandler : ScaleDeviceHandler() {
             return
         }
 
+        if (characteristic == CHAR_WEIGHT_MEAS) {
+            handleWeightMeasNotify(data, user)
+            return
+        }
+
         // Some firmwares may leak data elsewhere; log a small preview.
         logD("Notify $characteristic len=${data.size} ${data.toHexPreview(24)}")
     }
@@ -293,6 +298,17 @@ class MiScaleHandler : ScaleDeviceHandler() {
 
         // Otherwise treat as history chunk(s) → 10-byte aligned records.
         appendHistoryChunk(d)
+    }
+
+     private fun handleWeightMeasNotify(d: ByteArray, user: ScaleUser) {
+        // 10‑byte frame (same layout as history10)
+        if (variant == Variant.V1 && d.size == 10) {
+            parseHistory10(d, user)
+            return
+        }
+
+        // Other lengths: debug only
+        logD("WeightMeas notify len=${d.size} ${d.toHexPreview(24)}")
     }
 
     /** v2 live frame (13 bytes). With/without impedance. Publishes stabilized frames only. */


### PR DESCRIPTION
Handle the 10‑byte frames sent through CHAR_WEIGHT_MEAS and parse them with parseHistory10(). Live weight on Mi Scale v1 stopped working after 3.0.0. This restores it.
Tested on a real Mi Scale v1.
No changes made for v2.

Fixes #1293
