### PR TITLE
Add support for Xiaomi Body Composition Scale S400

### DIFF
--- a/android_app/app/build.gradle.kts
+++ b/android_app/app/build.gradle.kts
@@ -210,6 +210,9 @@ dependencies {
     // Blessed Kotlin
     implementation(libs.blessed.kotlin)
 
+    // BouncyCastle for AES-CCM decryption (Xiaomi S400 scale)
+    implementation(libs.bouncycastle)
+
     // Test dependencies
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleCommunicator.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleCommunicator.kt
@@ -17,6 +17,7 @@
  */
 package com.health.openscale.core.bluetooth
 
+import androidx.compose.runtime.Composable
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
 import kotlinx.coroutines.flow.SharedFlow
@@ -91,6 +92,14 @@ interface ScaleCommunicator {
 
     /** Request a measurement (if supported; some devices only push asynchronously). */
     fun requestMeasurement()
+
+    /**
+     * Renders the device-specific configuration UI.
+     * This allows the device handler to inject custom settings fields
+     * (like bind keys or user slots) into the settings screen.
+     */
+    @Composable
+    fun DeviceConfigurationUi()
 
     /** Stream of [BluetoothEvent] emitted by the communicator. */
     fun getEventsFlow(): SharedFlow<BluetoothEvent>

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -40,6 +40,7 @@ import com.health.openscale.core.bluetooth.scales.LinkMode
 import com.health.openscale.core.bluetooth.scales.MGBHandler
 import com.health.openscale.core.bluetooth.scales.MedisanaBs44xHandler
 import com.health.openscale.core.bluetooth.scales.MiScaleHandler
+import com.health.openscale.core.bluetooth.scales.MiScaleS400Handler
 import com.health.openscale.core.bluetooth.scales.OkOkHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneNewHandler
@@ -96,6 +97,7 @@ class ScaleFactory @Inject constructor(
         OneByoneHandler(),
         OneByoneNewHandler(),
         OkOkHandler(),
+        MiScaleS400Handler(),
         MiScaleHandler(),
         MGBHandler(),
         MedisanaBs44xHandler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -212,6 +212,17 @@ class ScaleFactory @Inject constructor(
     }
 
     /**
+     * Returns the first [ScaleDeviceHandler] that supports the given device, or null.
+     *
+     * This is safe for read-only inspection (e.g., querying [ScaleDeviceHandler.configFields]
+     * or [ScaleDeviceHandler.handlerNamespace]). The returned instance is a shared singleton;
+     * callers must not call [ScaleDeviceHandler.attach] on it.
+     */
+    fun getHandlerFor(deviceInfo: ScannedDeviceInfo): ScaleDeviceHandler? {
+        return modernKotlinHandlers.firstOrNull { it.supportFor(deviceInfo) != null }
+    }
+
+    /**
      * Checks if any known handler can theoretically support the given device.
      * This can be used by the UI to indicate if a device is potentially recognizable.
      *

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -212,17 +212,6 @@ class ScaleFactory @Inject constructor(
     }
 
     /**
-     * Returns the first [ScaleDeviceHandler] that supports the given device, or null.
-     *
-     * This is safe for read-only inspection (e.g., querying [ScaleDeviceHandler.configFields]
-     * or [ScaleDeviceHandler.handlerNamespace]). The returned instance is a shared singleton;
-     * callers must not call [ScaleDeviceHandler.attach] on it.
-     */
-    fun getHandlerFor(deviceInfo: ScannedDeviceInfo): ScaleDeviceHandler? {
-        return modernKotlinHandlers.firstOrNull { it.supportFor(deviceInfo) != null }
-    }
-
-    /**
      * Checks if any known handler can theoretically support the given device.
      * This can be used by the UI to indicate if a device is potentially recognizable.
      *

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/S400Decryptor.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/S400Decryptor.kt
@@ -1,0 +1,174 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Decryption logic for Xiaomi Body Composition Scale S400.
+ * Based on https://github.com/lswiderski/mi-scale-exporter and
+ * https://github.com/lswiderski/MiScaleBodyComposition
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import org.bouncycastle.crypto.engines.AESEngine
+import org.bouncycastle.crypto.modes.CCMBlockCipher
+import org.bouncycastle.crypto.params.AEADParameters
+import org.bouncycastle.crypto.params.KeyParameter
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Raw measurement data from S400 scale after decryption.
+ */
+data class S400Measurement(
+    val weightKg: Float,
+    val impedance: Float?,
+    val heartRate: Int?
+)
+
+/**
+ * Decrypts and parses advertisement data from Xiaomi Body Composition Scale S400.
+ *
+ * The S400 sends AES-CCM encrypted BLE advertisement data that requires:
+ * - The scale's MAC address (used in nonce construction)
+ * - A 16-byte BLE bind key from Xiaomi Cloud
+ */
+object S400Decryptor {
+
+    private const val EXPECTED_DATA_LENGTH = 24
+    private const val EXPECTED_DATA_LENGTH_WITH_HEADER = 26
+    private const val BIND_KEY_HEX_LENGTH = 32
+    private const val MAC_TAG_BITS = 32
+
+    /**
+     * Decrypt S400 advertisement data and extract measurements.
+     *
+     * @param advertisementData Raw service data from BLE advertisement (24 or 26 bytes)
+     * @param macAddress Scale's Bluetooth MAC address (format: "XX:XX:XX:XX:XX:XX")
+     * @param bindKey 32-character hex string (16 bytes) from Xiaomi Cloud
+     * @return Decrypted measurement or null if decryption fails or data is invalid
+     */
+    fun decrypt(
+        advertisementData: ByteArray,
+        macAddress: String,
+        bindKey: String
+    ): S400Measurement? {
+        // Validate bind key
+        if (bindKey.length != BIND_KEY_HEX_LENGTH) {
+            return null
+        }
+
+        // Normalize data length (strip 2-byte service UUID header if present)
+        val data = when (advertisementData.size) {
+            EXPECTED_DATA_LENGTH_WITH_HEADER -> advertisementData.copyOfRange(2, EXPECTED_DATA_LENGTH_WITH_HEADER)
+            EXPECTED_DATA_LENGTH -> advertisementData
+            else -> return null
+        }
+
+        return try {
+            val macBytes = hexStringToByteArray(macAddress.replace(":", ""))
+            val keyBytes = hexStringToByteArray(bindKey)
+
+            if (macBytes.size != 6 || keyBytes.size != 16) {
+                return null
+            }
+
+            // Build nonce: MAC_reversed[6] + data[2:5] + data[17:20]
+            val nonce = macBytes.reversedArray() +
+                data.copyOfRange(2, 5) +
+                data.copyOfRange(data.size - 7, data.size - 4)
+
+            // Extract MIC (authentication tag) - last 4 bytes
+            val mic = data.copyOfRange(data.size - 4, data.size)
+
+            // Extract encrypted payload - bytes 5 to (length - 7)
+            val encryptedPayload = data.copyOfRange(5, data.size - 7)
+
+            // Combine encrypted payload and MIC for decryption
+            val cipherText = encryptedPayload + mic
+
+            // AES-CCM decryption
+            val ccm = CCMBlockCipher.newInstance(AESEngine.newInstance())
+            val associatedData = byteArrayOf(0x11)
+            val params = AEADParameters(KeyParameter(keyBytes), MAC_TAG_BITS, nonce, associatedData)
+            ccm.init(false, params)
+
+            val decrypted = ByteArray(ccm.getOutputSize(cipherText.size))
+            val len = ccm.processBytes(cipherText, 0, cipherText.size, decrypted, 0)
+            ccm.doFinal(decrypted, len)
+
+            parseDecryptedData(decrypted)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Parse decrypted payload to extract weight, impedance, and heart rate.
+     */
+    private fun parseDecryptedData(decrypted: ByteArray): S400Measurement? {
+        if (decrypted.size < 12) return null
+
+        // Extract bytes 3-12 (9 bytes), then take 4 bytes at offset 1
+        val obj = decrypted.copyOfRange(3, 12)
+        val slice = obj.copyOfRange(1, 5)
+
+        // Convert to little-endian Int32
+        val value = ByteBuffer.wrap(slice).order(ByteOrder.LITTLE_ENDIAN).int
+
+        // Extract measurements using bit masks
+        val weightRaw = value and 0x7FF           // bits 0-10
+        val heartRateRaw = (value shr 11) and 0x7F // bits 11-17
+        val impedanceRaw = value shr 18            // bits 18+
+
+        val weightKg = weightRaw / 10.0f
+
+        // Heart rate: valid range is 1-126, then add 50
+        val heartRate = if (heartRateRaw in 1..126) heartRateRaw + 50 else null
+
+        // Impedance: only valid if both impedance and weight are non-zero
+        val impedance = if (impedanceRaw != 0 && weightRaw != 0) {
+            impedanceRaw / 10.0f
+        } else null
+
+        return if (weightKg > 0) {
+            S400Measurement(weightKg, impedance, heartRate)
+        } else null
+    }
+
+    /**
+     * Convert hex string to byte array.
+     */
+    private fun hexStringToByteArray(hex: String): ByteArray {
+        val cleanHex = hex.replace(" ", "").replace(":", "")
+        return cleanHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    }
+
+    /**
+     * Validate that a bind key is properly formatted.
+     */
+    fun isValidBindKey(bindKey: String): Boolean {
+        if (bindKey.length != BIND_KEY_HEX_LENGTH) return false
+        return bindKey.all { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+    }
+
+    /**
+     * Validate that a MAC address is properly formatted.
+     */
+    fun isValidMacAddress(mac: String): Boolean {
+        val pattern = Regex("^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+        return pattern.matches(mac)
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BroadcastScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BroadcastScaleAdapter.kt
@@ -19,6 +19,7 @@ package com.health.openscale.core.bluetooth.scales
 
 import android.bluetooth.le.ScanResult
 import android.os.SystemClock
+import androidx.compose.runtime.Composable
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
 import com.health.openscale.core.bluetooth.data.ScaleUser
@@ -124,6 +125,12 @@ class BroadcastScaleAdapter(
                 }
             }
         }
+    }
+
+    @Composable
+    override fun DeviceConfigurationUi() {
+        // Delegate to the actual protocol handler
+        handler.DeviceConfigurationUi()
     }
 
     private fun ensureCentral() {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BroadcastScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BroadcastScaleAdapter.kt
@@ -144,7 +144,6 @@ class BroadcastScaleAdapter(
         val driverSettings = FacadeDriverSettings(
             facade = settingsFacade,
             scope = scope,
-            deviceAddress = address,
             handlerNamespace = handler::class.simpleName ?: "Handler"
         )
         handler.attach(noopTransport, appCallbacks, driverSettings, dataProvider)

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
@@ -21,6 +21,7 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.le.ScanResult
 import android.content.Context
 import android.os.SystemClock
+import androidx.compose.runtime.Composable
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
 import com.health.openscale.core.bluetooth.data.ScaleUser
@@ -98,6 +99,12 @@ class GattScaleAdapter(
                 }
             }
         }
+    }
+
+    @Composable
+    override fun DeviceConfigurationUi() {
+        // Delegate to the actual protocol handler
+        handler.DeviceConfigurationUi()
     }
 
     private suspend fun ioGap(ms: Long) {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
@@ -189,7 +189,6 @@ class GattScaleAdapter(
             val driverSettings = FacadeDriverSettings(
                 facade = settingsFacade,
                 scope = scope,
-                deviceAddress = peripheral.address,
                 handlerNamespace = handler::class.simpleName ?: "Handler"
             )
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
@@ -34,6 +34,8 @@ package com.health.openscale.core.bluetooth.scales
 
 import android.bluetooth.le.ScanResult
 import android.os.ParcelUuid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
@@ -72,6 +74,19 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
 
     // Track if we've warned about missing configuration
     private var warnedMissingConfig = false
+
+    override fun configFields(): List<ScaleConfigField> = listOf(
+        ScaleConfigField(
+            key = SETTINGS_KEY_BIND_KEY,
+            labelRes = R.string.s400_bind_key_label,
+            descriptionRes = R.string.s400_bind_key_description,
+            placeholderRes = R.string.s400_bind_key_placeholder,
+            errorRes = R.string.s400_bind_key_error,
+            icon = Icons.Default.Key,
+            maxLength = 32,
+            inputFilter = InputFilter.HEX,
+        )
+    )
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name.uppercase(Locale.ROOT)

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
@@ -1,0 +1,228 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * Xiaomi Body Composition Scale S400 handler.
+ *
+ * Based on https://github.com/lswiderski/mi-scale-exporter and
+ * https://github.com/lswiderski/MiScaleBodyComposition
+ *
+ * The S400 broadcasts AES-CCM encrypted advertisement data containing:
+ * - Weight
+ * - Impedance (for body composition calculation)
+ * - Heart rate
+ *
+ * Unlike older Mi Scales, the S400 requires:
+ * - A BLE bind key extracted from Xiaomi Cloud
+ * - The scale's MAC address (used in nonce construction)
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.le.ScanResult
+import android.os.ParcelUuid
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.MiScaleLib
+import com.health.openscale.core.bluetooth.libs.S400Decryptor
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.service.ScannedDeviceInfo
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Handler for Xiaomi Body Composition Scale S400.
+ *
+ * This scale uses broadcast-only mode (no GATT connection) and sends
+ * AES-CCM encrypted service data in BLE advertisements.
+ */
+class MiScaleS400Handler : ScaleDeviceHandler() {
+
+    companion object {
+        // Settings keys for S400 configuration
+        const val SETTINGS_KEY_BIND_KEY = "s400_bind_key"
+        const val SETTINGS_KEY_MAC_ADDRESS = "s400_mac_address"
+
+        // Known S400 device name patterns
+        // The S400 may advertise with various names depending on firmware/region
+        // Format seen in practice: "Xiaomi Scale S400 XXXX" where XXXX is last 4 of MAC
+        private val KNOWN_NAME_PATTERNS = listOf(
+            "SCALE S400",                  // Core pattern - matches "Xiaomi Scale S400 8E8B"
+            "XMTZC14HM",                   // S400 model identifier (raw BLE name)
+            "XMTZC",                       // Xiaomi scale prefix
+        )
+
+        // S400 Service UUID (Xiaomi Body Composition service)
+        private val SERVICE_UUID_S400 = ParcelUuid.fromString("0000181b-0000-1000-8000-00805f9b34fb")
+    }
+
+    // Track if we've warned about missing configuration
+    private var warnedMissingConfig = false
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        val name = device.name.uppercase(Locale.ROOT)
+
+        // Check if device name matches known S400 patterns
+        // Use contains() for flexibility - some names may have prefixes/suffixes
+        val isS400 = KNOWN_NAME_PATTERNS.any { pattern ->
+            val upperPattern = pattern.uppercase(Locale.ROOT)
+            name.contains(upperPattern) || name.startsWith(upperPattern)
+        }
+
+        if (!isS400) return null
+
+        return DeviceSupport(
+            displayName = "Xiaomi Body Composition Scale S400",
+            capabilities = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION
+            ),
+            implemented = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION
+            ),
+            linkMode = LinkMode.BROADCAST_ONLY
+        )
+    }
+
+    /**
+     * Process BLE advertisements from the S400 scale.
+     *
+     * The S400 sends encrypted service data that we need to decrypt
+     * using the user's bind key and the scale's MAC address.
+     */
+    override fun onAdvertisement(result: ScanResult, user: ScaleUser): BroadcastAction {
+        // Get configured bind key and MAC address
+        val bindKey = settingsGetString(SETTINGS_KEY_BIND_KEY)
+        val configuredMac = settingsGetString(SETTINGS_KEY_MAC_ADDRESS)
+
+        // Get MAC from scan result (format: XX:XX:XX:XX:XX:XX)
+        val deviceMac = result.device.address
+
+        // Use configured MAC if available, otherwise use detected MAC
+        val macAddress = if (!configuredMac.isNullOrEmpty() && S400Decryptor.isValidMacAddress(configuredMac)) {
+            configuredMac
+        } else {
+            deviceMac
+        }
+
+        // Validate configuration
+        if (bindKey.isNullOrEmpty() || !S400Decryptor.isValidBindKey(bindKey)) {
+            if (!warnedMissingConfig) {
+                logW("S400: Missing or invalid bind key. Configure in Settings.")
+                userWarn(R.string.bt_s400_missing_bind_key)
+                warnedMissingConfig = true
+            }
+            return BroadcastAction.IGNORED
+        }
+
+        // Extract service data from advertisement
+        val serviceData = extractServiceData(result) ?: return BroadcastAction.IGNORED
+
+        logD("S400 advert: ${serviceData.size} bytes from $deviceMac")
+
+        // Attempt decryption
+        val measurement = try {
+            S400Decryptor.decrypt(serviceData, macAddress, bindKey)
+        } catch (e: Exception) {
+            logW("S400 decryption failed: ${e.message}")
+            return BroadcastAction.IGNORED
+        }
+
+        if (measurement == null) {
+            logD("S400: No valid measurement in advertisement")
+            return BroadcastAction.IGNORED
+        }
+
+        logI("S400 measurement: weight=${measurement.weightKg}kg, impedance=${measurement.impedance}, hr=${measurement.heartRate}")
+
+        // Build scale measurement
+        val scaleMeasurement = ScaleMeasurement().apply {
+            dateTime = Date()
+            weight = measurement.weightKg
+            userId = user.id
+
+            // Calculate body composition if we have impedance
+            measurement.impedance?.let { imp ->
+                if (imp > 0) {
+                    val sex = if (user.gender == GenderType.MALE) 1 else 0
+                    val lib = MiScaleLib(sex, user.age, user.bodyHeight)
+
+                    fat = lib.getBodyFat(weight, imp)
+                    water = lib.getWater(weight, imp)
+                    muscle = lib.getMuscle(weight, imp)
+                    bone = lib.getBoneMass(weight, imp)
+                    lbm = lib.getLBM(weight, imp)
+                    visceralFat = lib.getVisceralFat(weight)
+                }
+            }
+        }
+
+        publish(scaleMeasurement)
+
+        // S400 sends a single final measurement, so we're done
+        return BroadcastAction.CONSUMED_STOP
+    }
+
+    /**
+     * Extract service data from the BLE scan result.
+     *
+     * The S400 sends data via Service Data (AD type 0x16) for the
+     * Body Composition Service UUID (0x181B).
+     */
+    private fun extractServiceData(result: ScanResult): ByteArray? {
+        val scanRecord = result.scanRecord ?: return null
+
+        // Try to get service data for the Body Composition Service
+        val serviceData = scanRecord.serviceData
+
+        // Check for 0x181B service data
+        serviceData?.get(SERVICE_UUID_S400)?.let { data ->
+            if (data.size >= 24) {
+                return data
+            }
+        }
+
+        // Some devices may include the service UUID in the data
+        // Try all service data entries
+        serviceData?.values?.forEach { data ->
+            if (data.size >= 24 && data.size <= 26) {
+                return data
+            }
+        }
+
+        // Fallback: check raw advertisement bytes for service data
+        val rawBytes = scanRecord.bytes
+        if (rawBytes != null && rawBytes.size >= 26) {
+            // Look for service data AD type (0x16) followed by 0x1B 0x18 (little-endian 0x181B)
+            for (i in 0 until rawBytes.size - 26) {
+                if (rawBytes[i] == 0x16.toByte() &&
+                    rawBytes[i + 1] == 0x1B.toByte() &&
+                    rawBytes[i + 2] == 0x18.toByte()) {
+                    // Found service data header, extract the data
+                    val dataStart = i + 3
+                    val remaining = rawBytes.size - dataStart
+                    if (remaining >= 24) {
+                        return rawBytes.copyOfRange(dataStart, dataStart + minOf(remaining, 26))
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
@@ -191,6 +191,7 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
                 DeviceCapability.LIVE_WEIGHT_STREAM,
                 DeviceCapability.BODY_COMPOSITION
             ),
+            tuningProfile = TuningProfile.Conservative,
             linkMode = LinkMode.BROADCAST_ONLY
         )
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,8 +73,8 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
 
     companion object {
         // Settings keys for S400 configuration
-        const val SETTINGS_KEY_BIND_KEY = "s400_bind_key"
-        const val SETTINGS_KEY_MAC_ADDRESS = "s400_mac_address"
+        private const val SETTINGS_KEY_BIND_KEY = "s400_bind_key"
+        private const val SETTINGS_KEY_MAC_ADDRESS = "s400_mac_address"
 
         // Known S400 device name patterns
         // The S400 may advertise with various names depending on firmware/region
@@ -94,19 +95,30 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
 
     @Composable
     override fun DeviceConfigurationUi() {
-        // Retrieve the current bind key from settings
-        val currentValue = settingsGetString(SETTINGS_KEY_BIND_KEY) ?: ""
+        // 1. Read the initial value from settings
+        val persistedValue = settingsGetString(SETTINGS_KEY_BIND_KEY) ?: ""
 
-        // Internal state for the text field to handle unsaved changes
-        var inputValue by remember(currentValue) { mutableStateOf(currentValue) }
+        // 2. Track the local input and a "isSaved" flag for immediate feedback
+        var inputValue by remember(persistedValue) { mutableStateOf(persistedValue) }
+        var lastSavedValue by remember { mutableStateOf(persistedValue) }
 
-        // Validation logic (S400 bind key must be exactly 32 hex chars)
+        // Validation logic
         val isValid = inputValue.length == 32
-        val hasChanged = inputValue != currentValue
         val showError = inputValue.isNotEmpty() && !isValid
+        // Logic: It's saved if it's valid and matches the last value we successfully wrote
+        val isSuccessfullySaved = isValid && inputValue == lastSavedValue && inputValue.isNotEmpty()
+
+        // Auto-save effect
+        LaunchedEffect(inputValue) {
+            if (isValid && inputValue != lastSavedValue) {
+                logD("Auto-saving valid bind key: $inputValue")
+                settingsPutString(SETTINGS_KEY_BIND_KEY, inputValue)
+                // Update the local "last saved" state immediately to trigger UI feedback
+                lastSavedValue = inputValue
+            }
+        }
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            // Description text explaining the bind key requirement
             Text(
                 text = stringResource(R.string.s400_bind_key_description),
                 style = MaterialTheme.typography.bodySmall,
@@ -116,7 +128,6 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
             OutlinedTextField(
                 value = inputValue,
                 onValueChange = { newValue ->
-                    // Filter: only allow digits and a-f, force lowercase, limit to 32 chars
                     val filtered = newValue
                         .filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
                         .lowercase()
@@ -124,7 +135,6 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
                         inputValue = filtered
                     }
                 },
-                // Using s400_bind_key_label as it fits the naming pattern
                 label = { Text(stringResource(R.string.s400_bind_key_label)) },
                 modifier = Modifier.fillMaxWidth(),
                 leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
@@ -136,36 +146,19 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         if (showError) {
-                            // Error message if input is not 32 characters
                             Text(stringResource(R.string.s400_bind_key_error))
+                        } else if (isSuccessfullySaved) {
+                            Text(
+                                text = stringResource(R.string.saved),
+                                color = MaterialTheme.colorScheme.primary
+                            )
                         } else {
-                            // Placeholder to keep the counter aligned to the right
                             Spacer(modifier = Modifier.weight(1f))
                         }
-                        // Character counter
                         Text("${inputValue.length}/32")
                     }
                 }
             )
-
-            // Action row with Save button
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-                androidx.compose.material3.TextButton(
-                    onClick = {
-                        if (isValid) {
-                            // Persist the value using the handler's helper
-                            settingsPutString(SETTINGS_KEY_BIND_KEY, inputValue)
-                        }
-                    },
-                    enabled = isValid && hasChanged
-                ) {
-                    // Using the generic save string
-                    Text(stringResource(R.string.save))
-                }
-            }
         }
     }
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleS400Handler.kt
@@ -15,6 +15,41 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.le.ScanResult
+import android.os.ParcelUuid
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.MiScaleLib
+import com.health.openscale.core.bluetooth.libs.S400Decryptor
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.service.ScannedDeviceInfo
+import java.util.Date
+import java.util.Locale
+import kotlin.text.isNotEmpty
+import kotlin.text.lowercase
+
 /**
  * Xiaomi Body Composition Scale S400 handler.
  *
@@ -29,25 +64,6 @@
  * Unlike older Mi Scales, the S400 requires:
  * - A BLE bind key extracted from Xiaomi Cloud
  * - The scale's MAC address (used in nonce construction)
- */
-package com.health.openscale.core.bluetooth.scales
-
-import android.bluetooth.le.ScanResult
-import android.os.ParcelUuid
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Key
-import com.health.openscale.R
-import com.health.openscale.core.bluetooth.data.ScaleMeasurement
-import com.health.openscale.core.bluetooth.data.ScaleUser
-import com.health.openscale.core.bluetooth.libs.MiScaleLib
-import com.health.openscale.core.bluetooth.libs.S400Decryptor
-import com.health.openscale.core.data.GenderType
-import com.health.openscale.core.service.ScannedDeviceInfo
-import java.util.Date
-import java.util.Locale
-
-/**
- * Handler for Xiaomi Body Composition Scale S400.
  *
  * This scale uses broadcast-only mode (no GATT connection) and sends
  * AES-CCM encrypted service data in BLE advertisements.
@@ -75,18 +91,83 @@ class MiScaleS400Handler : ScaleDeviceHandler() {
     // Track if we've warned about missing configuration
     private var warnedMissingConfig = false
 
-    override fun configFields(): List<ScaleConfigField> = listOf(
-        ScaleConfigField(
-            key = SETTINGS_KEY_BIND_KEY,
-            labelRes = R.string.s400_bind_key_label,
-            descriptionRes = R.string.s400_bind_key_description,
-            placeholderRes = R.string.s400_bind_key_placeholder,
-            errorRes = R.string.s400_bind_key_error,
-            icon = Icons.Default.Key,
-            maxLength = 32,
-            inputFilter = InputFilter.HEX,
-        )
-    )
+
+    @Composable
+    override fun DeviceConfigurationUi() {
+        // Retrieve the current bind key from settings
+        val currentValue = settingsGetString(SETTINGS_KEY_BIND_KEY) ?: ""
+
+        // Internal state for the text field to handle unsaved changes
+        var inputValue by remember(currentValue) { mutableStateOf(currentValue) }
+
+        // Validation logic (S400 bind key must be exactly 32 hex chars)
+        val isValid = inputValue.length == 32
+        val hasChanged = inputValue != currentValue
+        val showError = inputValue.isNotEmpty() && !isValid
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Description text explaining the bind key requirement
+            Text(
+                text = stringResource(R.string.s400_bind_key_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            OutlinedTextField(
+                value = inputValue,
+                onValueChange = { newValue ->
+                    // Filter: only allow digits and a-f, force lowercase, limit to 32 chars
+                    val filtered = newValue
+                        .filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+                        .lowercase()
+                    if (filtered.length <= 32) {
+                        inputValue = filtered
+                    }
+                },
+                // Using s400_bind_key_label as it fits the naming pattern
+                label = { Text(stringResource(R.string.s400_bind_key_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                leadingIcon = { Icon(Icons.Default.Key, contentDescription = null) },
+                singleLine = true,
+                isError = showError,
+                supportingText = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        if (showError) {
+                            // Error message if input is not 32 characters
+                            Text(stringResource(R.string.s400_bind_key_error))
+                        } else {
+                            // Placeholder to keep the counter aligned to the right
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                        // Character counter
+                        Text("${inputValue.length}/32")
+                    }
+                }
+            )
+
+            // Action row with Save button
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        if (isValid) {
+                            // Persist the value using the handler's helper
+                            settingsPutString(SETTINGS_KEY_BIND_KEY, inputValue)
+                        }
+                    },
+                    enabled = isValid && hasChanged
+                ) {
+                    // Using the generic save string
+                    Text(stringResource(R.string.save))
+                }
+            }
+        }
+    }
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name.uppercase(Locale.ROOT)

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ModernScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ModernScaleAdapter.kt
@@ -193,11 +193,10 @@ fun TuningProfile.forSpp(): BtSppTuning = when (this) {
 class FacadeDriverSettings(
     private val facade: SettingsFacade,
     private val scope: CoroutineScope,
-    deviceAddress: String,
     handlerNamespace: String
 ) : ScaleDeviceHandler.DriverSettings {
 
-    private val prefix = "ble/$handlerNamespace/$deviceAddress/"
+    private val prefix = "ble/$handlerNamespace/"
     private val mem = ConcurrentHashMap<String, String>()
 
     override fun getInt(key: String, default: Int): Int {
@@ -280,6 +279,13 @@ abstract class ModernScaleAdapter(
     @Volatile protected var lastSnapshot: Map<Int, ScaleMeasurement> = emptyMap()
 
     init {
+        val driverSettings = FacadeDriverSettings(
+            facade = settingsFacade,
+            scope = scope,
+            handlerNamespace = handler.javaClass.simpleName
+        )
+        handler.attachSettings(driverSettings)
+
         // Keep a *live* non-blocking snapshot of the current user.
         scope.launch {
             userFacade.observeSelectedUser().collect { u ->

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.outlined.BatteryStd
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
@@ -84,35 +85,6 @@ enum class LinkMode { CONNECT_GATT, BROADCAST_ONLY, CLASSIC_SPP }
  */
 enum class BroadcastAction { IGNORED, CONSUMED_KEEP_SCANNING, CONSUMED_STOP }
 
-/** How user input should be filtered for a [ScaleConfigField]. */
-enum class InputFilter { NONE, HEX }
-
-/**
- * Describes a user-configurable setting that a handler needs.
- *
- * The Bluetooth detail screen renders these generically so that each handler
- * can declare its own settings without any handler-specific UI code.
- *
- * @property key         Settings key passed to [ScaleDeviceHandler.DriverSettings] (e.g., "s400_bind_key").
- * @property labelRes    String resource for the input field label.
- * @property descriptionRes Optional string resource shown as helper text above the input.
- * @property placeholderRes Optional string resource shown as placeholder inside the input.
- * @property errorRes    Optional string resource shown when validation fails.
- * @property icon        Optional leading icon for the input field.
- * @property maxLength   Maximum input length; also used for validation (input is valid when length == maxLength).
- * @property inputFilter How to filter keystrokes (e.g., [InputFilter.HEX] for hex-only input).
- */
-data class ScaleConfigField(
-    val key: String,
-    @StringRes val labelRes: Int,
-    @StringRes val descriptionRes: Int? = null,
-    @StringRes val placeholderRes: Int? = null,
-    @StringRes val errorRes: Int? = null,
-    val icon: ImageVector? = null,
-    val maxLength: Int? = null,
-    val inputFilter: InputFilter = InputFilter.NONE,
-)
-
 /**
  * # ScaleDeviceHandler
  *
@@ -144,20 +116,13 @@ abstract class ScaleDeviceHandler {
     abstract fun supportFor(device: ScannedDeviceInfo): DeviceSupport?
 
     /**
-     * Stable identifier used as the namespace in persisted driver settings keys.
-     * Matches the value used by [FacadeDriverSettings]: `"ble/{handlerNamespace}/{address}/{key}"`.
+     * Optional UI component for device-specific settings.
+     * Override this in concrete handlers to show custom input fields.
      */
-    val handlerNamespace: String get() = this::class.simpleName ?: "Handler"
-
-    /**
-     * Override to declare configuration fields shown in the Bluetooth detail screen.
-     *
-     * Each returned [ScaleConfigField] becomes an input field that the user can edit.
-     * The values are persisted via [DriverSettings] using the field's [ScaleConfigField.key].
-     *
-     * Default: empty list (no handler-specific configuration).
-     */
-    open fun configFields(): List<ScaleConfigField> = emptyList()
+    @Composable
+    open fun DeviceConfigurationUi() {
+        // Default implementation is empty
+    }
 
     // --- Lifecycle entry points called by the adapter -------------------------
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -19,6 +19,8 @@ package com.health.openscale.core.bluetooth.scales
 
 import android.bluetooth.le.ScanResult
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoGraph
 import androidx.compose.material.icons.filled.FitnessCenter
@@ -27,8 +29,13 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.outlined.BatteryStd
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
 import com.health.openscale.core.bluetooth.BluetoothEvent.UserInteractionType
@@ -121,7 +128,17 @@ abstract class ScaleDeviceHandler {
      */
     @Composable
     open fun DeviceConfigurationUi() {
-        // Default implementation is empty
+        // Default message when no specific configuration is required
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.no_special_configuration_available),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 
     // --- Lifecycle entry points called by the adapter -------------------------

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -143,6 +143,10 @@ abstract class ScaleDeviceHandler {
 
     // --- Lifecycle entry points called by the adapter -------------------------
 
+    internal fun attachSettings(settings: DriverSettings) {
+        this.settings = settings
+    }
+
     internal fun attach(transport: Transport, callbacks: Callbacks, settings: DriverSettings, data: DataProvider) {
         this.transport = transport
         this.callbacks = callbacks
@@ -272,11 +276,11 @@ abstract class ScaleDeviceHandler {
     protected fun resolveString(@StringRes resId: Int, vararg args: Any): String =
         callbacks?.resolveString(resId, *args) ?: "res:$resId"
 
-    protected fun settingsGetInt(key: String, default: Int = -1): Int = settings?.getInt(key, default) ?: default
-    protected fun settingsPutInt(key: String, value: Int) { settings?.putInt(key, value) }
+    protected fun settingsGetInt(key: String, default: Int = -1): Int = settings.getInt(key, default)
+    protected fun settingsPutInt(key: String, value: Int) { settings.putInt(key, value) }
 
-    protected fun settingsGetString(key: String, default: String? = null): String? = settings?.getString(key, default) ?: default
-    protected fun settingsPutString(key: String, value: String) { settings?.putString(key, value) }
+    protected fun settingsGetString(key: String, default: String? = null): String? = settings.getString(key, default)
+    protected fun settingsPutString(key: String, value: String) { settings.putString(key, value) }
 
     protected fun currentAppUser(): ScaleUser = data.currentUser()
     protected fun usersForDevice(): List<ScaleUser> = data.usersForDevice()
@@ -317,7 +321,7 @@ abstract class ScaleDeviceHandler {
 
     private var transport: Transport? = null
     private var callbacks: Callbacks? = null
-    private var settings: DriverSettings? = null
+    private lateinit var settings: DriverSettings
     private lateinit var data: DataProvider
     /**
      * BLE transport the adapter provides. No threading/queueing implied here—

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -272,11 +272,11 @@ abstract class ScaleDeviceHandler {
     protected fun resolveString(@StringRes resId: Int, vararg args: Any): String =
         callbacks?.resolveString(resId, *args) ?: "res:$resId"
 
-    protected fun settingsGetInt(key: String, default: Int = -1): Int = settings.getInt(key, default)
-    protected fun settingsPutInt(key: String, value: Int) { settings.putInt(key, value) }
+    protected fun settingsGetInt(key: String, default: Int = -1): Int = settings?.getInt(key, default) ?: default
+    protected fun settingsPutInt(key: String, value: Int) { settings?.putInt(key, value) }
 
-    protected fun settingsGetString(key: String, default: String? = null): String? = settings.getString(key, default)
-    protected fun settingsPutString(key: String, value: String) { settings.putString(key, value) }
+    protected fun settingsGetString(key: String, default: String? = null): String? = settings?.getString(key, default) ?: default
+    protected fun settingsPutString(key: String, value: String) { settings?.putString(key, value) }
 
     protected fun currentAppUser(): ScaleUser = data.currentUser()
     protected fun usersForDevice(): List<ScaleUser> = data.usersForDevice()
@@ -317,7 +317,7 @@ abstract class ScaleDeviceHandler {
 
     private var transport: Transport? = null
     private var callbacks: Callbacks? = null
-    private lateinit var settings: DriverSettings
+    private var settings: DriverSettings? = null
     private lateinit var data: DataProvider
     /**
      * BLE transport the adapter provides. No threading/queueing implied here—

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SppScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SppScaleAdapter.kt
@@ -24,6 +24,7 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import android.os.SystemClock
+import androidx.compose.runtime.Composable
 import androidx.core.content.getSystemService
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
@@ -73,6 +74,12 @@ class SppScaleAdapter(
     private var sppOut: OutputStream? = null
 
     private val writeMutex = Mutex()
+
+    @Composable
+    override fun DeviceConfigurationUi() {
+        // Delegate to the actual protocol handler
+        handler.DeviceConfigurationUi()
+    }
 
     @SuppressLint("MissingPermission")
     override fun doConnect(address: String, selectedUser: ScaleUser) {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SppScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SppScaleAdapter.kt
@@ -162,7 +162,6 @@ class SppScaleAdapter(
                     val driverSettings = FacadeDriverSettings(
                         facade = settingsFacade,
                         scope = scope,
-                        deviceAddress = addr,
                         handlerNamespace = handler::class.simpleName ?: "Handler"
                     )
                     handler.attach(sppTransport, appCallbacks, driverSettings, dataProvider)

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/BluetoothFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/BluetoothFacade.kt
@@ -20,13 +20,14 @@ package com.health.openscale.core.facade
 import android.app.Application
 import android.bluetooth.BluetoothManager
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import com.health.openscale.core.bluetooth.BluetoothEvent
 import com.health.openscale.core.bluetooth.ScaleFactory
 import com.health.openscale.core.bluetooth.data.ScaleUser
 import com.health.openscale.core.bluetooth.scales.DeviceSupport
-import com.health.openscale.core.bluetooth.scales.ScaleConfigField
 import com.health.openscale.core.bluetooth.scales.TuningProfile
 import com.health.openscale.core.data.ConnectionStatus
 import com.health.openscale.core.data.User
@@ -43,7 +44,6 @@ import com.health.openscale.core.service.ScannedDeviceInfo
 import com.health.openscale.core.service.BluetoothScannerManager
 import com.health.openscale.core.service.BleConnector
 import com.health.openscale.ui.shared.SnackbarEvent
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * Facade responsible for orchestrating Bluetooth operations.
@@ -119,33 +119,17 @@ class BluetoothFacade @Inject constructor(
         }
     }
 
-    // --- Handler configuration ---
-    // Exposes the saved device's handler config fields and provides generic read/write
-    // using the same key format as FacadeDriverSettings: "ble/{handlerNamespace}/{address}/{key}"
+    @Composable
+    fun DeviceConfigurationUi() {
+        val device by savedDevice.collectAsState()
 
-    /** Config fields declared by the handler for the currently saved device. */
-    val savedDeviceConfigFields: StateFlow<List<ScaleConfigField>> =
-        savedDevice.map { device ->
-            if (device == null) return@map emptyList()
-            scaleFactory.getHandlerFor(device)?.configFields() ?: emptyList()
-        }.stateIn(scope, SharingStarted.WhileSubscribed(5000), emptyList())
+        device?.let { dev ->
+            // Create or remember the communicator for the current saved device
+            val communicator = remember(dev) { scaleFactory.createCommunicator(dev) }
 
-    /** Observe a single driver setting value for the currently saved device. */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    fun observeDriverSetting(key: String): Flow<String> {
-        return savedDevice.flatMapLatest { device ->
-            if (device == null) return@flatMapLatest flowOf("")
-            val ns = scaleFactory.getHandlerFor(device)?.handlerNamespace
-                ?: return@flatMapLatest flowOf("")
-            settingsFacade.observeSetting("ble/$ns/${device.address}/$key", "")
+            // Render the device-specific UI directly from the communicator
+            communicator?.DeviceConfigurationUi()
         }
-    }
-
-    /** Save a driver setting value for the currently saved device. */
-    suspend fun saveDriverSetting(key: String, value: String) {
-        val device = savedDevice.value ?: return
-        val ns = scaleFactory.getHandlerFor(device)?.handlerNamespace ?: return
-        settingsFacade.saveSetting("ble/$ns/${device.address}/$key", value)
     }
 
     // --- Current user context ---

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -193,10 +193,6 @@ interface SettingsFacade {
     val smartAssignmentIgnoreOutsideTolerance: Flow<Boolean>
     suspend fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean)
 
-    // S400 Scale Configuration
-    fun observeS400BindKey(deviceAddress: String): Flow<String>
-    suspend fun saveS400BindKey(deviceAddress: String, bindKey: String)
-
     val showChartDataPoints: Flow<Boolean>
     suspend fun setShowChartDataPoints(show: Boolean)
 
@@ -564,20 +560,6 @@ class SettingsFacadeImpl @Inject constructor(
 
     override suspend fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE.name, ignore)
-    }
-
-    // S400 Scale Configuration
-    // Key format matches FacadeDriverSettings: "ble/{handlerName}/{deviceAddress}/{settingKey}"
-    private fun s400BindKeyPath(deviceAddress: String) = "ble/MiScaleS400Handler/$deviceAddress/s400_bind_key"
-
-    override fun observeS400BindKey(deviceAddress: String): Flow<String> = observeSetting(
-        s400BindKeyPath(deviceAddress),
-        ""
-    )
-
-    override suspend fun saveS400BindKey(deviceAddress: String, bindKey: String) {
-        LogManager.d(TAG, "Saving S400 bind key for $deviceAddress (length: ${bindKey.length})")
-        saveSetting(s400BindKeyPath(deviceAddress), bindKey)
     }
 
     override val showChartDataPoints: Flow<Boolean> = observeSetting(

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -193,6 +193,10 @@ interface SettingsFacade {
     val smartAssignmentIgnoreOutsideTolerance: Flow<Boolean>
     suspend fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean)
 
+    // S400 Scale Configuration
+    fun observeS400BindKey(deviceAddress: String): Flow<String>
+    suspend fun saveS400BindKey(deviceAddress: String, bindKey: String)
+
     val showChartDataPoints: Flow<Boolean>
     suspend fun setShowChartDataPoints(show: Boolean)
 
@@ -560,6 +564,20 @@ class SettingsFacadeImpl @Inject constructor(
 
     override suspend fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE.name, ignore)
+    }
+
+    // S400 Scale Configuration
+    // Key format matches FacadeDriverSettings: "ble/{handlerName}/{deviceAddress}/{settingKey}"
+    private fun s400BindKeyPath(deviceAddress: String) = "ble/MiScaleS400Handler/$deviceAddress/s400_bind_key"
+
+    override fun observeS400BindKey(deviceAddress: String): Flow<String> = observeSetting(
+        s400BindKeyPath(deviceAddress),
+        ""
+    )
+
+    override suspend fun saveS400BindKey(deviceAddress: String, bindKey: String) {
+        LogManager.d(TAG, "Saving S400 bind key for $deviceAddress (length: ${bindKey.length})")
+        saveSetting(s400BindKeyPath(deviceAddress), bindKey)
     }
 
     override val showChartDataPoints: Flow<Boolean> = observeSetting(

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothDetailScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothDetailScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.DeleteForever
-import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
@@ -52,6 +51,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -70,6 +70,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.health.openscale.R
+import com.health.openscale.core.bluetooth.scales.InputFilter
+import com.health.openscale.core.bluetooth.scales.ScaleConfigField
 import com.health.openscale.core.bluetooth.scales.TuningProfile
 import com.health.openscale.core.data.InputFieldType
 import com.health.openscale.core.data.MeasurementTypeIcon
@@ -108,11 +110,9 @@ fun BluetoothDetailScreen(
     val availableTuningProfiles = remember { TuningProfile.entries.toList() }
     var showToleranceDialog by remember { mutableStateOf(false) }
 
-    // --- S400 Configuration State ---
-    val isS400Device = savedSupport?.displayName?.contains("S400", ignoreCase = true) == true
-    val s400BindKey by bluetoothViewModel.s400BindKey.collectAsStateWithLifecycle("")
-    var s400BindKeyInput by remember(s400BindKey) { mutableStateOf(s400BindKey) }
-    var showS400BindKeyError by remember { mutableStateOf(false) }
+    // --- Handler Configuration State ---
+    val configFields by bluetoothViewModel.configFields.collectAsStateWithLifecycle()
+    val configValues by bluetoothViewModel.configValues.collectAsStateWithLifecycle()
 
     if (showToleranceDialog) {
         NumberInputDialog(
@@ -146,61 +146,19 @@ fun BluetoothDetailScreen(
             .padding(all = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // --- S400 CONFIGURATION SECTION (only shown for S400 devices) ---
-        if (isS400Device) {
-            SettingsSectionTitle(title = stringResource(R.string.s400_configuration_title))
+        // --- HANDLER CONFIGURATION SECTION (shown when handler declares config fields) ---
+        if (configFields.isNotEmpty()) {
+            SettingsSectionTitle(title = stringResource(R.string.scale_configuration_title))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        text = stringResource(R.string.s400_bind_key_description),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = s400BindKeyInput,
-                        onValueChange = { newValue ->
-                            // Only allow hex characters
-                            val filtered = newValue.filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
-                                .take(32)
-                                .lowercase()
-                            s400BindKeyInput = filtered
-                            showS400BindKeyError = filtered.isNotEmpty() && filtered.length != 32
-                        },
-                        label = { Text(stringResource(R.string.s400_bind_key_label)) },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Default.Key,
-                                contentDescription = null
-                            )
-                        },
-                        placeholder = { Text(stringResource(R.string.s400_bind_key_placeholder)) },
-                        isError = showS400BindKeyError,
-                        supportingText = if (showS400BindKeyError) {
-                            { Text(stringResource(R.string.s400_bind_key_error)) }
-                        } else {
-                            { Text("${s400BindKeyInput.length}/32") }
-                        },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        androidx.compose.material3.TextButton(
-                            onClick = {
-                                if (s400BindKeyInput.length == 32) {
-                                    scope.launch {
-                                        bluetoothViewModel.setS400BindKey(s400BindKeyInput)
-                                    }
-                                }
-                            },
-                            enabled = s400BindKeyInput.length == 32 && s400BindKeyInput != s400BindKey
-                        ) {
-                            Text(stringResource(R.string.save))
-                        }
+                    configFields.forEach { field ->
+                        ScaleConfigFieldInput(
+                            field = field,
+                            currentValue = configValues[field.key] ?: "",
+                            onSave = { value ->
+                                scope.launch { bluetoothViewModel.setConfigValue(field.key, value) }
+                            }
+                        )
                     }
                 }
             }
@@ -439,6 +397,81 @@ private fun SettingsRow(
                 }
             }
             content()
+        }
+    }
+}
+
+/**
+ * Generic composable that renders a single [ScaleConfigField] as an input field
+ * with appropriate filtering, validation, and a save button.
+ */
+@Composable
+private fun ScaleConfigFieldInput(
+    field: ScaleConfigField,
+    currentValue: String,
+    onSave: (String) -> Unit
+) {
+    var inputValue by remember(currentValue) { mutableStateOf(currentValue) }
+    var showError by remember { mutableStateOf(false) }
+
+    val maxLen = field.maxLength
+
+    // Description text
+    field.descriptionRes?.let { resId ->
+        Text(
+            text = stringResource(resId),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    OutlinedTextField(
+        value = inputValue,
+        onValueChange = { newValue ->
+            val filtered = when (field.inputFilter) {
+                InputFilter.HEX -> newValue
+                    .filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
+                    .lowercase()
+                InputFilter.NONE -> newValue
+            }
+            val capped = if (maxLen != null) filtered.take(maxLen) else filtered
+            inputValue = capped
+            showError = capped.isNotEmpty() && maxLen != null && capped.length != maxLen
+        },
+        label = { Text(stringResource(field.labelRes)) },
+        leadingIcon = field.icon?.let { icon ->
+            { Icon(imageVector = icon, contentDescription = null) }
+        },
+        placeholder = field.placeholderRes?.let { resId ->
+            { Text(stringResource(resId)) }
+        },
+        isError = showError,
+        supportingText = when {
+            showError && field.errorRes != null -> {
+                { Text(stringResource(field.errorRes)) }
+            }
+            maxLen != null -> {
+                { Text("${inputValue.length}/$maxLen") }
+            }
+            else -> null
+        },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth()
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        val isValid = maxLen == null || inputValue.length == maxLen
+        TextButton(
+            onClick = { if (isValid) onSave(inputValue) },
+            enabled = isValid && inputValue != currentValue
+        ) {
+            Text(stringResource(R.string.save))
         }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothDetailScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothDetailScreen.kt
@@ -46,12 +46,10 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -70,8 +68,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.health.openscale.R
-import com.health.openscale.core.bluetooth.scales.InputFilter
-import com.health.openscale.core.bluetooth.scales.ScaleConfigField
 import com.health.openscale.core.bluetooth.scales.TuningProfile
 import com.health.openscale.core.data.InputFieldType
 import com.health.openscale.core.data.MeasurementTypeIcon
@@ -110,10 +106,6 @@ fun BluetoothDetailScreen(
     val availableTuningProfiles = remember { TuningProfile.entries.toList() }
     var showToleranceDialog by remember { mutableStateOf(false) }
 
-    // --- Handler Configuration State ---
-    val configFields by bluetoothViewModel.configFields.collectAsStateWithLifecycle()
-    val configValues by bluetoothViewModel.configValues.collectAsStateWithLifecycle()
-
     if (showToleranceDialog) {
         NumberInputDialog(
             title = stringResource(R.string.tolerance_label),
@@ -146,21 +138,10 @@ fun BluetoothDetailScreen(
             .padding(all = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // --- HANDLER CONFIGURATION SECTION (shown when handler declares config fields) ---
-        if (configFields.isNotEmpty()) {
-            SettingsSectionTitle(title = stringResource(R.string.scale_configuration_title))
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    configFields.forEach { field ->
-                        ScaleConfigFieldInput(
-                            field = field,
-                            currentValue = configValues[field.key] ?: "",
-                            onSave = { value ->
-                                scope.launch { bluetoothViewModel.setConfigValue(field.key, value) }
-                            }
-                        )
-                    }
-                }
+        SettingsSectionTitle(title = stringResource(R.string.scale_configuration_title))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                bluetoothViewModel.DeviceConfigurationUi()
             }
         }
 
@@ -397,81 +378,6 @@ private fun SettingsRow(
                 }
             }
             content()
-        }
-    }
-}
-
-/**
- * Generic composable that renders a single [ScaleConfigField] as an input field
- * with appropriate filtering, validation, and a save button.
- */
-@Composable
-private fun ScaleConfigFieldInput(
-    field: ScaleConfigField,
-    currentValue: String,
-    onSave: (String) -> Unit
-) {
-    var inputValue by remember(currentValue) { mutableStateOf(currentValue) }
-    var showError by remember { mutableStateOf(false) }
-
-    val maxLen = field.maxLength
-
-    // Description text
-    field.descriptionRes?.let { resId ->
-        Text(
-            text = stringResource(resId),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-    }
-
-    OutlinedTextField(
-        value = inputValue,
-        onValueChange = { newValue ->
-            val filtered = when (field.inputFilter) {
-                InputFilter.HEX -> newValue
-                    .filter { it.isDigit() || it.lowercaseChar() in 'a'..'f' }
-                    .lowercase()
-                InputFilter.NONE -> newValue
-            }
-            val capped = if (maxLen != null) filtered.take(maxLen) else filtered
-            inputValue = capped
-            showError = capped.isNotEmpty() && maxLen != null && capped.length != maxLen
-        },
-        label = { Text(stringResource(field.labelRes)) },
-        leadingIcon = field.icon?.let { icon ->
-            { Icon(imageVector = icon, contentDescription = null) }
-        },
-        placeholder = field.placeholderRes?.let { resId ->
-            { Text(stringResource(resId)) }
-        },
-        isError = showError,
-        supportingText = when {
-            showError && field.errorRes != null -> {
-                { Text(stringResource(field.errorRes)) }
-            }
-            maxLen != null -> {
-                { Text("${inputValue.length}/$maxLen") }
-            }
-            else -> null
-        },
-        singleLine = true,
-        modifier = Modifier.fillMaxWidth()
-    )
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End
-    ) {
-        val isValid = maxLen == null || inputValue.length == maxLen
-        TextButton(
-            onClick = { if (isValid) onSave(inputValue) },
-            enabled = isValid && inputValue != currentValue
-        ) {
-            Text(stringResource(R.string.save))
         }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothViewModel.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothViewModel.kt
@@ -89,6 +89,9 @@ class BluetoothViewModel @Inject constructor(
     val smartAssignmentTolerancePercent = settingsFacade.smartAssignmentTolerancePercent
     val smartAssignmentIgnoreOutsideTolerance = settingsFacade.smartAssignmentIgnoreOutsideTolerance
 
+    // S400 configuration
+    val s400BindKey = bt.s400BindKey
+
     fun setSmartAssignmentEnabled(enabled: Boolean) = viewModelScope.launch {
         settingsFacade.setSmartAssignmentEnabled(enabled)
     }
@@ -99,6 +102,10 @@ class BluetoothViewModel @Inject constructor(
 
     fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean) = viewModelScope.launch {
         settingsFacade.setSmartAssignmentIgnoreOutsideTolerance(ignore)
+    }
+
+    fun setS400BindKey(bindKey: String) = viewModelScope.launch {
+        bt.setS400BindKey(bindKey)
     }
 
     // --- Snackbar events for UI ---

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothViewModel.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothViewModel.kt
@@ -17,48 +17,21 @@
  */
 package com.health.openscale.ui.screen.settings
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.BluetoothEvent
-import com.health.openscale.core.bluetooth.scales.ScaleConfigField
 import com.health.openscale.core.bluetooth.scales.TuningProfile
 import com.health.openscale.core.facade.BluetoothFacade
 import com.health.openscale.core.facade.SettingsFacade
 import com.health.openscale.core.service.ScannedDeviceInfo
 import com.health.openscale.ui.shared.SnackbarEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -97,30 +70,6 @@ class BluetoothViewModel @Inject constructor(
     val smartAssignmentTolerancePercent = settingsFacade.smartAssignmentTolerancePercent
     val smartAssignmentIgnoreOutsideTolerance = settingsFacade.smartAssignmentIgnoreOutsideTolerance
 
-    // --- Handler-declared configuration fields ---
-    val configFields: StateFlow<List<ScaleConfigField>> = bt.savedDeviceConfigFields
-
-    /** Current values for each handler config field, keyed by [ScaleConfigField.key]. */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val configValues: StateFlow<Map<String, String>> = configFields
-        .flatMapLatest { fields ->
-            if (fields.isEmpty()) return@flatMapLatest flowOf(emptyMap<String, String>())
-            val flows = fields.map { field ->
-                bt.observeDriverSetting(field.key).stateIn(
-                    viewModelScope, SharingStarted.WhileSubscribed(5000), ""
-                )
-            }
-            combine(flows) { values ->
-                fields.mapIndexed { i, field -> field.key to values[i] }.toMap()
-            }
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
-
-    /** Save a handler config field value. */
-    fun setConfigValue(key: String, value: String) = viewModelScope.launch {
-        bt.saveDriverSetting(key, value)
-    }
-
     fun setSmartAssignmentEnabled(enabled: Boolean) = viewModelScope.launch {
         settingsFacade.setSmartAssignmentEnabled(enabled)
     }
@@ -146,6 +95,9 @@ class BluetoothViewModel @Inject constructor(
     }
 
     // --- Delegated actions ---
+    @Composable
+    fun DeviceConfigurationUi() = bt.DeviceConfigurationUi()
+
     fun requestStartDeviceScan() {
         if (!bt.isBluetoothEnabled()) {
             emitSnack(R.string.bluetooth_must_be_enabled_for_scan, SnackbarDuration.Long)

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -359,8 +359,10 @@
     <string name="developer_section_title">Developer</string>
     <string name="danger_zone_title">Danger Zone</string>
 
+    <!-- Scale Configuration (generic, shown when a handler declares config fields) -->
+    <string name="scale_configuration_title">Scale Configuration</string>
+
     <!-- S400 Scale Configuration -->
-    <string name="s400_configuration_title">S400 Configuration</string>
     <string name="s400_bind_key_label">BLE Bind Key</string>
     <string name="s400_bind_key_placeholder">32-character hex key</string>
     <string name="s400_bind_key_description">The Xiaomi S400 scale requires a BLE bind key for decryption. Extract this key from Xiaomi Cloud using the Xiaomi Cloud Tokens Extractor tool.</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="clear_button">Clear</string>
     <string name="confirm_button">Confirm</string>
     <string name="dialog_ok">OK</string>
+    <string name="save">Save</string>
     <string name="switch_on">On</string>
     <string name="switch_off">Off</string>
     <string name="open_link_content_description">Open link</string>
@@ -357,6 +358,14 @@
     <string name="tolerance_desc">Max. weight deviation to automatically assign to a user.</string>
     <string name="developer_section_title">Developer</string>
     <string name="danger_zone_title">Danger Zone</string>
+
+    <!-- S400 Scale Configuration -->
+    <string name="s400_configuration_title">S400 Configuration</string>
+    <string name="s400_bind_key_label">BLE Bind Key</string>
+    <string name="s400_bind_key_placeholder">32-character hex key</string>
+    <string name="s400_bind_key_description">The Xiaomi S400 scale requires a BLE bind key for decryption. Extract this key from Xiaomi Cloud using the Xiaomi Cloud Tokens Extractor tool.</string>
+    <string name="s400_bind_key_error">Bind key must be exactly 32 hex characters</string>
+    <string name="bt_s400_missing_bind_key">S400: Bind key not configured. Go to Bluetooth settings to enter your BLE key.</string>
 
     <!-- Bluetooth Connector -->
     <string name="bluetooth_connector_connected_to">Connected to %1$s</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="clear_button">Clear</string>
     <string name="confirm_button">Confirm</string>
     <string name="dialog_ok">OK</string>
-    <string name="save">Save</string>
+    <string name="saved">Saved</string>
     <string name="switch_on">On</string>
     <string name="switch_off">Off</string>
     <string name="open_link_content_description">Open link</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -361,6 +361,7 @@
 
     <!-- Scale Configuration (generic, shown when a handler declares config fields) -->
     <string name="scale_configuration_title">Scale Configuration</string>
+    <string name="no_special_configuration_available">No additional special configuration available for this device.</string>
 
     <!-- S400 Scale Configuration -->
     <string name="s400_bind_key_label">BLE Bind Key</string>

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/S400DecryptorTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/S400DecryptorTest.kt
@@ -1,0 +1,199 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [S400Decryptor].
+ *
+ * Test vectors are derived from the mi-scale-exporter project:
+ * https://github.com/lswiderski/MiScaleBodyComposition
+ */
+class S400DecryptorTest {
+
+    companion object {
+        // Test configuration from mi-scale-exporter test suite
+        private const val TEST_MAC = "84:46:93:64:A5:E6"
+        private const val TEST_BIND_KEY = "58305740b64e4b425e518aa1f4e51339"
+
+        private fun hexToByteArray(hex: String): ByteArray {
+            val cleanHex = hex.replace(" ", "").lowercase()
+            return cleanHex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        }
+    }
+
+    // --- Validation tests ---
+
+    @Test
+    fun isValidBindKey_acceptsValid32CharHexKey() {
+        assertThat(S400Decryptor.isValidBindKey("58305740b64e4b425e518aa1f4e51339")).isTrue()
+        assertThat(S400Decryptor.isValidBindKey("00000000000000000000000000000000")).isTrue()
+        assertThat(S400Decryptor.isValidBindKey("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")).isTrue()
+        assertThat(S400Decryptor.isValidBindKey("abcdef0123456789abcdef0123456789")).isTrue()
+    }
+
+    @Test
+    fun isValidBindKey_rejectsInvalidKeys() {
+        // Too short
+        assertThat(S400Decryptor.isValidBindKey("58305740b64e4b425e518aa1f4e5133")).isFalse()
+        // Too long
+        assertThat(S400Decryptor.isValidBindKey("58305740b64e4b425e518aa1f4e513399")).isFalse()
+        // Contains invalid characters
+        assertThat(S400Decryptor.isValidBindKey("58305740b64e4b425e518aa1f4e5133g")).isFalse()
+        // Empty
+        assertThat(S400Decryptor.isValidBindKey("")).isFalse()
+    }
+
+    @Test
+    fun isValidMacAddress_acceptsValidFormats() {
+        assertThat(S400Decryptor.isValidMacAddress("84:46:93:64:A5:E6")).isTrue()
+        assertThat(S400Decryptor.isValidMacAddress("00:00:00:00:00:00")).isTrue()
+        assertThat(S400Decryptor.isValidMacAddress("FF:FF:FF:FF:FF:FF")).isTrue()
+        assertThat(S400Decryptor.isValidMacAddress("aa:bb:cc:dd:ee:ff")).isTrue()
+    }
+
+    @Test
+    fun isValidMacAddress_rejectsInvalidFormats() {
+        // No colons
+        assertThat(S400Decryptor.isValidMacAddress("844693e4A5E6")).isFalse()
+        // Wrong separator
+        assertThat(S400Decryptor.isValidMacAddress("84-46-93-64-A5-E6")).isFalse()
+        // Too short
+        assertThat(S400Decryptor.isValidMacAddress("84:46:93:64:A5")).isFalse()
+        // Invalid characters
+        assertThat(S400Decryptor.isValidMacAddress("84:46:93:64:A5:GG")).isFalse()
+        // Empty
+        assertThat(S400Decryptor.isValidMacAddress("")).isFalse()
+    }
+
+    // --- Decryption tests using vectors from mi-scale-exporter ---
+
+    @Test
+    fun decrypt_24ByteData_returnsCorrectWeight() {
+        // Test1 from S400Test.cs: expected weight = 74.2
+        val data = hexToByteArray("4859d53b2d3314943c58b133638c7457a4000000c3e670dc")
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.weightKg).isWithin(0.1f).of(74.2f)
+    }
+
+    @Test
+    fun decrypt_26ByteDataFromHex_returnsCorrectWeight() {
+        // Test26bytesHex from S400Test.cs: expected weight = 73.2
+        val data = hexToByteArray("95FE4859D53B3BDE6BC8D05B51C0CDFD9021C9000000925C5039")
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.weightKg).isWithin(0.1f).of(73.2f)
+    }
+
+    @Test
+    fun decrypt_26ByteDataFromBytes_returnsCorrectWeight() {
+        // Test26bytes from S400Test.cs: expected weight = 73.3
+        val data = byteArrayOf(
+            149.toByte(), 254.toByte(), 72, 89, 213.toByte(), 59, 77, 111, 53,
+            156.toByte(), 229.toByte(), 111, 31, 126, 126, 10, 221.toByte(),
+            220.toByte(), 38, 0, 0, 0, 12, 19, 211.toByte(), 196.toByte()
+        )
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.weightKg).isWithin(0.1f).of(73.3f)
+    }
+
+    @Test
+    fun decrypt_weightOnlyData_returnsWeightWithNoImpedance() {
+        // Test26bytesOnlyWeight from S400Test.cs: weight > 0, impedance = null
+        val data = byteArrayOf(
+            149.toByte(), 254.toByte(), 72, 89, 213.toByte(), 59, 99, 187.toByte(),
+            88, 121, 80, 225.toByte(), 4, 44, 172.toByte(), 28, 95, 24, 246.toByte(),
+            0, 0, 0, 219.toByte(), 233.toByte(), 112, 52
+        )
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.weightKg).isGreaterThan(0f)
+        assertThat(result.impedance).isNull()
+    }
+
+    @Test
+    fun decrypt_invalidDataLength_returnsNull() {
+        // TestJustMACAddress from S400Test.cs: too short data (11 bytes)
+        val data = hexToByteArray("1059d53b06e6a5649346 84")
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun decrypt_invalidBindKey_returnsNull() {
+        val data = hexToByteArray("4859d53b2d3314943c58b133638c7457a4000000c3e670dc")
+        val invalidKey = "00000000000000000000000000000000"
+
+        // Decryption with wrong key should fail (or return null/invalid data)
+        val result = S400Decryptor.decrypt(data, TEST_MAC, invalidKey)
+
+        // With wrong key, decryption will either:
+        // 1. Return null (if exception is caught)
+        // 2. Return invalid measurement (weight = 0 or nonsense)
+        val isInvalidResult = result == null || result.weightKg <= 0f || result.weightKg > 500f
+        assertThat(isInvalidResult).isTrue()
+    }
+
+    @Test
+    fun decrypt_shortBindKey_returnsNull() {
+        val data = hexToByteArray("4859d53b2d3314943c58b133638c7457a4000000c3e670dc")
+        val shortKey = "58305740b64e4b42" // Only 16 chars instead of 32
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, shortKey)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun decrypt_emptyData_returnsNull() {
+        val result = S400Decryptor.decrypt(byteArrayOf(), TEST_MAC, TEST_BIND_KEY)
+        assertThat(result).isNull()
+    }
+
+    // --- Measurement value extraction tests ---
+
+    @Test
+    fun measurement_hasExpectedFields() {
+        val data = hexToByteArray("4859d53b2d3314943c58b133638c7457a4000000c3e670dc")
+
+        val result = S400Decryptor.decrypt(data, TEST_MAC, TEST_BIND_KEY)
+
+        assertThat(result).isNotNull()
+        // Weight should be reasonable (between 0 and 300 kg)
+        assertThat(result!!.weightKg).isGreaterThan(0f)
+        assertThat(result.weightKg).isLessThan(300f)
+        // Impedance if present should be reasonable (typically 300-1000 ohms for body)
+        result.impedance?.let { imp ->
+            assertThat(imp).isGreaterThan(0f)
+        }
+    }
+}

--- a/android_app/gradle/libs.versions.toml
+++ b/android_app/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ glance = "1.1.1"
 kotlinCsv = "1.10.0"
 blessedKotlin = "3.0.11"
 truth = "1.4.5"
+bouncycastle = "1.79"
 
 
 [libraries]
@@ -67,6 +68,7 @@ androidx-glance-material3 = { group = "androidx.glance", name = "glance-material
 kotlin-csv-jvm = { group = "com.github.doyaaaaaken", name = "kotlin-csv-jvm", version.ref = "kotlinCsv" }
 blessed-kotlin = { group = "com.github.weliem", name = "blessed-kotlin", version.ref = "blessedKotlin" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 
 
 [plugins]


### PR DESCRIPTION
Hi,

Thank you for maintaining openScale. I just bought the Xiaomi Body Composition Scale S400 and I noticed openScale didn't support it, so here we are.

I didn't reverse the bluetooth protocol myself, I leveraged the work done [in this repo](https://github.com/lswiderski/mi-scale-exporter), so that sped things up.

This scale uses encryption in its bluetooth protocol, so the BLE key must be extracted. Here is how:

---

# 1. Initial Scale Setup (if not done)

1. Install the Xiaomi Home app on your phone
2. Add your S400 scale as a new device
3. Complete at least one weighing to ensure the scale is registered with Xiaomi Cloud

# 2. Extract Tokens Using Xiaomi Cloud Tokens Extractor

```bash
# Clone the repository
git clone https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor.git
cd Xiaomi-cloud-tokens-extractor

# Install dependencies
pip install -r requirements.txt

# Run the extractor
python token_extractor.py
```

When prompted:
1. Enter your Xiaomi account email/username
2. Enter your password
3. Select your region (e.g., `de` for Germany, `us` for USA, `cn` for China)

# 3. Find Your Scale's Information

The extractor will output a list of all your Xiaomi devices. Look for your scale:

```
Device: Xiaomi Body Composition Scale S400
Model: xmtzc14hm (or similar)
MAC: AA:BB:CC:DD:EE:FF
BLE KEY: 0123456789abcdef0123456789abcdef
```

**Save these two values:**
- **MAC**: The Bluetooth address (format `XX:XX:XX:XX:XX:XX`)
- **BLE KEY**: A 32-character hexadecimal string

# 4. Kill the Xiaomi Home App

Kill the app or uninstall it.

---

Once you have the key, this is pretty straightforward.


This is a measurement done with the Xiaomi Home App:

<img width="1220" height="2712" alt="Screenshot_20260129-075926 Xiaomi Home" src="https://github.com/user-attachments/assets/f83ecac9-e39e-4aa9-ba6c-fe7474b79bd3" />

This is a measurement done with openScale (there is a difference because I did the measurement in the Xiaomi Home app the day after, while making this PR, to prove that it works):
<img width="1220" height="2712" alt="Screenshot_20260129-074517 openScale" src="https://github.com/user-attachments/assets/bbb6a665-e521-4927-850a-408880e18eaf" />

Here are a few other screenshots:


<img width="1220" height="2712" alt="Screenshot_20260129-074325 openScale" src="https://github.com/user-attachments/assets/929dd7cc-e783-4431-b3bb-075f1d26fdd2" />
<img width="1220" height="2712" alt="Screenshot_20260129-074334 openScale" src="https://github.com/user-attachments/assets/409b03f5-0432-4030-bdc4-e3c837eaa398" />
<img width="1220" height="2712" alt="Screenshot_20260129-074420 openScale" src="https://github.com/user-attachments/assets/e63927d6-8a07-4f09-bba0-7a06ac7185e2" />

To be clear: I built the app locally in debug mode, sideloaded it onto my phone and performed a real measurement.

I had to add a little bit of UI to add the BLE bind key in the setting. I couldn't find an existing example in openScale where this was done already, please let me know if I missed it.

Disclaimer: I did use AI to write most of the code. However I reviewed the code to the best of my abilities and I carefully tested the app. I compared all the metrics one by one with the official app to make sure that the values make sense in openScale.