### PR TITLE
Fix unnecessary muscle percentage calculation

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardWeightProfileHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardWeightProfileHandler.kt
@@ -179,7 +179,6 @@ open class StandardWeightProfileHandler : ScaleDeviceHandler() {
 
         val w = m.weight.takeIf { it > 0f } ?: 1f
 
-        m.muscle = (m.muscle / w) * 100f
         m.water = (m.water / w) * 100f
 
         logD("transformed values before publish: weight=${m.weight}kg, lbm=${m.lbm}kg, bone=${m.bone}kg, " +


### PR DESCRIPTION
Removed muscle percentage calculation from measurement transformation, since the acquired value from the raw measurement is already a percentage and not an absolute value: https://github.com/oliexdev/openScale/blob/73cfb820f37c31faade5f9766be0fe1e9737fc75/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardWeightProfileHandler.kt#L414-L417

Fixes #1282 