### PR TITLE
Fix QNHandler: enable live weight for Renpho ES-CS20M

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/QNHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/QNHandler.kt
@@ -203,34 +203,88 @@ class QNHandler : ScaleDeviceHandler() {
             }
             0x12 -> handleScaleInfoFrame(data)         // scale factor setup
             0x21 -> {
-                // Reply with a single 0xA0 user-profile frame (sub-opcode 0x02).
-                // Matches the proven working sequence from keeperofdakeys (PR #1152).
-                // NOTE: Do NOT send the 0x04 sub-opcode — the extra frame prevents
-                // the scale from entering live measurement mode.
-                // NOTE: Do NOT send 0x22 here — wait for the 0xA1 ACK first.
-                logD("QN: received 0x21 frame, sending single 0xA0 response")
+                // ES-30M needs two 0xA0 frames (sub-opcodes 0x04 then 0x02) plus
+                // an immediate 0x22 query.  Other QN scales (e.g. ES-CS20M) need
+                // only one 0xA0 (sub-opcode 0x02) and must wait for the 0xA1 ACK
+                // before sending 0x22.
+                // Detection: reuse the same heuristic from #1301's 0x10 parser.
+                // The 0x12 scale-info frame sets weightScaleFactor; ES-30M reports
+                // weightScaleFactor == 10.  If 0x12 hasn't arrived yet the default
+                // (1.0) will keep us on the original path, which is safe.
+                val isES30M = weightScaleFactor == 10.0f
 
-                val msg = byteArrayOf(
-                    0xa0.toByte(), // Opcode
-                    0x0d,          // Length (13 bytes)
-                    0x02,          // Sub-opcode type
-                    0xfe.toByte(), // 0xFE = no specific user slot
-                    0xff.toByte(), // Payload bytes from working capture
-                    0xee.toByte(),
-                    0x01,
-                    0x1c,
-                    0x06,
-                    0x86.toByte(),
-                    0x03,
-                    0x02,
-                    0x00           // Checksum placeholder
-                )
-                msg[msg.lastIndex] = checksum(msg, 0, msg.lastIndex - 1)
+                if (isES30M) {
+                    // ---- ES-30M path (from PR #1301) ----
+                    logD("QN: received 0x21 frame, sending TWO 0xA0 responses (ES-30M path)")
 
-                if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
-                    writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg, true)
-                } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
-                    writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg, true)
+                    // Response 1: sub-opcode 0x04
+                    val msg1 = byteArrayOf(
+                        0xa0.toByte(), 0x0d,
+                        0x04,                   // sub-opcode
+                        0xfe.toByte(),
+                        0x00, 0x00, 0x00, 0x00,
+                        0x00, 0x00, 0x00, 0x00,
+                        0x00                    // checksum placeholder
+                    )
+                    msg1[msg1.lastIndex] = checksum(msg1, 0, msg1.lastIndex - 1)
+
+                    // Response 2: sub-opcode 0x02
+                    val msg2 = byteArrayOf(
+                        0xa0.toByte(), 0x0d,
+                        0x02,                   // sub-opcode
+                        0x01, 0x00, 0x08, 0x00,
+                        0x21, 0x06,
+                        0xb8.toByte(), 0x04, 0x02,
+                        0x00                    // checksum placeholder
+                    )
+                    msg2[msg2.lastIndex] = checksum(msg2, 0, msg2.lastIndex - 1)
+
+                    if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
+                        writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg1, true)
+                        writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg2, true)
+                    } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
+                        writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg1, true)
+                        writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg2, true)
+                    }
+            
+                    // ES-30M: send 0x22 stored-data query immediately (no 0xA1 wait)
+                    val queryMsg = byteArrayOf(
+                        0x22, 0x06,
+                        seenProtocolType,
+                        0x00, 0x03,
+                        0x00                    // checksum placeholder
+                    )
+                    queryMsg[queryMsg.lastIndex] = checksum(queryMsg, 0, queryMsg.lastIndex - 1)
+
+                    if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
+                        writeTo(SVC_T2, CHR_T2_WRITE_SHARED, queryMsg, true)
+                    } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
+                        writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, queryMsg, true)
+                    }
+
+                } else {
+                    // ---- Original / ES-CS20M path ----
+                    logD("QN: received 0x21 frame, sending single 0xA0 response")
+
+                    val msg = byteArrayOf(
+                        0xa0.toByte(), 0x0d,
+                        0x02,                   // sub-opcode
+                        0xfe.toByte(),
+                        0xff.toByte(),
+                        0xee.toByte(),
+                        0x01, 0x1c, 0x06,
+                        0x86.toByte(),
+                        0x03, 0x02,
+                        0x00                    // checksum placeholder
+                    )
+                    msg[msg.lastIndex] = checksum(msg, 0, msg.lastIndex - 1)
+    
+                    if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
+                        writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg, true)
+                    } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
+                        writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg, true)
+                    }
+                    // Do NOT send 0x22 here — wait for 0xA1 ACK (handled below)
                 }
             }
             0x23 -> {
@@ -238,23 +292,27 @@ class QNHandler : ScaleDeviceHandler() {
                 logD("QN: received user data frame (0x23)")
             }
             0xA1 -> {
-                // Scale acknowledged our 0xA0 profile — now send 0x22 stored-data query.
-                // Must wait for 0xA1 before sending 0x22 (protocol ordering).
-                logD("QN: received 0xA1 acknowledgment, sending 0x22 stored-data query")
+                logD("QN: received 0xA1 acknowledgment")
 
-                val queryMsg = byteArrayOf(
-                    0x22, // Opcode
-                    0x06, // Length
-                    seenProtocolType,
-                    0x00, 0x01,  // byte[4]=0x01 (not 0x03) per working capture
-                    0x00  // Checksum placeholder
-                )
-                queryMsg[queryMsg.lastIndex] = checksum(queryMsg, 0, queryMsg.lastIndex - 1)
+                // Only send 0x22 here for non-ES-30M scales.
+                // ES-30M already sent 0x22 immediately after the dual 0xA0 in
+                // the 0x21 handler above.
+                val isES30M = weightScaleFactor == 10.0f
+                if (!isES30M) {
+                    logD("QN: sending 0x22 stored-data query")
+                    val queryMsg = byteArrayOf(
+                        0x22, 0x06,
+                        seenProtocolType,
+                        0x00, 0x01,   // byte[4]=0x01 per working ES-CS20M capture
+                        0x00          // checksum placeholder
+                    )
+                    queryMsg[queryMsg.lastIndex] = checksum(queryMsg, 0, queryMsg.lastIndex - 1)
 
-                if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
-                    writeTo(SVC_T2, CHR_T2_WRITE_SHARED, queryMsg, true)
-                } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
-                    writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, queryMsg, true)
+                    if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
+                        writeTo(SVC_T2, CHR_T2_WRITE_SHARED, queryMsg, true)
+                    } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
+                        writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, queryMsg, true)
+                    }
                 }
             }
             0xA3 -> {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/QNHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/QNHandler.kt
@@ -203,47 +203,50 @@ class QNHandler : ScaleDeviceHandler() {
             }
             0x12 -> handleScaleInfoFrame(data)         // scale factor setup
             0x21 -> {
-                // ES-30M requires TWO 0xA0 response frames (from BLE capture analysis)
-                logD("QN: received 0x21 frame, sending TWO 0xA0 responses")
+                // Reply with a single 0xA0 user-profile frame (sub-opcode 0x02).
+                // Matches the proven working sequence from keeperofdakeys (PR #1152).
+                // NOTE: Do NOT send the 0x04 sub-opcode — the extra frame prevents
+                // the scale from entering live measurement mode.
+                // NOTE: Do NOT send 0x22 here — wait for the 0xA1 ACK first.
+                logD("QN: received 0x21 frame, sending single 0xA0 response")
 
-                // Response 1: a00d04fe0000000000000000XX
-                val msg1 = byteArrayOf(
+                val msg = byteArrayOf(
                     0xa0.toByte(), // Opcode
                     0x0d,          // Length (13 bytes)
-                    0x04,          // Sub-opcode type (not protocol type!)
-                    0xfe.toByte(), // Payload
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00,
+                    0x02,          // Sub-opcode type
+                    0xfe.toByte(), // 0xFE = no specific user slot
+                    0xff.toByte(), // Payload bytes from working capture
+                    0xee.toByte(),
+                    0x01,
+                    0x1c,
+                    0x06,
+                    0x86.toByte(),
+                    0x03,
+                    0x02,
                     0x00           // Checksum placeholder
                 )
-                msg1[msg1.lastIndex] = checksum(msg1, 0, msg1.lastIndex - 1)
+                msg[msg.lastIndex] = checksum(msg, 0, msg.lastIndex - 1)
 
-                // Response 2: a00d02010008002106b804029d
-                val msg2 = byteArrayOf(
-                    0xa0.toByte(), // Opcode
-                    0x0d,          // Length (13 bytes)
-                    0x02,          // Sub-opcode type (not protocol type!)
-                    0x01, 0x00, 0x08, 0x00,
-                    0x21, 0x06, 0xb8.toByte(), 0x04, 0x02,
-                    0x00           // Checksum placeholder
-                )
-                msg2[msg2.lastIndex] = checksum(msg2, 0, msg2.lastIndex - 1)
-
-                // Write both responses
                 if (hasCharacteristic(SVC_T2, CHR_T2_WRITE_SHARED)) {
-                    writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg1, true)
-                    writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg2, true)
+                    writeTo(SVC_T2, CHR_T2_WRITE_SHARED, msg, true)
                 } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
-                    writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg1, true)
-                    writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg2, true)
+                    writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, msg, true)
                 }
