### PR TITLE
Fix consent code not being cleared on rejection or device removal. 

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -279,6 +279,8 @@ abstract class ScaleDeviceHandler {
     protected fun settingsGetInt(key: String, default: Int = -1): Int = settings.getInt(key, default)
     protected fun settingsPutInt(key: String, value: Int) { settings.putInt(key, value) }
 
+    protected fun settingsRemove(key: String) { settings.remove(key) }
+
     protected fun settingsGetString(key: String, default: String? = null): String? = settings.getString(key, default)
     protected fun settingsPutString(key: String, value: String) { settings.putString(key, value) }
 

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardWeightProfileHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardWeightProfileHandler.kt
@@ -557,6 +557,11 @@ open class StandardWeightProfileHandler : ScaleDeviceHandler() {
                         val idx = findKnownScaleIndexForAppUser(appId)
                         idx?.let { userInfo(R.string.bt_info_consent_needed, it) }
                         logW("UDS CONSENT failed: User not authorized for appUserId=$appId")
+                        idx?.let {
+                            saveConsentForScaleIndex(it, -1)
+                            logD("Cleared bad consent for scaleIndex=$it, re-prompting user")
+                            requestScaleUserConsent(appId, it)
+                        }
                     }
                     else -> {
                         logW("UDS CONSENT unhandled result=$result for appUserId=${pendingAppUserId ?: currentAppUser().id}")

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/BluetoothFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/BluetoothFacade.kt
@@ -206,6 +206,7 @@ class BluetoothFacade @Inject constructor(
     fun removeSavedDevice() {
         scope.launch {
             settingsFacade.clearSavedBluetoothScale()
+            settingsFacade.clearBleDriverSettings()
             settingsFacade.saveBluetoothTuneProfile(null)
         }
     }

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -180,6 +180,7 @@ interface SettingsFacade {
     fun observeSavedDevice(): Flow<ScannedDeviceInfo?>
     suspend fun saveSavedDevice(device: ScannedDeviceInfo)
     suspend fun clearSavedBluetoothScale()
+    suspend fun clearBleDriverSettings()
 
     val savedBluetoothTuneProfile: Flow<String?>
     suspend fun saveBluetoothTuneProfile(name: String?)
@@ -507,6 +508,17 @@ class SettingsFacadeImpl @Inject constructor(
             prefs.remove(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS)
             prefs.remove(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT)
             prefs.remove(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA)
+        }
+    }
+
+    override suspend fun clearBleDriverSettings() {
+        LogManager.i(TAG, "Clearing all BLE driver settings (consent codes, user mappings).")
+        dataStore.edit { prefs ->
+            val bleKeys = prefs.asMap().keys.filter { it.name.startsWith("ble/") }
+            for (key in bleKeys) {
+                prefs.remove(key)
+            }
+            LogManager.d(TAG, "Removed ${bleKeys.size} BLE driver setting(s).")
         }
     }
 


### PR DESCRIPTION
When a scale rejects a wrong consent code, the stored code is now reset and the user is re-prompted immediately. Removing a saved device now also clears all persisted BLE driver settings (consent codes, user-slot mappings) so re-pairing starts fresh.

Issues:
#1216 #1236 #1307 #1187 #1157