### PR TITLE
Implemented StandardImpedanceLib and switched Etekcity ESF-551 to use that lib

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/StandardImpedanceLib.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/StandardImpedanceLib.kt
@@ -1,0 +1,133 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import com.health.openscale.core.data.GenderType
+
+/**
+ * This provides as far as possible science-based algorithms which are as far as possible based on impedance.
+ * Use this for scales which don't provide all the measurements or in general as a replacement for a scale's
+ * built-in formulas which are often unscientific and ignore impedance.
+ *
+ * The formulas strive to be consistent within themselves and with established formulas.
+ * For example, this paper mentions a formula for TBW (total body water) vs. FFM (fat-free mass):
+ * https://pmc.ncbi.nlm.nih.gov/articles/PMC11625996/
+ * TBW / FFM = 0.732
+ * So, our water percentage and body fat percentage and fat-free mass should be consistent with that formula.
+ *
+ * Also, when taking a normal person, all formulas should produce values that are considered normal.
+ * For example, the TBW should be 59% for an average male, but can range from 43-73%.
+ *
+ * Finally, let's get to the problems:
+ * We assume that the calculated absolute values are imprecise. One reason is that consumer scales are imprecise.
+ * Also, impedance can vary quite a bit based on what you did that day.
+ * For example, when you sweat a lot (i.e. your body loses water), this can influence the impedance.
+ * So, don't measure directly after a workout, but better wait for at least 2h.
+ * Ideally you keep all conditions as similar as possible when doing measurements and avoid measuring directly
+ * after workout or a big lunch break.
+ *
+ * So does this mean all measurements are useless? Not quite:
+ * We can still focus on tracking relative changes over longer time periods. You can still see that your muscle mass
+ * has increased or your body fat has decreased over several months. Also, you might see these changes in the data
+ * earlier than in the mirror. At least it can be fun and motivating to track.
+ *
+ * Assumption about impedance measurements:
+ * For a man who is around 180cm tall and has normal BMI, the scale should report an impedance of around 500 ± 100.
+ * Even such a large error won't have a huge influence on the calculated body fat, so you can at least approximately
+ * track how well in shape you are.
+ * However, if your scale reports an impedance of e.g. 250 or 800 then better don't use this class.
+ */
+data class StandardImpedanceLib(
+    val gender: GenderType,
+    val age: Int,
+    val weightKg: Double,
+    val heightM: Double,
+    val impedance: Double,
+) {
+    val isMale = gender == GenderType.MALE
+    val genderInt = if (isMale) 1 else 0
+
+    val heightCm = heightM * 100.0
+
+    /**
+     * Reusable constant for H_cm^2 / R which appears in several impedance-based formulas.
+     */
+    val h2rCoeff = heightCm * heightCm / impedance
+
+    /**
+     * BMI using standard formula.
+     */
+    val bmi: Double = weightKg / (heightM * heightM)
+
+    /**
+     * FFM / fat-free mass according to Sun SS et al. (2003).
+     *
+     * https://www.researchgate.net/publication/10940351_Sun_SS_Chumlea_WC_Heymsfield_SB_Lukaski_HC_Schoeller_D_Friedl_K_Kuczmarski_RJ_Flegal_KM_Johnson_CL_Hubbard_VSDevelopment_of_bioelectrical_impedance_analysis_prediction_equations_for_body_composition_w
+     */
+    val fatFreeMassKg: Double by lazy {
+        if (isMale) {
+            -10.68 + 0.65 * h2rCoeff + 0.26 * weightKg + 0.02 * impedance
+        } else {
+            -9.53 + 0.69 * h2rCoeff + 0.17 * weightKg + 0.02 * impedance
+        }
+    }
+
+    val totalFatPercentage: Double = (1.0 - fatFreeMassKg / weightKg) * 100.0
+
+    /**
+     * TBW / total body water according to Sun SS et al. (2003).
+     *
+     * https://www.researchgate.net/publication/10940351_Sun_SS_Chumlea_WC_Heymsfield_SB_Lukaski_HC_Schoeller_D_Friedl_K_Kuczmarski_RJ_Flegal_KM_Johnson_CL_Hubbard_VSDevelopment_of_bioelectrical_impedance_analysis_prediction_equations_for_body_composition_w
+     *
+     * TODO: For children we might want to use the Mellits-Cheek formula.
+     */
+    val totalBodyWaterKg: Double by lazy {
+        val liters = if (isMale) 1.2 + 0.45 * h2rCoeff + 0.18 * weightKg else 3.75 + 0.45 * h2rCoeff + 0.11 * weightKg
+        // Convert liters to kg at an average 36.5°C water temperature across the whole body
+        0.99513 * liters
+    }
+
+    val totalBodyWaterPercentage: Double by lazy {
+        (totalBodyWaterKg / weightKg) * 100.0
+    }
+
+    /**
+     * BMR / basal metabolic rate according to Katch-McArdle.
+     *
+     * TODO: For women we might have to distinguish by age: https://www.mdpi.com/2072-6643/13/2/345
+     */
+    val basalMetabolicRate: Double = fatFreeMassKg * 21.6 + 370
+
+    /**
+     * Skeletal Muscle Mass (%) according to Janssen et al.
+     *
+     * Not to be confused with the total muscle mass.
+     */
+    val skeletalMuscleMassKg: Double by lazy {
+        0.401 * h2rCoeff + 3.825 * genderInt - 0.071 * age + 5.102
+    }
+
+    val skeletalMusclePercentage: Double by lazy {
+        (skeletalMuscleMassKg / weightKg) * 100.0
+    }
+
+    val boneMassKg: Double by lazy {
+        val factor = if (isMale) 0.057 else 0.05
+        factor * fatFreeMassKg
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityESF551Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityESF551Handler.kt
@@ -20,7 +20,7 @@ package com.health.openscale.core.bluetooth.scales
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
-import com.health.openscale.core.bluetooth.libs.EtekcityLib
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
 import com.health.openscale.core.data.WeightUnit
 import com.health.openscale.core.service.ScannedDeviceInfo
 import java.util.Date
@@ -110,7 +110,7 @@ class EtekcityESF551Handler : ScaleDeviceHandler() {
         }
 
         val weightRaw = data[10].toUInt() or data[11].toUInt().shl(8) or data[12].toUInt().shl(16)
-        val weightKg = weightRaw.toInt() / 1000.0
+        val weightKg = weightRaw.toDouble() / 1000.0
         val impedance = (data[13].toUInt() or data[14].toUInt().shl(8)).toDouble()
 //        val displayUnit = WeightUnit.fromInt(data[21].toInt())
         val measurement = ScaleMeasurement(
@@ -120,31 +120,19 @@ class EtekcityESF551Handler : ScaleDeviceHandler() {
             impedance = impedance,
         )
 
-        if (impedance > 0) {
-            val lib = EtekcityLib(
+        if (impedance > 0 && impedance < 1500) {
+            val lib = StandardImpedanceLib(
                 gender = user.gender,
                 age = user.age,
                 weightKg = weightKg,
                 heightM = user.bodyHeight / 100.0,
                 impedance = impedance,
             )
-            measurement.fat = lib.bodyFatPercentage.toFloat()
-            measurement.water = lib.water.toFloat()
+            measurement.fat = lib.totalFatPercentage.toFloat()
+            measurement.water = lib.totalBodyWaterPercentage.toFloat()
             measurement.muscle = lib.skeletalMusclePercentage.toFloat()
-            measurement.visceralFat = lib.visceralFat.toFloat()
-            measurement.bone = lib.boneMass.toFloat()
+            measurement.bone = lib.boneMassKg.toFloat()
             measurement.bmr = lib.basalMetabolicRate.toFloat()
-
-            // TODO: Add other measurements once supported
-//            measurement.fatFreeWeight = lib.fatFreeWeight.toFloat()
-//            measurement.subcutaneousFat = lib.subcutaneousFat.toFloat()
-//            measurement.muscleMass = lib.muscleMass.toFloat()
-//            measurement.proteinPercentage = lib.proteinPercentage.toFloat()
-//            measurement.weightScore = lib.weightScore
-//            measurement.fatScore = lib.fatScore
-//            measurement.bmiScore = lib.bmiScore
-//            measurement.healthScore = lib.healthScore
-//            measurement.metabolicAge = lib.metabolicAge
         }
 
         if (data[20] == 1.toByte() && impedance > 0) {

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/StandardImpedanceLibTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/StandardImpedanceLibTest.kt
@@ -22,31 +22,26 @@ import com.health.openscale.core.data.GenderType
 import org.junit.Test
 
 /**
- * Unit tests for [EtekcityLib].
+ * Unit tests for [StandardImpedanceLib].
  */
-class EtekcityLibTest {
+class StandardImpedanceLibTest {
     internal val EPS = 1e-3 // general float tolerance
 
-    val lib = EtekcityLib(gender = GenderType.MALE, age = 30, weightKg = 80.0, heightM = 1.8, impedance = 527.0)
+    val lib = StandardImpedanceLib(gender = GenderType.MALE, age = 30, weightKg = 80.0, heightM = 1.8, impedance = 527.0)
 
     @Test
     fun bmi_isComputedCorrectly_forTypicalMale() {
         assertThat(lib.bmi).isWithin(EPS).of(24.69136)
-        assertThat(lib.bodyFatPercentage).isWithin(EPS).of(17.7)
-        assertThat(lib.fatFreeWeight).isWithin(EPS).of(65.84)
-        assertThat(lib.visceralFat).isWithin(EPS).of(7.64163)
-        assertThat(lib.water).isWithin(EPS).of(59.4206)
-        assertThat(lib.basalMetabolicRate).isWithin(EPS).of(1792.144)
-        assertThat(lib.skeletalMusclePercentage).isWithin(EPS).of(53.1658)
-        assertThat(lib.boneMass).isWithin(EPS).of(3.292)
-        assertThat(lib.subcutaneousFat).isWithin(EPS).of(15.3993)
-        assertThat(lib.muscleMass).isWithin(EPS).of(62.548)
-        assertThat(lib.proteinPercentage).isWithin(EPS).of(18.7644)
-        assertThat(lib.weightScore).isEqualTo(76)
-        assertThat(lib.fatScore).isEqualTo(97)
-        assertThat(lib.bmiScore).isEqualTo(89)
-        assertThat(lib.healthScore).isEqualTo(87)
-        assertThat(lib.metabolicAge).isEqualTo(29)
+        assertThat(lib.fatFreeMassKg).isWithin(EPS).of(60.622)
+        assertThat(lib.totalFatPercentage).isWithin(EPS).of(24.222)
+        assertThat(lib.totalBodyWaterPercentage).isWithin(EPS).of(53.819)
+        assertThat(lib.basalMetabolicRate).isWithin(EPS).of(1679.436)
+        assertThat(lib.skeletalMusclePercentage).isWithin(EPS).of(39.313)
+        assertThat(lib.boneMassKg).isWithin(EPS).of(3.455)
+
+        // We're within ±3% of TBW / FFM = 0.732 (https://pmc.ncbi.nlm.nih.gov/articles/PMC11625996/)
+        val tbwFFM = 0.732
+        assertThat(lib.totalBodyWaterKg / lib.fatFreeMassKg).isWithin(tbwFFM * 0.03).of(tbwFFM)
     }
 
     @Test


### PR DESCRIPTION
The measurements at least look plausible for my body. I've linked to the respective research and they all use the same H^2/R factor, so that's at least consistent. The unit test also checks if we're in the right ballpark of TBW / FFM = 0.732.

Only bone mass is an estimate based on FFM percentage, which should work well enough, but in a future PR I'd like to find a better formula which takes age into account.

Visceral fat is missing completely since it's hard to estimate the fat distribution in the body based on the few values we measure. It might make sense to skip that completely, at least until we find a good formula.

The BMR value is still ignored because openScale hard-codes its own calculation. The Katch-McArdle formula is 5kcal lower for me than the hard-coded formula. The difference is bigger with higher body fat.

Could you please also test this lib with your scale and see if the values make sense? I also still plan to take my scale to a few friends and do measurements with them at least to double-check for plausibility.

Also, the fat percentage is based on FFM instead of LBM. I originally wanted to include the following code which is based on EtekcityLib, but couldn't find a respective paper for LBM. The FFM based value for my own measurement falls more nicely within openScale's value range, but most online sources and the U.S. Navy value ranges at least work with lower values which seem to be LBM based instead of FFM. Not sure if we should add LBM as an estimate based on FFM, but simply subtract 2-3 percent points for men (if I understand the literature correctly that's the expected difference? and for women it was around twice as high).

```kotlin
    /**
     * Body fat percentage based on [EtekcityLib].
     *
     * This formula is not really scientific, but currently the best we have.
     *
     * It seems to align with the U.S. Navy value ranges and these sources:
     * https://www.newhealthadvisor.org/Body-Fat-Percentage-Chart.html
     * https://www.medicalnewstoday.com/articles/body-fat-percentage-chart#men
     * https://www.calculator.net/body-fat-calculator.html
     *
     * Also, see this paper for details about the confusion around FFM (fat-free mass) vs. LBM (lean body mass):
     * https://pmc.ncbi.nlm.nih.gov/articles/PMC11625996/
     */
    val bodyFatPercentageWithoutEssentialFats: Double by lazy {
        val ageFactor = if (isMale) 0.103 else 0.097
        val bmiFactor = if (isMale) 1.524 else 1.545
        val constant = if (isMale) 22.0 else 12.7
        ageFactor * age + bmiFactor * bmi - 500.0 / impedance - constant
    }

    /**
     * LBM / lean body mass.
     *
     * Note: Based on the assumption that [bodyFatPercentageWithoutEssentialFats] doesn't contain essential lipids.
     * Also, see this paper for details about the confusion around FFM (fat-free mass) vs. LBM (lean body mass):
     * https://pmc.ncbi.nlm.nih.gov/articles/PMC11625996/
     */
    val leanBodyMass: Double = weightKg * (1 - bodyFatPercentageWithoutEssentialFats / 100)
```