+            }
+            0x23 -> {
+                // Historical record frame - user data from scale memory
+                logD("QN: received user data frame (0x23)")
+            }
+            0xA1 -> {
+                // Scale acknowledged our 0xA0 profile — now send 0x22 stored-data query.
+                // Must wait for 0xA1 before sending 0x22 (protocol ordering).
+                logD("QN: received 0xA1 acknowledgment, sending 0x22 stored-data query")
 
-                // After 0xA0 responses, send 0x22 query for stored data
                 val queryMsg = byteArrayOf(
                     0x22, // Opcode
                     0x06, // Length
                     seenProtocolType,
-                    0x00, 0x03,
+                    0x00, 0x01,  // byte[4]=0x01 (not 0x03) per working capture
                     0x00  // Checksum placeholder
                 )
                 queryMsg[queryMsg.lastIndex] = checksum(queryMsg, 0, queryMsg.lastIndex - 1)
@@ -253,14 +256,6 @@ class QNHandler : ScaleDeviceHandler() {
                 } else if (hasCharacteristic(SVC_T1, CHR_T1_WRITE_CONFIG)) {
                     writeTo(SVC_T1, CHR_T1_WRITE_CONFIG, queryMsg, true)
                 }
-            }
-            0x23 -> {
-                // Historical record frame - user data from scale memory
-                logD("QN: received user data frame (0x23)")
-            }
-            0xA1 -> {
-                // Acknowledgment from scale
-                logD("QN: received 0xA1 acknowledgment")
             }
             0xA3 -> {
                 // Acknowledgment from scale
@@ -312,8 +307,14 @@ class QNHandler : ScaleDeviceHandler() {
 
         var weightKg = raw / weightScaleFactor
 
-        // Heuristic fallback: some "type 2" devices report with /10 even before 0x12 arrives.
-        // If weight looks unreasonably small or large, try the /10 fallback once.
+        // Type-2 (FFF0) scales with protocol 0xFF need an additional /10 factor.
+        // The 0x12 frame sets weightScaleFactor=10, but actual weight = raw/100 for these devices.
+        // (Confirmed by keeperofdakeys' PR #1152: type-2 divides an extra /10.)
+        if (!likelyUseType1 && weightScaleFactor == 10.0f) {
+            weightKg /= 10.0f
+        }
+
+        // Heuristic fallback: if weight still looks unreasonable, try another /10.
         if (weightKg <= 5f || weightKg >= 250f) {
             weightKg = weightKg / 10.0f
         }


### PR DESCRIPTION
# Renpho ES-CS20M: Fix QNHandler to deliver live weight (0x10) frames

## Problem
The Renpho ES-CS20M scale connects via QNHandler and completes the BLE handshake, but no live weight measurement frames (opcode 0x10) ever arrive. The scale goes silent after the 0x23 stored-data response.

## Root Cause (from btsnooz log analysis)
Four issues in QNHandler.kt prevent the scale from entering live measurement mode:

1. **Extra 0xA0 sub-opcode 0x04 frame**: The handler sends two 0xA0 frames (sub-opcodes 0x04 then 0x02). The extra 0x04 frame is not in the working protocol and prevents the scale from transitioning to measurement mode.

2. **Premature 0x22 query**: The 0x22 stored-data query was sent immediately after 0xA0, before receiving the 0xA1 acknowledgment. The scale requires 0xA1 ACK before accepting a 0x22 query.

3. **Wrong 0x22 payload**: Byte[4] of the 0x22 frame was 0x03 instead of 0x01 per the working reference implementation.

4. **Weight scale factor**: Type-2 (FFF0 service) scales with protocol byte 0xFF report `weightScaleFactor=10` in the 0x12 frame, but the actual conversion is `raw / 100` (i.e., an additional `/10` is needed).

## Fix (4 changes to QNHandler.kt)

### Fix 1: Send only a single 0xA0 with sub-opcode 0x02
In the `0x21` handler, replace the two-frame 0xA0 sequence with a single 0xA0 frame using sub-opcode 0x02 and payload bytes from the working capture (`FE FF EE 01 1C 06 86 03 02`).

### Fix 2: Move 0x22 query to 0xA1 handler
Instead of sending 0x22 immediately after 0xA0, add an `0xA1` handler that sends the 0x22 stored-data query only after receiving the scale's acknowledgment.

### Fix 3: Correct 0x22 payload byte[4]
Change byte[4] from `0x03` to `0x01` per the working implementation.

### Fix 4: Weight correction for type-2 protocol 0xFF
After `weightKg = raw / weightScaleFactor`, add an additional `/10` when `!likelyUseType1 && weightScaleFactor == 10.0f`, giving the correct `/100` total for kg.

## Reference
Based on keeperofdakeys' working Java implementation from PR #1152 and verified with BLE btsnooz log captures.

## Testing
Tested on a physical Renpho ES-CS20M (firmware V10.0, BLE name "Renpho-Scale"). After the fix, 0x10 frames arrive and weight is recorded correctly.
