### PR TITLE
SBF70: Skip high priority connection request

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BeurerSanitasHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BeurerSanitasHandler.kt
@@ -46,6 +46,10 @@ import kotlin.math.max
  */
 class BeurerSanitasHandler : ScaleDeviceHandler() {
 
+    // These scales drop the link if the central renegotiates connection
+    // priority during the handshake; the legacy driver never did so.
+    override val supportsHighConnectionPriority: Boolean = false
+
     enum class DeviceType { BEURER_BF700_800_RT_LIBRA, BEURER_BF710, SANITAS_SBF70_70 }
 
     // UUIDs

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/GattScaleAdapter.kt
@@ -179,7 +179,9 @@ class GattScaleAdapter(
             LogManager.d(TAG, "Services discovered for ${peripheral.address}")
             currentPeripheral = peripheral
 
-            if (tuning.requestHighConnectionPriority) runCatching { peripheral.requestConnectionPriority(ConnectionPriority.HIGH) }
+            if (tuning.requestHighConnectionPriority && handler.supportsHighConnectionPriority) {
+                runCatching { peripheral.requestConnectionPriority(ConnectionPriority.HIGH) }
+            }
             if (tuning.requestMtuBytes > 23) runCatching { peripheral.requestMtu(tuning.requestMtuBytes) }
 
             val user = selectedUserSnapshot ?: run {

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/ScaleDeviceHandler.kt
@@ -109,6 +109,14 @@ enum class BroadcastAction { IGNORED, CONSUMED_KEEP_SCANNING, CONSUMED_STOP }
 abstract class ScaleDeviceHandler {
     val TAG = this::class.simpleName ?: "ScaleDeviceHandler"
 
+    /**
+     * Some older peripherals (such as the Sanitas SBF 70) lock up or drop
+     * the connection when the central requests HIGH connection priority 
+     * during their handshake. Handlers for such devices should override
+     * this to false so the adapter does not interrupt the handshake.
+     */
+    open val supportsHighConnectionPriority: Boolean = true
+
     companion object {
         // Pseudo UUIDs for Classic/SPP
         val CLASSIC_FAKE_SERVICE: UUID =


### PR DESCRIPTION
This fixes an issue where there was no communication between openScale and the Sanitas SBF70 scale.

At the moment there is a request to switch to a high-priority connection during the BLE handshake for all scales, except when the selected profile unsets it (but none do). Sanitas SBF70 (and similar scales?) does not seem to be able to handle this request and the handshake breaks with the scale becoming unresponsive until timeout.

The request was not present in v2 and only appeared in v3 just as this scale stopped receiving data (see
https://github.com/oliexdev/openScale/issues/1259). This change allows for a particular scale handler to disable the request completely without having to rely on the profile.

Tested on Sanitas SBF 70 (LineageOS 23, Galaxy S8).

Disclaimer: I used Claude Code for the code and for debugging. I reviewed and refactored the code where necessary, and tested it with the scale.

Fixes #1259