### PR TITLE
Data export to influxdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
 fastlane/README.md
+
+# VS Code local config (machine-specific, not for repo)
+.vscode/launch.json
+.vscode/tasks.json
+.vscode/noop.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides context for AI assistants working with this repository.
+
+## Project Overview
+
+**openScale** is an open-source Android app for weight and body metrics tracking with Bluetooth scale support.
+
+## Repository Structure
+
+```
+android_app/        # Android application (Kotlin + Jetpack Compose)
+arduino_mcu/        # Arduino firmware for custom scale hardware
+docs/               # Documentation and hardware schematics
+fastlane/           # Fastlane metadata and release automation
+```
+
+## Tech Stack
+
+- **Language**: Kotlin
+- **UI**: Jetpack Compose
+- **DI**: Hilt
+- **DB**: Room (with migration schemas in `app/schemas/`)
+- **Android Gradle Plugin**: 8.13.2
+- **Kotlin**: 2.3.10
+- **Min SDK**: 31 / Target SDK: 36
+- **Java / Kotlin JVM target**: 21
+
+## Build Requirements
+
+- **JDK 21+** required — the system default may be too old. Use JDK 23 (Temurin):
+  ```
+  JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-23.jdk/Contents/Home
+  ```
+- Android SDK with API 36
+
+## Build Commands
+
+```bash
+cd android_app
+
+# Build debug APK
+JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-23.jdk/Contents/Home ./gradlew assembleDebug
+
+# Build + install + launch on connected device
+JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-23.jdk/Contents/Home ./gradlew installDebug && \
+  adb shell am start -n com.health.openscale.debug/com.health.openscale.MainActivity
+```
+
+Press **F5** in VS Code to build, install, and launch the app (requires a connected device or running emulator).
+
+## App IDs
+
+| Build type | Application ID |
+|------------|----------------|
+| debug      | `com.health.openscale.debug` |
+| release    | `com.health.openscale` |
+| beta       | `com.health.openscale.beta` |
+| oss        | `com.health.openscale.oss` |
+
+## Known Issues / Notes
+
+- `kotlinOptions` DSL is deprecated in this Kotlin version — use `kotlin { compilerOptions { } }` instead.
+- Release/OSS signing requires keystore files outside the repo (`../../openScale.keystore`). Debug builds work without them.
+- Some string resources (e.g. `insights_chip_now`) lack default values and are stripped during resource processing — this is a known warning, not an error.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,79 @@ If you want to help to translate the app in your language please see [here](http
   </tr>
 </table>
 
+# Data Export & Integration :electric_plug:
+
+openScale supports pushing measurements to external services via **Webhook** and **InfluxDB** export, configurable under *Settings → Data Management*.
+
+## Webhook Export
+
+On every new measurement, openScale sends an HTTP POST with a JSON body to a configurable URL. This makes it easy to integrate with any service that accepts webhooks (e.g. Home Assistant, n8n, Supabase, custom APIs).
+
+**JSON payload schema:**
+
+```json
+{
+  "timestamp": 1778076662705,
+  "id": 4,
+  "userId": 1,
+  "weight": 66.5,
+  "body_fat": 13.04,
+  "water": 59.66,
+  "muscle": 44.74,
+  "visceral_fat": 5.00,
+  "bone": 2.58,
+  "lbm": 57.83
+}
+```
+
+The three base fields are always present. All measurement fields are **only included if the scale (or manual entry) provides them** — the exact set depends on what your scale supports.
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | `long` | Unix timestamp in milliseconds |
+| `id` | `int` | Measurement ID |
+| `userId` | `int` | App user ID |
+| `weight` | `float` | Weight in the user's configured unit (kg / lb / st) |
+| `bmi` | `float` | Body mass index |
+| `body_fat` | `float` | Body fat (% or kg/lb/st) |
+| `water` | `float` | Body water (% or kg/lb/st) |
+| `muscle` | `float` | Muscle mass (% or kg/lb/st) |
+| `lbm` | `float` | Lean body mass (kg/lb/st) |
+| `bone` | `float` | Bone mass (kg/lb) |
+| `waist` | `float` | Waist circumference (cm/in) |
+| `whr` | `float` | Waist-to-hip ratio |
+| `whtr` | `float` | Waist-to-height ratio |
+| `hips` | `float` | Hip circumference (cm/in) |
+| `visceral_fat` | `float` | Visceral fat level |
+| `chest` | `float` | Chest circumference (cm/in) |
+| `thigh` | `float` | Thigh circumference (cm/in) |
+| `biceps` | `float` | Biceps circumference (cm/in) |
+| `neck` | `float` | Neck circumference (cm/in) |
+| `caliper_1` / `caliper_2` / `caliper_3` | `float` | Body fat caliper measurements (cm/in) |
+| `caliper` | `float` | Calculated body fat from caliper (%) |
+| `bmr` | `float` | Basal metabolic rate (kcal) |
+| `tdee` | `float` | Total daily energy expenditure (kcal) |
+| `heart_rate` | `int` | Heart rate (bpm) |
+| `calories` | `float` | Calories (kcal) |
+| `comment` | `string` | Optional comment |
+| `custom_<id>` | `float / int / string` | Custom metric with its type ID |
+
+**Test your endpoint with [webhook.site](https://webhook.site)** — create a free temporary URL and paste it into the Webhook URL field to inspect live requests.
+
+## InfluxDB Export
+
+Measurements are sent as [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/) via HTTP POST on every new measurement. Both InfluxDB v1 and v2 are supported.
+
+Configure under *Settings → Data Management → InfluxDB Export*:
+- **Host URL** — e.g. `http://192.168.1.100:8086`
+- **Database / Bucket** — target database (v1) or bucket (v2)
+- **Measurement name** — InfluxDB measurement/table name
+- **Field mapping** — customize field names to match existing Grafana dashboards
+
+## Automatic Backups
+
+The app can automatically back up its database on a configurable interval (daily / weekly / monthly) to a folder of your choice. Configure under *Settings → Data Management → Automatic Backups*.
+
 # License :page_facing_up:
 
 openScale is licensed under the GPL v3, see LICENSE file for full notice.

--- a/android_app/app/build.gradle.kts
+++ b/android_app/app/build.gradle.kts
@@ -144,6 +144,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+        }
+    }
+
     kapt {
         arguments {
             arg("room.schemaLocation", "$projectDir/schemas")

--- a/android_app/app/build.gradle.kts
+++ b/android_app/app/build.gradle.kts
@@ -221,6 +221,9 @@ dependencies {
     // BouncyCastle for AES-CCM decryption (Xiaomi S400 scale)
     implementation(libs.bouncycastle)
 
+    // OkHttp for webhook export
+    implementation(libs.okhttp)
+
     // Test dependencies
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <permission
         android:name="${applicationId}.READ_WRITE_DATA"

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -132,6 +132,15 @@ object SettingsPreferenceKeys {
     val WEBHOOK_EXPORT_ENABLED = booleanPreferencesKey("webhook_export_enabled")
     val WEBHOOK_EXPORT_URL = stringPreferencesKey("webhook_export_url")
 
+    // --- InfluxDB Export Settings ---
+    val INFLUXDB_EXPORT_ENABLED = booleanPreferencesKey("influxdb_export_enabled")
+    val INFLUXDB_VERSION = stringPreferencesKey("influxdb_version")
+    val INFLUXDB_HOST = stringPreferencesKey("influxdb_host")
+    val INFLUXDB_DATABASE = stringPreferencesKey("influxdb_database")
+    val INFLUXDB_MEASUREMENT = stringPreferencesKey("influxdb_measurement")
+    val INFLUXDB_USERNAME = stringPreferencesKey("influxdb_username")
+    val INFLUXDB_PASSWORD = stringPreferencesKey("influxdb_password")
+
     // Context strings for screen-specific settings (can be used as prefixes for dynamic keys)
     const val OVERVIEW_SCREEN_CONTEXT = "overview_screen"
     const val GRAPH_SCREEN_CONTEXT = "graph_screen"
@@ -289,6 +298,22 @@ interface SettingsFacade {
 
     val webhookExportUrl: Flow<String?>
     suspend fun setWebhookExportUrl(url: String?)
+
+    // --- InfluxDB Export Settings ---
+    val influxDbExportEnabled: Flow<Boolean>
+    suspend fun setInfluxDbExportEnabled(enabled: Boolean)
+    val influxDbVersion: Flow<String>
+    suspend fun setInfluxDbVersion(version: String)
+    val influxDbHost: Flow<String>
+    suspend fun setInfluxDbHost(host: String)
+    val influxDbDatabase: Flow<String>
+    suspend fun setInfluxDbDatabase(database: String)
+    val influxDbMeasurement: Flow<String>
+    suspend fun setInfluxDbMeasurement(measurement: String)
+    val influxDbUsername: Flow<String>
+    suspend fun setInfluxDbUsername(username: String)
+    val influxDbPassword: Flow<String>
+    suspend fun setInfluxDbPassword(password: String)
 
     // Generic Settings Accessors
     /**
@@ -1073,6 +1098,43 @@ class SettingsFacadeImpl @Inject constructor(private val dataStore: DataStore<Pr
             else preferences.remove(SettingsPreferenceKeys.WEBHOOK_EXPORT_URL)
         }
     }
+
+    // --- InfluxDB Export Settings ---
+    override val influxDbExportEnabled: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_EXPORT_ENABLED.name, false)
+    override suspend fun setInfluxDbExportEnabled(enabled: Boolean) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_EXPORT_ENABLED.name, enabled)
+
+    override val influxDbVersion: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_VERSION.name, "v1")
+    override suspend fun setInfluxDbVersion(version: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_VERSION.name, version)
+
+    override val influxDbHost: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_HOST.name, "")
+    override suspend fun setInfluxDbHost(host: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_HOST.name, host)
+
+    override val influxDbDatabase: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_DATABASE.name, "")
+    override suspend fun setInfluxDbDatabase(database: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_DATABASE.name, database)
+
+    override val influxDbMeasurement: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_MEASUREMENT.name, "koerpergewicht")
+    override suspend fun setInfluxDbMeasurement(measurement: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_MEASUREMENT.name, measurement)
+
+    override val influxDbUsername: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_USERNAME.name, "")
+    override suspend fun setInfluxDbUsername(username: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_USERNAME.name, username)
+
+    override val influxDbPassword: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.INFLUXDB_PASSWORD.name, "")
+    override suspend fun setInfluxDbPassword(password: String) =
+            saveSetting(SettingsPreferenceKeys.INFLUXDB_PASSWORD.name, password)
+
     override fun <T> observeSetting(keyName: String, defaultValue: T): Flow<T> {
         // LogManager.v(
         //    TAG,

--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -20,6 +20,8 @@ package com.health.openscale.core.facade
 import android.content.Context
 import android.util.Base64
 import android.util.SparseArray
+import androidx.core.util.isNotEmpty
+import androidx.core.util.size
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -45,25 +47,21 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import java.io.IOException
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import java.io.IOException
-import java.util.UUID
-import javax.inject.Inject
-import javax.inject.Singleton
-import androidx.core.util.size
 import org.json.JSONObject
-import androidx.core.util.isNotEmpty
 
 // DataStore instance for user settings
 val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
-/**
- * Defines keys for user preferences stored in DataStore.
- */
+/** Defines keys for user preferences stored in DataStore. */
 object SettingsPreferenceKeys {
     // General App Settings
     val IS_FILE_LOGGING_ENABLED = booleanPreferencesKey("is_file_logging_enabled")
@@ -75,20 +73,28 @@ object SettingsPreferenceKeys {
     val USE_HIGH_CONTRAST = booleanPreferencesKey("use_high_contrast")
 
     // Settings for specific UI components
-    val SELECTED_TYPES_TABLE = stringSetPreferencesKey("selected_types_table") // IDs of measurement types selected for the data table
+    val SELECTED_TYPES_TABLE =
+            stringSetPreferencesKey(
+                    "selected_types_table"
+            ) // IDs of measurement types selected for the data table
     val MY_GOALS_EXPANDED_OVERVIEW = booleanPreferencesKey("my_goals_expanded")
 
     // Saved Bluetooth Scale
-    val SAVED_BLUETOOTH_DEVICE_ADDRESS        = stringPreferencesKey("saved_bluetooth_device_address")
-    val SAVED_BLUETOOTH_DEVICE_NAME           = stringPreferencesKey("saved_bluetooth_device_name")
-    val SAVED_BLUETOOTH_DEVICE_RSSI           = intPreferencesKey("saved_bluetooth_device_rssi")
-    val SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS  = stringSetPreferencesKey("saved_bluetooth_device_service_uuids")
-    val SAVED_BLUETOOTH_DEVICE_HANDLER_HINT   = stringPreferencesKey("saved_bluetooth_device_handler_hint")
-    val SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA   = stringPreferencesKey("saved_bluetooth_device_manufacturer_data")
+    val SAVED_BLUETOOTH_DEVICE_ADDRESS = stringPreferencesKey("saved_bluetooth_device_address")
+    val SAVED_BLUETOOTH_DEVICE_NAME = stringPreferencesKey("saved_bluetooth_device_name")
+    val SAVED_BLUETOOTH_DEVICE_RSSI = intPreferencesKey("saved_bluetooth_device_rssi")
+    val SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS =
+            stringSetPreferencesKey("saved_bluetooth_device_service_uuids")
+    val SAVED_BLUETOOTH_DEVICE_HANDLER_HINT =
+            stringPreferencesKey("saved_bluetooth_device_handler_hint")
+    val SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA =
+            stringPreferencesKey("saved_bluetooth_device_manufacturer_data")
     val SAVED_BLUETOOTH_TUNE_PROFILE = stringPreferencesKey("saved_bluetooth_tune_profile")
-    val SAVED_BLUETOOTH_SMART_ASSIGNMENT_ENABLED = booleanPreferencesKey("saved_bluetooth_smart_assignment_enabled")
+    val SAVED_BLUETOOTH_SMART_ASSIGNMENT_ENABLED =
+            booleanPreferencesKey("saved_bluetooth_smart_assignment_enabled")
     val SAVED_BLUETOOTH_TOLERANCE_PERCENT = intPreferencesKey("saved_bluetooth_tolerance_percent")
-    val SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE = booleanPreferencesKey("saved_bluetooth_ignore_outside_tolerance")
+    val SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE =
+            booleanPreferencesKey("saved_bluetooth_ignore_outside_tolerance")
     val SAVED_BLUETOOTH_AUTO_CONNECT = booleanPreferencesKey("saved_bluetooth_auto_connect")
 
     // Settings for chart
@@ -108,7 +114,8 @@ object SettingsPreferenceKeys {
     val AUTO_BACKUP_LOCATION_URI = stringPreferencesKey("auto_backup_location_uri")
     val AUTO_BACKUP_INTERVAL = stringPreferencesKey("auto_backup_interval")
     val AUTO_BACKUP_CREATE_NEW_FILE = booleanPreferencesKey("auto_backup_create_new_file")
-    val AUTO_BACKUP_LAST_SUCCESSFUL_TIMESTAMP = longPreferencesKey("auto_backup_last_successful_timestamp")
+    val AUTO_BACKUP_LAST_SUCCESSFUL_TIMESTAMP =
+            longPreferencesKey("auto_backup_last_successful_timestamp")
 
     // --- Reminder Settings ---
     val REMINDER_ENABLED = booleanPreferencesKey("reminder_enabled")
@@ -117,9 +124,13 @@ object SettingsPreferenceKeys {
     val REMINDER_MINUTE = intPreferencesKey("reminder_minute")
     val REMINDER_DAYS = stringSetPreferencesKey("reminder_days")
 
-    val BODY_FAT_FORMULA_OPTION   = stringPreferencesKey("body_fat_formula_option")
+    val BODY_FAT_FORMULA_OPTION = stringPreferencesKey("body_fat_formula_option")
     val BODY_WATER_FORMULA_OPTION = stringPreferencesKey("body_water_formula_option")
-    val LBM_FORMULA_OPTION        = stringPreferencesKey("lbm_formula_option")
+    val LBM_FORMULA_OPTION = stringPreferencesKey("lbm_formula_option")
+
+    // --- Webhook Export Settings ---
+    val WEBHOOK_EXPORT_ENABLED = booleanPreferencesKey("webhook_export_enabled")
+    val WEBHOOK_EXPORT_URL = stringPreferencesKey("webhook_export_url")
 
     // Context strings for screen-specific settings (can be used as prefixes for dynamic keys)
     const val OVERVIEW_SCREEN_CONTEXT = "overview_screen"
@@ -135,25 +146,18 @@ object SettingsProvidesModule {
 
     @Provides
     @Singleton
-    fun provideUserSettingsDataStore(
-        @ApplicationContext context: Context
-    ): DataStore<Preferences> = context.settingsDataStore
+    fun provideUserSettingsDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+            context.settingsDataStore
 }
 
 @Module
 @InstallIn(SingletonComponent::class)
 interface SettingsBindsModule {
 
-    @Binds
-    @Singleton
-    fun bindUserSettingsRepository(
-        impl: SettingsFacadeImpl
-    ): SettingsFacade
+    @Binds @Singleton fun bindUserSettingsRepository(impl: SettingsFacadeImpl): SettingsFacade
 }
 
-/**
- * Repository interface for accessing and managing user settings.
- */
+/** Repository interface for accessing and managing user settings. */
 interface SettingsFacade {
     // General app settings
     val isFileLoggingEnabled: Flow<Boolean>
@@ -185,7 +189,7 @@ interface SettingsFacade {
     suspend fun setMyGoalsExpandedOverview(isExpanded: Boolean)
 
     fun observeSplitterWeight(keyPrefix: String, defaultValue: Float): Flow<Float>
-    suspend fun setSplitterWeight(keyPrefix : String, weight: Float)
+    suspend fun setSplitterWeight(keyPrefix: String, weight: Float)
 
     // Bluetooth scale settings
     fun observeSavedDevice(): Flow<ScannedDeviceInfo?>
@@ -196,7 +200,7 @@ interface SettingsFacade {
     val savedBluetoothTuneProfile: Flow<String?>
     suspend fun saveBluetoothTuneProfile(name: String?)
 
-    val isSmartAssignmentEnabled : Flow<Boolean>
+    val isSmartAssignmentEnabled: Flow<Boolean>
     suspend fun setSmartAssignmentEnabled(enabled: Boolean)
 
     val smartAssignmentTolerancePercent: Flow<Int>
@@ -279,68 +283,78 @@ interface SettingsFacade {
     val autoConnectOnStartup: Flow<Boolean>
     suspend fun setAutoConnectOnStartup(enabled: Boolean)
 
+    // --- Webhook Export Settings ---
+    val webhookExportEnabled: Flow<Boolean>
+    suspend fun setWebhookExportEnabled(enabled: Boolean)
+
+    val webhookExportUrl: Flow<String?>
+    suspend fun setWebhookExportUrl(url: String?)
+
     // Generic Settings Accessors
     /**
-     * Observes a setting with the given key name and default value.
-     * The type T determines the preference key type.
+     * Observes a setting with the given key name and default value. The type T determines the
+     * preference key type.
      */
     fun <T> observeSetting(keyName: String, defaultValue: T): Flow<T>
 
     /**
-     * Saves a setting with the given key name and value.
-     * The type T determines the preference key type.
+     * Saves a setting with the given key name and value. The type T determines the preference key
+     * type.
      */
     suspend fun <T> saveSetting(keyName: String, value: T)
 }
 
-/**
- * Implementation of [SettingsFacade] using Jetpack DataStore.
- */
+/** Implementation of [SettingsFacade] using Jetpack DataStore. */
 @Singleton
-class SettingsFacadeImpl @Inject constructor(
-    private val dataStore: DataStore<Preferences>
-): SettingsFacade {
+class SettingsFacadeImpl @Inject constructor(private val dataStore: DataStore<Preferences>) :
+        SettingsFacade {
     private val TAG = "UserSettingsRepository" // Tag for logging
 
-    override val isFileLoggingEnabled: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.IS_FILE_LOGGING_ENABLED.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing isFileLoggingEnabled", exception)
-        emit(false) // Fallback to default on error
-    }
+    override val isFileLoggingEnabled: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.IS_FILE_LOGGING_ENABLED.name, false).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing isFileLoggingEnabled", exception)
+                emit(false) // Fallback to default on error
+            }
 
     override suspend fun setFileLoggingEnabled(enabled: Boolean) {
         LogManager.d(TAG, "Setting file logging enabled to: $enabled")
         saveSetting(SettingsPreferenceKeys.IS_FILE_LOGGING_ENABLED.name, enabled)
     }
 
-    override val isFirstAppStart: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.IS_FIRST_APP_START.name,
-        true // Default to true, meaning it IS the first start until explicitly set otherwise
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing isFirstAppStart", exception)
-        emit(true) // Fallback to default on error
-    }
+    override val isFirstAppStart: Flow<Boolean> =
+            observeSetting(
+                            SettingsPreferenceKeys.IS_FIRST_APP_START.name,
+                            true // Default to true, meaning it IS the first start until explicitly
+                            // set otherwise
+                            )
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing isFirstAppStart", exception)
+                        emit(true) // Fallback to default on error
+                    }
 
     override suspend fun setFirstAppStartCompleted(completed: Boolean) {
         LogManager.d(TAG, "Setting first app start completed to: $completed")
         saveSetting(SettingsPreferenceKeys.IS_FIRST_APP_START.name, completed)
     }
 
-    override val appLanguageCode: Flow<String?> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading appLanguageCode from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            preferences[SettingsPreferenceKeys.APP_LANGUAGE_CODE]
-        }
-        .distinctUntilChanged()
+    override val appLanguageCode: Flow<String?> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error reading appLanguageCode from DataStore.",
+                                exception
+                        )
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences -> preferences[SettingsPreferenceKeys.APP_LANGUAGE_CODE] }
+                    .distinctUntilChanged()
 
     override suspend fun setAppLanguageCode(languageCode: String?) {
         LogManager.d(TAG, "Setting app language code to: $languageCode")
@@ -353,50 +367,45 @@ class SettingsFacadeImpl @Inject constructor(
         }
     }
 
-    override val hapticOnMeasurement: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.HAPTIC_ON_MEASUREMENT.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing hapticOnMeasurement", exception)
-        emit(false)
-    }
+    override val hapticOnMeasurement: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.HAPTIC_ON_MEASUREMENT.name, false).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing hapticOnMeasurement", exception)
+                emit(false)
+            }
 
     override suspend fun setHapticOnMeasurement(value: Boolean) {
         LogManager.d(TAG, "Setting hapticOnMeasurement to: $value")
         saveSetting(SettingsPreferenceKeys.HAPTIC_ON_MEASUREMENT.name, value)
     }
 
-    override val useDynamicColor: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.USE_DYNAMIC_COLOR.name,
-        false
-    )
+    override val useDynamicColor: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.USE_DYNAMIC_COLOR.name, false)
 
     override suspend fun setUseDynamicColor(enabled: Boolean) {
         saveSetting(SettingsPreferenceKeys.USE_DYNAMIC_COLOR.name, enabled)
     }
 
-    override val useHighContrast: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.USE_HIGH_CONTRAST.name,
-        false
-    )
+    override val useHighContrast: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.USE_HIGH_CONTRAST.name, false)
 
     override suspend fun setHighContrast(enabled: Boolean) {
         saveSetting(SettingsPreferenceKeys.USE_HIGH_CONTRAST.name, enabled)
     }
 
-    override val currentUserId: Flow<Int?> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading currentUserId from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            preferences[SettingsPreferenceKeys.CURRENT_USER_ID]
-        }
-        .distinctUntilChanged()
+    override val currentUserId: Flow<Int?> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error reading currentUserId from DataStore.", exception)
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences -> preferences[SettingsPreferenceKeys.CURRENT_USER_ID] }
+                    .distinctUntilChanged()
 
     override suspend fun setCurrentUserId(userId: Int?) {
         LogManager.d(TAG, "Setting current user ID to: $userId")
@@ -409,115 +418,141 @@ class SettingsFacadeImpl @Inject constructor(
         }
     }
 
-    override val selectedTableTypeIds: Flow<Set<String>> = observeSetting(
-        SettingsPreferenceKeys.SELECTED_TYPES_TABLE.name,
-        emptySet<String>()
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing selectedTableTypeIds", exception)
-        emit(emptySet()) // Fallback to default on error
-    }
+    override val selectedTableTypeIds: Flow<Set<String>> =
+            observeSetting(SettingsPreferenceKeys.SELECTED_TYPES_TABLE.name, emptySet<String>())
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing selectedTableTypeIds", exception)
+                        emit(emptySet()) // Fallback to default on error
+                    }
 
     override suspend fun saveSelectedTableTypeIds(typeIds: Set<String>) {
         // LogManager.d(TAG, "Saving selected table type IDs: $typeIds")
         saveSetting(SettingsPreferenceKeys.SELECTED_TYPES_TABLE.name, typeIds)
     }
 
-    override val myGoalsExpandedOverview: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.MY_GOALS_EXPANDED_OVERVIEW.name,
-        true
-    ).catch { exception ->
-        emit(true)
-    }
+    override val myGoalsExpandedOverview: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.MY_GOALS_EXPANDED_OVERVIEW.name, true).catch {
+                    exception ->
+                emit(true)
+            }
 
     override suspend fun setMyGoalsExpandedOverview(isExpanded: Boolean) {
         saveSetting(SettingsPreferenceKeys.MY_GOALS_EXPANDED_OVERVIEW.name, isExpanded)
     }
 
-
     override fun observeSplitterWeight(keyPrefix: String, defaultValue: Float): Flow<Float> {
         val dynamicKey = floatPreferencesKey("${keyPrefix}_splitter_weight")
         return dataStore.data
-            .catch { exception ->
-                LogManager.e(TAG, "Error observing splitter weight for key $dynamicKey", exception)
-                emit(emptyPreferences())
-            }
-            .map { preferences ->
-                preferences[dynamicKey] ?: defaultValue
-            }
+                .catch { exception ->
+                    LogManager.e(
+                            TAG,
+                            "Error observing splitter weight for key $dynamicKey",
+                            exception
+                    )
+                    emit(emptyPreferences())
+                }
+                .map { preferences -> preferences[dynamicKey] ?: defaultValue }
     }
 
     override suspend fun setSplitterWeight(keyPrefix: String, weight: Float) {
         val dynamicKey = floatPreferencesKey("${keyPrefix}_splitter_weight")
-        dataStore.edit { preferences ->
-            preferences[dynamicKey] = weight
-        }
+        dataStore.edit { preferences -> preferences[dynamicKey] = weight }
     }
 
-
     override fun observeSavedDevice(): Flow<ScannedDeviceInfo?> {
-        val addrF  = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_ADDRESS.name,  null as String?)
-        val nameF  = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_NAME.name,     null as String?)
-        val rssiF  = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_RSSI.name,     0)
-        val uuidsF = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS.name, emptySet<String>())
-        val hintF  = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT.name,  null as String?)
-        val manDataF = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA.name, null as String?)
+        val addrF =
+                observeSetting(
+                        SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_ADDRESS.name,
+                        null as String?
+                )
+        val nameF =
+                observeSetting(
+                        SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_NAME.name,
+                        null as String?
+                )
+        val rssiF = observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_RSSI.name, 0)
+        val uuidsF =
+                observeSetting(
+                        SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS.name,
+                        emptySet<String>()
+                )
+        val hintF =
+                observeSetting(
+                        SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT.name,
+                        null as String?
+                )
+        val manDataF =
+                observeSetting(
+                        SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA.name,
+                        null as String?
+                )
 
         return combine(addrF, nameF, rssiF, uuidsF, hintF, manDataF) { array ->
-            val addr        = array[0] as String?
-            val name        = array[1] as String?
-            val rssi        = array[2] as Int
-            val uuidStrSet = (array[3] as? Set<*>)?.filterIsInstance<String>() ?: emptySet()
-            val hint        = array[4] as String?
-            val manDataJson = array[5] as String?
+                    val addr = array[0] as String?
+                    val name = array[1] as String?
+                    val rssi = array[2] as Int
+                    val uuidStrSet = (array[3] as? Set<*>)?.filterIsInstance<String>() ?: emptySet()
+                    val hint = array[4] as String?
+                    val manDataJson = array[5] as String?
 
-            if (addr.isNullOrBlank() || name.isNullOrBlank()) {
-                null
-            } else {
-                // Convert to UUID list with stable ordering to keep distinctUntilChanged effective
-                val uuids = uuidStrSet
-                    .mapNotNull { runCatching { UUID.fromString(it) }.getOrNull() }
-                    .sortedBy { it.toString() }
+                    if (addr.isNullOrBlank() || name.isNullOrBlank()) {
+                        null
+                    } else {
+                        // Convert to UUID list with stable ordering to keep distinctUntilChanged
+                        // effective
+                        val uuids =
+                                uuidStrSet
+                                        .mapNotNull {
+                                            runCatching { UUID.fromString(it) }.getOrNull()
+                                        }
+                                        .sortedBy { it.toString() }
 
-                // ManufacturerData
-                val manData = SparseArray<ByteArray>()
-                manDataJson?.let { jsonStr ->
-                    runCatching {
-                        val jsonObj = JSONObject(jsonStr)
-                        jsonObj.keys().forEach { key ->
-                            val value = Base64.decode(jsonObj.getString(key), Base64.NO_WRAP)
-                            manData.put(key.toInt(), value)
+                        // ManufacturerData
+                        val manData = SparseArray<ByteArray>()
+                        manDataJson?.let { jsonStr ->
+                            runCatching {
+                                val jsonObj = JSONObject(jsonStr)
+                                jsonObj.keys().forEach { key ->
+                                    val value =
+                                            Base64.decode(jsonObj.getString(key), Base64.NO_WRAP)
+                                    manData.put(key.toInt(), value)
+                                }
+                            }
                         }
+
+                        ScannedDeviceInfo(
+                                name = name,
+                                address = addr,
+                                rssi = rssi,
+                                serviceUuids = uuids,
+                                manufacturerData = if (manData.isNotEmpty()) manData else null,
+                                isSupported = false,
+                                determinedHandlerDisplayName = hint
+                        )
                     }
                 }
-
-                ScannedDeviceInfo(
-                    name = name,
-                    address = addr,
-                    rssi = rssi,
-                    serviceUuids = uuids,
-                    manufacturerData = if (manData.isNotEmpty()) manData else null,
-                    isSupported = false,
-                    determinedHandlerDisplayName = hint
-                )
-            }
-        }
-            .catch { e ->
-                LogManager.e("UserSettingsRepository", "observeSavedDevice failed", e)
-                emit(null)
-            }
-            .distinctUntilChanged()
+                .catch { e ->
+                    LogManager.e("UserSettingsRepository", "observeSavedDevice failed", e)
+                    emit(null)
+                }
+                .distinctUntilChanged()
     }
 
     override suspend fun saveSavedDevice(device: ScannedDeviceInfo) {
-        LogManager.i(TAG, "Saving device snapshot: addr=${device.address}, name=${device.name}, uuids=${device.serviceUuids.size}, hint=${device.determinedHandlerDisplayName}")
+        LogManager.i(
+                TAG,
+                "Saving device snapshot: addr=${device.address}, name=${device.name}, uuids=${device.serviceUuids.size}, hint=${device.determinedHandlerDisplayName}"
+        )
         dataStore.edit { prefs ->
-            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_ADDRESS]       = device.address
-            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_NAME]          = device.name
-            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_RSSI]          = device.rssi
-            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS] = device.serviceUuids.map(UUID::toString).toSet()
+            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_ADDRESS] = device.address
+            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_NAME] = device.name
+            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_RSSI] = device.rssi
+            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_SERVICE_UUIDS] =
+                    device.serviceUuids.map(UUID::toString).toSet()
             device.determinedHandlerDisplayName?.let {
                 prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT] = it
-            } ?: prefs.remove(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT)
+            }
+                    ?: prefs.remove(SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_HANDLER_HINT)
 
             val manData = JSONObject()
             device.manufacturerData?.let { sparse ->
@@ -527,7 +562,8 @@ class SettingsFacadeImpl @Inject constructor(
                     manData.put(key, value)
                 }
             }
-            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA] = manData.toString()
+            prefs[SettingsPreferenceKeys.SAVED_BLUETOOTH_DEVICE_MANUFACTURER_DATA] =
+                    manData.toString()
         }
     }
 
@@ -555,19 +591,25 @@ class SettingsFacadeImpl @Inject constructor(
         }
     }
 
-    override val savedBluetoothTuneProfile: Flow<String?> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading savedBluetoothTuneProfile from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            preferences[SettingsPreferenceKeys.SAVED_BLUETOOTH_TUNE_PROFILE]
-        }
-        .distinctUntilChanged()
+    override val savedBluetoothTuneProfile: Flow<String?> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error reading savedBluetoothTuneProfile from DataStore.",
+                                exception
+                        )
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences ->
+                        preferences[SettingsPreferenceKeys.SAVED_BLUETOOTH_TUNE_PROFILE]
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun saveBluetoothTuneProfile(name: String?) {
         LogManager.i(TAG, "Saving Bluetooth tune profile: Name=$name")
@@ -580,87 +622,95 @@ class SettingsFacadeImpl @Inject constructor(
         }
     }
 
-    override val autoConnectOnStartup: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.SAVED_BLUETOOTH_AUTO_CONNECT.name,
-        false
-    )
+    override val autoConnectOnStartup: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_AUTO_CONNECT.name, false)
 
     override suspend fun setAutoConnectOnStartup(enabled: Boolean) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_AUTO_CONNECT.name, enabled)
     }
 
-    override val isSmartAssignmentEnabled: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.SAVED_BLUETOOTH_SMART_ASSIGNMENT_ENABLED.name,
-        false
-    )
+    override val isSmartAssignmentEnabled: Flow<Boolean> =
+            observeSetting(
+                    SettingsPreferenceKeys.SAVED_BLUETOOTH_SMART_ASSIGNMENT_ENABLED.name,
+                    false
+            )
 
     override suspend fun setSmartAssignmentEnabled(enabled: Boolean) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_SMART_ASSIGNMENT_ENABLED.name, enabled)
     }
 
-    override val smartAssignmentTolerancePercent: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.SAVED_BLUETOOTH_TOLERANCE_PERCENT.name,
-        10
-    )
+    override val smartAssignmentTolerancePercent: Flow<Int> =
+            observeSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_TOLERANCE_PERCENT.name, 10)
 
     override suspend fun setSmartAssignmentTolerancePercent(tolerance: Int) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_TOLERANCE_PERCENT.name, tolerance)
     }
 
-    override val smartAssignmentIgnoreOutsideTolerance: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE.name,
-        false
-    )
+    override val smartAssignmentIgnoreOutsideTolerance: Flow<Boolean> =
+            observeSetting(
+                    SettingsPreferenceKeys.SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE.name,
+                    false
+            )
 
     override suspend fun setSmartAssignmentIgnoreOutsideTolerance(ignore: Boolean) {
         saveSetting(SettingsPreferenceKeys.SAVED_BLUETOOTH_IGNORE_OUTSIDE_TOLERANCE.name, ignore)
     }
 
-    override val showChartDataPoints: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.CHART_SHOW_DATA_POINTS.name,
-        true
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing showChartDataPoints", exception)
-        emit(true)
-    }
+    override val showChartDataPoints: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.CHART_SHOW_DATA_POINTS.name, true).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing showChartDataPoints", exception)
+                emit(true)
+            }
 
     override suspend fun setShowChartDataPoints(show: Boolean) {
         LogManager.d(TAG, "Setting showChartDataPoints to: $show")
         saveSetting(SettingsPreferenceKeys.CHART_SHOW_DATA_POINTS.name, show)
     }
 
-    override val chartSmoothingAlgorithm: Flow<SmoothingAlgorithm> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading chartSmoothingAlgorithm from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            val algorithmName = preferences[SettingsPreferenceKeys.CHART_SMOOTHING_ALGORITHM]
-            try {
-                algorithmName?.let { SmoothingAlgorithm.valueOf(it) } ?: SmoothingAlgorithm.NONE
-            } catch (e: IllegalArgumentException) {
-                LogManager.w(TAG, "Invalid smoothing algorithm name '$algorithmName' in DataStore. Defaulting to NONE.", e)
-                SmoothingAlgorithm.NONE
-            }
-        }
-        .distinctUntilChanged()
+    override val chartSmoothingAlgorithm: Flow<SmoothingAlgorithm> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error reading chartSmoothingAlgorithm from DataStore.",
+                                exception
+                        )
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences ->
+                        val algorithmName =
+                                preferences[SettingsPreferenceKeys.CHART_SMOOTHING_ALGORITHM]
+                        try {
+                            algorithmName?.let { SmoothingAlgorithm.valueOf(it) }
+                                    ?: SmoothingAlgorithm.NONE
+                        } catch (e: IllegalArgumentException) {
+                            LogManager.w(
+                                    TAG,
+                                    "Invalid smoothing algorithm name '$algorithmName' in DataStore. Defaulting to NONE.",
+                                    e
+                            )
+                            SmoothingAlgorithm.NONE
+                        }
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setChartSmoothingAlgorithm(algorithm: SmoothingAlgorithm) {
         LogManager.d(TAG, "Setting chart smoothing algorithm to: ${algorithm.name}")
         saveSetting(SettingsPreferenceKeys.CHART_SMOOTHING_ALGORITHM.name, algorithm.name)
     }
 
-    override val chartSmoothingAlpha: Flow<Float> = observeSetting(
-        SettingsPreferenceKeys.CHART_SMOOTHING_ALPHA.name,
-        0.5f
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartSmoothingAlpha", exception)
-        emit(0.5f)
-    }
+    override val chartSmoothingAlpha: Flow<Float> =
+            observeSetting(SettingsPreferenceKeys.CHART_SMOOTHING_ALPHA.name, 0.5f).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing chartSmoothingAlpha", exception)
+                emit(0.5f)
+            }
 
     override suspend fun setChartSmoothingAlpha(alpha: Float) {
         val validAlpha = alpha.coerceIn(0.01f, 0.99f)
@@ -668,119 +718,139 @@ class SettingsFacadeImpl @Inject constructor(
         saveSetting(SettingsPreferenceKeys.CHART_SMOOTHING_ALPHA.name, validAlpha)
     }
 
-    override val chartSmoothingWindowSize: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.CHART_SMOOTHING_WINDOW_SIZE.name,
-        5
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartSmoothingWindowSize", exception)
-        emit(5)
-    }
+    override val chartSmoothingWindowSize: Flow<Int> =
+            observeSetting(SettingsPreferenceKeys.CHART_SMOOTHING_WINDOW_SIZE.name, 5).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing chartSmoothingWindowSize", exception)
+                emit(5)
+            }
 
     override suspend fun setChartSmoothingWindowSize(windowSize: Int) {
         val validWindowSize = windowSize.coerceIn(2, 50)
-        LogManager.d(TAG, "Setting chart smoothing window size to: $validWindowSize (raw input: $windowSize)")
+        LogManager.d(
+                TAG,
+                "Setting chart smoothing window size to: $validWindowSize (raw input: $windowSize)"
+        )
         saveSetting(SettingsPreferenceKeys.CHART_SMOOTHING_WINDOW_SIZE.name, validWindowSize)
     }
 
-    override val chartSmoothingMaxGapDays: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.CHART_SMOOTHING_MAX_GAP_DAYS.name,
-        7 // Default to 7 days
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartSmoothingMaxGapDays", exception)
-        emit(7) // Fallback to default on error
-    }
+    override val chartSmoothingMaxGapDays: Flow<Int> =
+            observeSetting(
+                            SettingsPreferenceKeys.CHART_SMOOTHING_MAX_GAP_DAYS.name,
+                            7 // Default to 7 days
+                    )
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing chartSmoothingMaxGapDays", exception)
+                        emit(7) // Fallback to default on error
+                    }
 
     override suspend fun setChartSmoothingMaxGapDays(days: Int) {
         LogManager.d(TAG, "Setting chart smoothing max gap to: $days days")
         saveSetting(SettingsPreferenceKeys.CHART_SMOOTHING_MAX_GAP_DAYS.name, days)
     }
 
-    override val showChartGoalLines: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.CHART_SHOW_GOAL_LINES.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing showChartGoalLines", exception)
-        emit(false)
-    }
+    override val showChartGoalLines: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.CHART_SHOW_GOAL_LINES.name, false).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing showChartGoalLines", exception)
+                emit(false)
+            }
 
     override suspend fun setShowChartGoalLines(show: Boolean) {
         saveSetting(SettingsPreferenceKeys.CHART_SHOW_GOAL_LINES.name, show)
     }
 
-    override val chartProjectionEnabled: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.CHART_PROJECTION_ENABLED.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartProjectionEnabled", exception)
-        emit(false)
-    }
+    override val chartProjectionEnabled: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.CHART_PROJECTION_ENABLED.name, false).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing chartProjectionEnabled", exception)
+                emit(false)
+            }
 
     override suspend fun setChartProjectionEnabled(enabled: Boolean) {
         saveSetting(SettingsPreferenceKeys.CHART_PROJECTION_ENABLED.name, enabled)
     }
 
-    override val chartProjectionDaysInThePast: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.CHART_PROJECTION_DAYS_IN_THE_PAST.name,
-        30 // Default value
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartProjectionDaysInThePast", exception)
-        emit(30)
-    }
+    override val chartProjectionDaysInThePast: Flow<Int> =
+            observeSetting(
+                            SettingsPreferenceKeys.CHART_PROJECTION_DAYS_IN_THE_PAST.name,
+                            30 // Default value
+                    )
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing chartProjectionDaysInThePast", exception)
+                        emit(30)
+                    }
 
     override suspend fun setChartProjectionDaysInThePast(days: Int) {
         saveSetting(SettingsPreferenceKeys.CHART_PROJECTION_DAYS_IN_THE_PAST.name, days)
     }
 
-    override val chartProjectionDaysToProject: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.CHART_PROJECTION_DAYS_TO_PROJECT.name,
-        14 // Default value
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartProjectionDaysToProject", exception)
-        emit(14)
-    }
+    override val chartProjectionDaysToProject: Flow<Int> =
+            observeSetting(
+                            SettingsPreferenceKeys.CHART_PROJECTION_DAYS_TO_PROJECT.name,
+                            14 // Default value
+                    )
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing chartProjectionDaysToProject", exception)
+                        emit(14)
+                    }
 
     override suspend fun setChartProjectionDaysToProject(days: Int) {
         saveSetting(SettingsPreferenceKeys.CHART_PROJECTION_DAYS_TO_PROJECT.name, days)
     }
 
-    override val chartProjectionPolynomialDegree: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.CHART_PROJECTION_POLYNOMIAL_DEGREE.name,
-        1 // Default to linear
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing chartProjectionPolynomialDegree", exception)
-        emit(1)
-    }
+    override val chartProjectionPolynomialDegree: Flow<Int> =
+            observeSetting(
+                            SettingsPreferenceKeys.CHART_PROJECTION_POLYNOMIAL_DEGREE.name,
+                            1 // Default to linear
+                    )
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error observing chartProjectionPolynomialDegree",
+                                exception
+                        )
+                        emit(1)
+                    }
 
     override suspend fun setChartProjectionPolynomialDegree(degree: Int) {
         saveSetting(SettingsPreferenceKeys.CHART_PROJECTION_POLYNOMIAL_DEGREE.name, degree)
     }
 
-    override val autoBackupEnabledGlobally: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.AUTO_BACKUP_ENABLED_GLOBALLY.name,
-        false // Standardmäßig deaktiviert
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing autoBackupEnabledGlobally", exception)
-        emit(false)
-    }
+    override val autoBackupEnabledGlobally: Flow<Boolean> =
+            observeSetting(
+                            SettingsPreferenceKeys.AUTO_BACKUP_ENABLED_GLOBALLY.name,
+                            false // Standardmäßig deaktiviert
+                    )
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error observing autoBackupEnabledGlobally", exception)
+                        emit(false)
+                    }
 
     override suspend fun setAutoBackupEnabledGlobally(enabled: Boolean) {
         LogManager.d(TAG, "Setting autoBackupEnabledGlobally to: $enabled")
         saveSetting(SettingsPreferenceKeys.AUTO_BACKUP_ENABLED_GLOBALLY.name, enabled)
     }
 
-    override val autoBackupLocationUri: Flow<String?> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading autoBackupLocationUri from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            preferences[SettingsPreferenceKeys.AUTO_BACKUP_LOCATION_URI]
-        }
-        .distinctUntilChanged()
+    override val autoBackupLocationUri: Flow<String?> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error reading autoBackupLocationUri from DataStore.",
+                                exception
+                        )
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences ->
+                        preferences[SettingsPreferenceKeys.AUTO_BACKUP_LOCATION_URI]
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setAutoBackupLocationUri(uri: String?) {
         LogManager.d(TAG, "Setting autoBackupLocationUri to: $uri")
@@ -793,52 +863,64 @@ class SettingsFacadeImpl @Inject constructor(
         }
     }
 
-    override val autoBackupInterval: Flow<BackupInterval> = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading autoBackupInterval from DataStore.", exception)
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
-        }
-        .map { preferences ->
-            val intervalName = preferences[SettingsPreferenceKeys.AUTO_BACKUP_INTERVAL]
-            try {
-                intervalName?.let { BackupInterval.valueOf(it) } ?: BackupInterval.WEEKLY
-            } catch (e: IllegalArgumentException) {
-                LogManager.w(TAG, "Invalid BackupInterval name '$intervalName' in DataStore. Defaulting to WEEKLY.", e)
-                BackupInterval.WEEKLY
-            }
-        }
-        .distinctUntilChanged()
+    override val autoBackupInterval: Flow<BackupInterval> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error reading autoBackupInterval from DataStore.",
+                                exception
+                        )
+                        if (exception is IOException) {
+                            emit(emptyPreferences())
+                        } else {
+                            throw exception
+                        }
+                    }
+                    .map { preferences ->
+                        val intervalName = preferences[SettingsPreferenceKeys.AUTO_BACKUP_INTERVAL]
+                        try {
+                            intervalName?.let { BackupInterval.valueOf(it) }
+                                    ?: BackupInterval.WEEKLY
+                        } catch (e: IllegalArgumentException) {
+                            LogManager.w(
+                                    TAG,
+                                    "Invalid BackupInterval name '$intervalName' in DataStore. Defaulting to WEEKLY.",
+                                    e
+                            )
+                            BackupInterval.WEEKLY
+                        }
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setAutoBackupInterval(interval: BackupInterval) {
         LogManager.d(TAG, "Setting autoBackupInterval to: ${interval.name}")
         saveSetting(SettingsPreferenceKeys.AUTO_BACKUP_INTERVAL.name, interval.name)
     }
 
-
-    override val autoBackupCreateNewFile: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.AUTO_BACKUP_CREATE_NEW_FILE.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing autoBackupCreateNewFile", exception)
-        emit(false)
-    }
+    override val autoBackupCreateNewFile: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.AUTO_BACKUP_CREATE_NEW_FILE.name, false).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing autoBackupCreateNewFile", exception)
+                emit(false)
+            }
 
     override suspend fun setAutoBackupCreateNewFile(createNew: Boolean) {
         LogManager.d(TAG, "Setting autoBackupCreateNewFile to: $createNew")
         saveSetting(SettingsPreferenceKeys.AUTO_BACKUP_CREATE_NEW_FILE.name, createNew)
     }
 
-    override val autoBackupLastSuccessfulTimestamp: Flow<Long> = observeSetting(
-        SettingsPreferenceKeys.AUTO_BACKUP_LAST_SUCCESSFUL_TIMESTAMP.name,
-        0L
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing autoBackupLastSuccessfulTimestamp", exception)
-        emit(0L) // Fallback
-    }
+    override val autoBackupLastSuccessfulTimestamp: Flow<Long> =
+            observeSetting(SettingsPreferenceKeys.AUTO_BACKUP_LAST_SUCCESSFUL_TIMESTAMP.name, 0L)
+                    .catch { exception ->
+                        LogManager.e(
+                                TAG,
+                                "Error observing autoBackupLastSuccessfulTimestamp",
+                                exception
+                        )
+                        emit(0L) // Fallback
+                    }
 
     override suspend fun setAutoBackupLastSuccessfulTimestamp(timestamp: Long) {
         LogManager.d(TAG, "Setting autoBackupLastSuccessfulTimestamp to: $timestamp")
@@ -846,39 +928,33 @@ class SettingsFacadeImpl @Inject constructor(
     }
 
     // --- Reminder Settings ---
-    override val reminderEnabled: Flow<Boolean> = observeSetting(
-        SettingsPreferenceKeys.REMINDER_ENABLED.name,
-        false
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing reminderEnabled", exception)
-        emit(false)
-    }
+    override val reminderEnabled: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.REMINDER_ENABLED.name, false).catch { exception ->
+                LogManager.e(TAG, "Error observing reminderEnabled", exception)
+                emit(false)
+            }
 
     override suspend fun setReminderEnabled(enabled: Boolean) {
         LogManager.d(TAG, "Setting reminderEnabled to: $enabled")
         saveSetting(SettingsPreferenceKeys.REMINDER_ENABLED.name, enabled)
     }
 
-    override val reminderText: Flow<String> = observeSetting(
-        SettingsPreferenceKeys.REMINDER_TEXT.name,
-        ""
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing reminderText", exception)
-        emit("")
-    }
+    override val reminderText: Flow<String> =
+            observeSetting(SettingsPreferenceKeys.REMINDER_TEXT.name, "").catch { exception ->
+                LogManager.e(TAG, "Error observing reminderText", exception)
+                emit("")
+            }
 
     override suspend fun setReminderText(text: String) {
         LogManager.d(TAG, "Setting reminderText to: $text")
         saveSetting(SettingsPreferenceKeys.REMINDER_TEXT.name, text)
     }
 
-    override val reminderHour: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.REMINDER_HOUR.name,
-        9
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing reminderHour", exception)
-        emit(9)
-    }
+    override val reminderHour: Flow<Int> =
+            observeSetting(SettingsPreferenceKeys.REMINDER_HOUR.name, 9).catch { exception ->
+                LogManager.e(TAG, "Error observing reminderHour", exception)
+                emit(9)
+            }
 
     override suspend fun setReminderHour(hour: Int) {
         val h = hour.coerceIn(0, 23)
@@ -886,13 +962,11 @@ class SettingsFacadeImpl @Inject constructor(
         saveSetting(SettingsPreferenceKeys.REMINDER_HOUR.name, h)
     }
 
-    override val reminderMinute: Flow<Int> = observeSetting(
-        SettingsPreferenceKeys.REMINDER_MINUTE.name,
-        0
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing reminderMinute", exception)
-        emit(0)
-    }
+    override val reminderMinute: Flow<Int> =
+            observeSetting(SettingsPreferenceKeys.REMINDER_MINUTE.name, 0).catch { exception ->
+                LogManager.e(TAG, "Error observing reminderMinute", exception)
+                emit(0)
+            }
 
     override suspend fun setReminderMinute(minute: Int) {
         val m = minute.coerceIn(0, 59)
@@ -900,150 +974,181 @@ class SettingsFacadeImpl @Inject constructor(
         saveSetting(SettingsPreferenceKeys.REMINDER_MINUTE.name, m)
     }
 
-    override val reminderDays: Flow<Set<String>> = observeSetting(
-        SettingsPreferenceKeys.REMINDER_DAYS.name,
-        emptySet<String>()
-    ).catch { exception ->
-        LogManager.e(TAG, "Error observing reminderDays", exception)
-        emit(emptySet())
-    }
+    override val reminderDays: Flow<Set<String>> =
+            observeSetting(SettingsPreferenceKeys.REMINDER_DAYS.name, emptySet<String>()).catch {
+                    exception ->
+                LogManager.e(TAG, "Error observing reminderDays", exception)
+                emit(emptySet())
+            }
 
     override suspend fun setReminderDays(days: Set<String>) {
-        val safe = days.filter {
-            runCatching { java.time.DayOfWeek.valueOf(it) }.isSuccess
-        }.toSet()
+        val safe = days.filter { runCatching { java.time.DayOfWeek.valueOf(it) }.isSuccess }.toSet()
         LogManager.d(TAG, "Setting reminderDays to: $safe (raw: $days)")
         saveSetting(SettingsPreferenceKeys.REMINDER_DAYS.name, safe)
     }
 
-    override val selectedBodyFatFormula = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading BODY_FAT_FORMULA_OPTION", exception)
-            if (exception is IOException) emit(emptyPreferences()) else throw exception
-        }
-        .map { prefs ->
-            val raw = prefs[SettingsPreferenceKeys.BODY_FAT_FORMULA_OPTION] ?: BodyFatFormulaOption.OFF.name
-            runCatching { BodyFatFormulaOption.valueOf(raw) }.getOrDefault(BodyFatFormulaOption.OFF)
-        }
-        .distinctUntilChanged()
+    override val selectedBodyFatFormula =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error reading BODY_FAT_FORMULA_OPTION", exception)
+                        if (exception is IOException) emit(emptyPreferences()) else throw exception
+                    }
+                    .map { prefs ->
+                        val raw =
+                                prefs[SettingsPreferenceKeys.BODY_FAT_FORMULA_OPTION]
+                                        ?: BodyFatFormulaOption.OFF.name
+                        runCatching { BodyFatFormulaOption.valueOf(raw) }
+                                .getOrDefault(BodyFatFormulaOption.OFF)
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setSelectedBodyFatFormula(option: BodyFatFormulaOption) {
         LogManager.d(TAG, "Setting BODY_FAT_FORMULA_OPTION to: ${option.name}")
         saveSetting(SettingsPreferenceKeys.BODY_FAT_FORMULA_OPTION.name, option.name)
     }
 
-    override val selectedBodyWaterFormula = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading BODY_WATER_FORMULA_OPTION", exception)
-            if (exception is IOException) emit(emptyPreferences()) else throw exception
-        }
-        .map { prefs ->
-            val raw = prefs[SettingsPreferenceKeys.BODY_WATER_FORMULA_OPTION] ?: BodyWaterFormulaOption.OFF.name
-            runCatching { BodyWaterFormulaOption.valueOf(raw) }.getOrDefault(BodyWaterFormulaOption.OFF)
-        }
-        .distinctUntilChanged()
+    override val selectedBodyWaterFormula =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error reading BODY_WATER_FORMULA_OPTION", exception)
+                        if (exception is IOException) emit(emptyPreferences()) else throw exception
+                    }
+                    .map { prefs ->
+                        val raw =
+                                prefs[SettingsPreferenceKeys.BODY_WATER_FORMULA_OPTION]
+                                        ?: BodyWaterFormulaOption.OFF.name
+                        runCatching { BodyWaterFormulaOption.valueOf(raw) }
+                                .getOrDefault(BodyWaterFormulaOption.OFF)
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setSelectedBodyWaterFormula(option: BodyWaterFormulaOption) {
         LogManager.d(TAG, "Setting BODY_WATER_FORMULA_OPTION to: ${option.name}")
         saveSetting(SettingsPreferenceKeys.BODY_WATER_FORMULA_OPTION.name, option.name)
     }
 
-    override val selectedLbmFormula = dataStore.data
-        .catch { exception ->
-            LogManager.e(TAG, "Error reading LBM_FORMULA_OPTION", exception)
-            if (exception is IOException) emit(emptyPreferences()) else throw exception
-        }
-        .map { prefs ->
-            val raw = prefs[SettingsPreferenceKeys.LBM_FORMULA_OPTION] ?: LbmFormulaOption.OFF.name
-            runCatching { LbmFormulaOption.valueOf(raw) }.getOrDefault(LbmFormulaOption.OFF)
-        }
-        .distinctUntilChanged()
+    override val selectedLbmFormula =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        LogManager.e(TAG, "Error reading LBM_FORMULA_OPTION", exception)
+                        if (exception is IOException) emit(emptyPreferences()) else throw exception
+                    }
+                    .map { prefs ->
+                        val raw =
+                                prefs[SettingsPreferenceKeys.LBM_FORMULA_OPTION]
+                                        ?: LbmFormulaOption.OFF.name
+                        runCatching { LbmFormulaOption.valueOf(raw) }
+                                .getOrDefault(LbmFormulaOption.OFF)
+                    }
+                    .distinctUntilChanged()
 
     override suspend fun setSelectedLbmFormula(option: LbmFormulaOption) {
         LogManager.d(TAG, "Setting LBM_FORMULA_OPTION to: ${option.name}")
         saveSetting(SettingsPreferenceKeys.LBM_FORMULA_OPTION.name, option.name)
     }
 
-    @Suppress("UNCHECKED_CAST")
+    // --- Webhook Export Settings ---
+    override val webhookExportEnabled: Flow<Boolean> =
+            observeSetting(SettingsPreferenceKeys.WEBHOOK_EXPORT_ENABLED.name, false)
+
+    override suspend fun setWebhookExportEnabled(enabled: Boolean) {
+        saveSetting(SettingsPreferenceKeys.WEBHOOK_EXPORT_ENABLED.name, enabled)
+    }
+
+    override val webhookExportUrl: Flow<String?> =
+            dataStore
+                    .data
+                    .catch { exception ->
+                        if (exception is IOException) emit(emptyPreferences()) else throw exception
+                    }
+                    .map { preferences -> preferences[SettingsPreferenceKeys.WEBHOOK_EXPORT_URL] }
+                    .distinctUntilChanged()
+
+    override suspend fun setWebhookExportUrl(url: String?) {
+        dataStore.edit { preferences ->
+            if (!url.isNullOrBlank()) preferences[SettingsPreferenceKeys.WEBHOOK_EXPORT_URL] = url
+            else preferences.remove(SettingsPreferenceKeys.WEBHOOK_EXPORT_URL)
+        }
+    }
     override fun <T> observeSetting(keyName: String, defaultValue: T): Flow<T> {
-        //LogManager.v(
+        // LogManager.v(
         //    TAG,
-        //    "Observing setting: key='$keyName', type='${defaultValue?.let { it::class.simpleName } ?: "null"}'"
-        //)
+        //    "Observing setting: key='$keyName', type='${defaultValue?.let { it::class.simpleName }
+        // ?: "null"}'"
+        // )
 
-        return dataStore.data
-            .catch { exception ->
-                LogManager.e(TAG, "Error reading setting '$keyName' from DataStore.", exception)
-                if (exception is IOException) {
-                    emit(emptyPreferences())
-                } else {
-                    throw exception
+        return dataStore
+                .data
+                .catch { exception ->
+                    LogManager.e(TAG, "Error reading setting '$keyName' from DataStore.", exception)
+                    if (exception is IOException) {
+                        emit(emptyPreferences())
+                    } else {
+                        throw exception
+                    }
                 }
-            }
-            .map { preferences ->
-                when (defaultValue) {
-                    // Nullable String case (e.g., observeSetting(KEY, null as String?))
-                    null -> {
-                        val key = stringPreferencesKey(keyName)
-                        // May return null; that's intended for nullable String
-                        preferences[key] as T?
-                    }
-
-                    is Boolean -> {
-                        val key = booleanPreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is Int -> {
-                        val key = intPreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is Long -> {
-                        val key = longPreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is Float -> {
-                        val key = floatPreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is Double -> {
-                        val key = doublePreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is String -> {
-                        val key = stringPreferencesKey(keyName)
-                        (preferences[key] ?: defaultValue) as T
-                    }
-
-                    is Set<*> -> {
-                        // only Set<String> is supported by DataStore
-                        if (!defaultValue.all { it is String }) {
-                            val msg = "Unsupported Set type for preference: $keyName. Only Set<String> is supported."
+                .map { preferences ->
+                    when (defaultValue) {
+                        // Nullable String case (e.g., observeSetting(KEY, null as String?))
+                        null -> {
+                            val key = stringPreferencesKey(keyName)
+                            // May return null; that's intended for nullable String
+                            preferences[key] as T?
+                        }
+                        is Boolean -> {
+                            val key = booleanPreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is Int -> {
+                            val key = intPreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is Long -> {
+                            val key = longPreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is Float -> {
+                            val key = floatPreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is Double -> {
+                            val key = doublePreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is String -> {
+                            val key = stringPreferencesKey(keyName)
+                            (preferences[key] ?: defaultValue) as T
+                        }
+                        is Set<*> -> {
+                            // only Set<String> is supported by DataStore
+                            if (!defaultValue.all { it is String }) {
+                                val msg =
+                                        "Unsupported Set type for preference: $keyName. Only Set<String> is supported."
+                                LogManager.e(TAG, msg)
+                                throw IllegalArgumentException(msg)
+                            }
+                            val key = stringSetPreferencesKey(keyName)
+                            @Suppress("UNCHECKED_CAST")
+                            (preferences[key] ?: defaultValue as Set<String>) as T
+                        }
+                        else -> {
+                            val msg =
+                                    "Unsupported type for preference: $keyName (Type: ${defaultValue::class.java.name})"
                             LogManager.e(TAG, msg)
                             throw IllegalArgumentException(msg)
                         }
-                        val key = stringSetPreferencesKey(keyName)
-                        @Suppress("UNCHECKED_CAST")
-                        (preferences[key] ?: defaultValue as Set<String>) as T
-                    }
-
-                    else -> {
-                        val msg = "Unsupported type for preference: $keyName (Type: ${defaultValue::class.java.name})"
-                        LogManager.e(TAG, msg)
-                        throw IllegalArgumentException(msg)
                     }
                 }
-            }
-            .distinctUntilChanged() as Flow<T>
+                .distinctUntilChanged() as
+                Flow<T>
     }
 
-
     override suspend fun <T> saveSetting(keyName: String, value: T) {
-        //LogManager.v(TAG, "Saving setting: key='$keyName', value='$value', type='${value!!::class.simpleName}'")
+        // LogManager.v(TAG, "Saving setting: key='$keyName', value='$value',
+        // type='${value!!::class.simpleName}'")
         try {
             dataStore.edit { preferences ->
                 when (value) {
@@ -1058,22 +1163,29 @@ class SettingsFacadeImpl @Inject constructor(
                             @Suppress("UNCHECKED_CAST")
                             preferences[stringSetPreferencesKey(keyName)] = value as Set<String>
                         } else {
-                            val errorMsg = "Unsupported Set type for preference: $keyName. Only Set<String> is supported."
+                            val errorMsg =
+                                    "Unsupported Set type for preference: $keyName. Only Set<String> is supported."
                             LogManager.e(TAG, errorMsg)
-                            throw IllegalArgumentException(errorMsg) // This will be caught by the outer try-catch
+                            throw IllegalArgumentException(
+                                    errorMsg
+                            ) // This will be caught by the outer try-catch
                         }
                     }
                     else -> {
-                        val errorMsg = "Unsupported type for preference: $keyName (Type: ${value!!::class.java.name})"
+                        val errorMsg =
+                                "Unsupported type for preference: $keyName (Type: ${value!!::class.java.name})"
                         LogManager.e(TAG, errorMsg)
-                        throw IllegalArgumentException(errorMsg) // This will be caught by the outer try-catch
+                        throw IllegalArgumentException(
+                                errorMsg
+                        ) // This will be caught by the outer try-catch
                     }
                 }
             }
-           // LogManager.d(TAG, "Successfully saved setting: key='$keyName'")
+            // LogManager.d(TAG, "Successfully saved setting: key='$keyName'")
         } catch (e: Exception) {
             LogManager.e(TAG, "Failed to save setting: key='$keyName', value='$value'", e)
-            // Depending on the app's needs, you might want to rethrow or handle specific exceptions differently.
+            // Depending on the app's needs, you might want to rethrow or handle specific exceptions
+            // differently.
         }
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/InfluxDbExportUseCases.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/InfluxDbExportUseCases.kt
@@ -1,0 +1,186 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.usecase
+
+import com.health.openscale.core.data.Measurement
+import com.health.openscale.core.data.MeasurementTypeKey
+import com.health.openscale.core.data.MeasurementValue
+import com.health.openscale.core.facade.SettingsFacade
+import com.health.openscale.core.utils.LogManager
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * Exports measurement data to an InfluxDB instance using the HTTP Line Protocol API.
+ *
+ * Supports InfluxDB v1 (POST /write?db=...) and v2 (POST /api/v2/write?org=...&bucket=...). Field
+ * names for the 7 main body metrics are configurable by the user. Other numeric fields are sent
+ * with their default openScale key names.
+ *
+ * Triggered automatically on every new measurement insert when enabled.
+ */
+@Singleton
+class InfluxDbExportUseCases @Inject constructor(private val settingsFacade: SettingsFacade) {
+    private val httpClient =
+            OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS)
+                    .build()
+    private val TAG = "InfluxDbExportUseCases"
+
+    suspend fun exportOnInsert(measurement: Measurement, values: List<MeasurementValue>) {
+        val enabled = settingsFacade.influxDbExportEnabled.first()
+        if (!enabled) return
+
+        val host = settingsFacade.influxDbHost.first()
+        if (host.isBlank()) return
+
+        val lineProtocol = buildLineProtocol(measurement, values)
+        if (lineProtocol.isBlank()) return
+
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val url = buildWriteUrl(host)
+                val requestBuilder =
+                        Request.Builder()
+                                .url(url)
+                                .post(
+                                        lineProtocol.toRequestBody(
+                                                "text/plain; charset=utf-8".toMediaType()
+                                        )
+                                )
+
+                val username = settingsFacade.influxDbUsername.first()
+                val password = settingsFacade.influxDbPassword.first()
+                if (username.isNotBlank()) {
+                    requestBuilder.header("Authorization", Credentials.basic(username, password))
+                }
+
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        LogManager.w(TAG, "InfluxDB POST failed: HTTP ${response.code} for $url")
+                    } else {
+                        LogManager.d(TAG, "InfluxDB POST succeeded: HTTP ${response.code}")
+                    }
+                }
+            }
+                    .onFailure { e -> LogManager.e(TAG, "InfluxDB POST error", e) }
+        }
+    }
+
+    /** Sends a test point and returns a human-readable result string. */
+    suspend fun sendTestRequest(): String =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val host = settingsFacade.influxDbHost.first()
+                    if (host.isBlank()) return@withContext "Error: Host is not configured"
+
+                    val measurement = settingsFacade.influxDbMeasurement.first()
+                    val lineProtocol =
+                            "${escapeTag(measurement)},source=openscale test=1i ${System.currentTimeMillis()}"
+                    val url = buildWriteUrl(host)
+
+                    val requestBuilder =
+                            Request.Builder()
+                                    .url(url)
+                                    .post(
+                                            lineProtocol.toRequestBody(
+                                                    "text/plain; charset=utf-8".toMediaType()
+                                            )
+                                    )
+
+                    val username = settingsFacade.influxDbUsername.first()
+                    val password = settingsFacade.influxDbPassword.first()
+                    if (username.isNotBlank()) {
+                        requestBuilder.header(
+                                "Authorization",
+                                Credentials.basic(username, password)
+                        )
+                    }
+
+                    httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                        "HTTP ${response.code} ${response.message}"
+                    }
+                }
+                        .getOrElse { e -> "Error: ${e.localizedMessage}" }
+            }
+
+    private suspend fun buildWriteUrl(host: String): String {
+        val cleanHost = host.trimEnd('/')
+        return when (settingsFacade.influxDbVersion.first()) {
+            "v2" -> "$cleanHost/api/v2/write?precision=ms"
+            else -> {
+                val database = settingsFacade.influxDbDatabase.first()
+                "$cleanHost/write?db=${encodeQueryParam(database)}&precision=ms"
+            }
+        }
+    }
+
+    private suspend fun buildLineProtocol(
+            measurement: Measurement,
+            values: List<MeasurementValue>
+    ): String {
+        val measurementName = settingsFacade.influxDbMeasurement.first()
+
+        val keyById = MeasurementTypeKey.entries.associateBy { it.id }
+        val fields =
+                values.mapNotNull { v ->
+                    val typeKey = keyById[v.typeId] ?: return@mapNotNull null
+                    // Skip non-numeric / metadata fields
+                    if (typeKey in
+                                    setOf(
+                                            MeasurementTypeKey.DATE,
+                                            MeasurementTypeKey.TIME,
+                                            MeasurementTypeKey.COMMENT,
+                                            MeasurementTypeKey.USER,
+                                            MeasurementTypeKey.CUSTOM
+                                    )
+                    )
+                            return@mapNotNull null
+
+                    val fieldName = typeKey.name.lowercase()
+
+                    when {
+                        v.floatValue != null -> "$fieldName=${v.floatValue}"
+                        v.intValue != null -> "${fieldName}=${v.intValue}i"
+                        else -> null
+                    }
+                }
+
+        if (fields.isEmpty()) return ""
+
+        // Line Protocol: <measurement>,<tags> <fields> <timestamp>
+        return "${escapeTag(measurementName)},source=openscale ${fields.joinToString(",")} ${measurement.timestamp}"
+    }
+
+    /** Escapes special characters in InfluxDB tag keys/values and measurement names. */
+    private fun escapeTag(value: String): String =
+            value.replace(",", "\\,").replace(" ", "\\ ").replace("=", "\\=")
+
+    /** Simple percent-encoding for query parameter values. */
+    private fun encodeQueryParam(value: String): String = java.net.URLEncoder.encode(value, "UTF-8")
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementCrudUseCases.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementCrudUseCases.kt
@@ -27,28 +27,30 @@ import com.health.openscale.core.database.DatabaseRepository
 import com.health.openscale.core.facade.SettingsFacade
 import com.health.openscale.ui.widget.MeasurementWidget
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
 
 /**
  * Bundles CRUD-related use cases for measurements.
  *
  * Contains:
  * - [saveMeasurement]: insert or update a measurement and reconcile its values.
- * - [deleteMeasurement]: delete a measurement (and rely on DB constraints to cascade values if configured).
+ * - [deleteMeasurement]: delete a measurement (and rely on DB constraints to cascade values if
+ * configured).
  */
 @Singleton
-class MeasurementCrudUseCases @Inject constructor(
-    @ApplicationContext private val appContext: Context,
-    private val settingsFacade: SettingsFacade,
-    private val sync: SyncUseCases,
-    private val transformation: MeasurementTransformationUseCase,
-    private val databaseRepository: DatabaseRepository
-    ) {
+class MeasurementCrudUseCases
+@Inject
+constructor(
+        @ApplicationContext private val appContext: Context,
+        private val settingsFacade: SettingsFacade,
+        private val sync: SyncUseCases,
+        private val webhookExport: WebhookExportUseCases,
+        private val transformation: MeasurementTransformationUseCase,
+        private val databaseRepository: DatabaseRepository
+) {
     private var lastVibrateTime = 0L
 
     /**
@@ -57,19 +59,20 @@ class MeasurementCrudUseCases @Inject constructor(
      * Rules:
      * - If `measurement.id == 0`: insert measurement, then insert all values for the new id.
      * - If `measurement.id != 0`: update measurement, then
-     *   - delete values that no longer exist in [values],
-     *   - update values that exist (by id),
-     *   - insert values that are new (id == 0).
+     * - delete values that no longer exist in [values],
+     * - update values that exist (by id),
+     * - insert values that are new (id == 0).
      *
-     * @return [Result.success] with the final measurement id (new or existing) on success,
-     * or [Result.failure] on error.
+     * @return [Result.success] with the final measurement id (new or existing) on success, or
+     * [Result.failure] on error.
      */
     suspend fun saveMeasurement(
-        measurement: Measurement,
-        values: List<MeasurementValue>
+            measurement: Measurement,
+            values: List<MeasurementValue>
     ): Result<Int> = runCatching {
         val correctedValues = transformation.applyAmputationCorrection(measurement, values)
-        val finalValues : List<MeasurementValue> = transformation.applySelectedFormulasForMeasurement(measurement, correctedValues)
+        val finalValues: List<MeasurementValue> =
+                transformation.applySelectedFormulasForMeasurement(measurement, correctedValues)
 
         if (measurement.id == 0) {
             // Insert path
@@ -80,9 +83,14 @@ class MeasurementCrudUseCases @Inject constructor(
                 databaseRepository.insertMeasurementValue(v.copy(measurementId = newId))
             }
 
-            sync.triggerSyncInsert(measurementWithId, finalValues,"com.health.openscale.sync")
-            sync.triggerSyncInsert(measurementWithId, finalValues,"com.health.openscale.sync.oss")
-            sync.triggerSyncInsert(measurementWithId, finalValues,"com.health.openscale.sync.debug")
+            sync.triggerSyncInsert(measurementWithId, finalValues, "com.health.openscale.sync")
+            sync.triggerSyncInsert(measurementWithId, finalValues, "com.health.openscale.sync.oss")
+            sync.triggerSyncInsert(
+                    measurementWithId,
+                    finalValues,
+                    "com.health.openscale.sync.debug"
+            )
+            webhookExport.exportOnInsert(measurementWithId, finalValues)
 
             MeasurementWidget.refreshAll(appContext)
 
@@ -105,15 +113,19 @@ class MeasurementCrudUseCases @Inject constructor(
             finalValues.forEach { v ->
                 val exists = existing.any { it.id == v.id && v.id != 0 }
                 if (exists) {
-                    databaseRepository.updateMeasurementValue(v.copy(measurementId = measurement.id))
+                    databaseRepository.updateMeasurementValue(
+                            v.copy(measurementId = measurement.id)
+                    )
                 } else {
-                    databaseRepository.insertMeasurementValue(v.copy(measurementId = measurement.id))
+                    databaseRepository.insertMeasurementValue(
+                            v.copy(measurementId = measurement.id)
+                    )
                 }
             }
 
             sync.triggerSyncUpdate(measurement, finalValues, "com.health.openscale.sync")
-            sync.triggerSyncUpdate(measurement, finalValues,"com.health.openscale.sync.oss")
-            sync.triggerSyncUpdate(measurement, finalValues,"com.health.openscale.sync.debug")
+            sync.triggerSyncUpdate(measurement, finalValues, "com.health.openscale.sync.oss")
+            sync.triggerSyncUpdate(measurement, finalValues, "com.health.openscale.sync.debug")
 
             MeasurementWidget.refreshAll(appContext)
 
@@ -124,14 +136,12 @@ class MeasurementCrudUseCases @Inject constructor(
     /**
      * Deletes the given [measurement].
      *
-     * Note: If value rows aren't configured to cascade-delete in the schema,
-     * the repository is expected to handle value cleanup as needed.
+     * Note: If value rows aren't configured to cascade-delete in the schema, the repository is
+     * expected to handle value cleanup as needed.
      *
      * @return [Result.success] on success or [Result.failure] on error.
      */
-    suspend fun deleteMeasurement(
-        measurement: Measurement
-    ): Result<Unit> = runCatching {
+    suspend fun deleteMeasurement(measurement: Measurement): Result<Unit> = runCatching {
         databaseRepository.deleteMeasurement(measurement)
         sync.triggerSyncDelete(Date(measurement.timestamp), "com.health.openscale.sync")
         sync.triggerSyncDelete(Date(measurement.timestamp), "com.health.openscale.sync.oss")
@@ -158,10 +168,7 @@ class MeasurementCrudUseCases @Inject constructor(
         val vibrator: Vibrator = vm.defaultVibrator
         if (!vibrator.hasVibrator()) return
 
-        val effect = VibrationEffect.createOneShot(
-            500L,
-            255
-        )
+        val effect = VibrationEffect.createOneShot(500L, 255)
         vibrator.vibrate(effect)
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementCrudUseCases.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementCrudUseCases.kt
@@ -48,6 +48,7 @@ constructor(
         private val settingsFacade: SettingsFacade,
         private val sync: SyncUseCases,
         private val webhookExport: WebhookExportUseCases,
+        private val influxDbExport: InfluxDbExportUseCases,
         private val transformation: MeasurementTransformationUseCase,
         private val databaseRepository: DatabaseRepository
 ) {
@@ -91,6 +92,7 @@ constructor(
                     "com.health.openscale.sync.debug"
             )
             webhookExport.exportOnInsert(measurementWithId, finalValues)
+            influxDbExport.exportOnInsert(measurementWithId, finalValues)
 
             MeasurementWidget.refreshAll(appContext)
 

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/WebhookExportUseCases.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/WebhookExportUseCases.kt
@@ -1,0 +1,121 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.usecase
+
+import com.health.openscale.core.data.Measurement
+import com.health.openscale.core.data.MeasurementTypeKey
+import com.health.openscale.core.data.MeasurementValue
+import com.health.openscale.core.facade.SettingsFacade
+import com.health.openscale.core.utils.LogManager
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * Sends measurement data as a JSON POST request to a user-configured webhook URL.
+ *
+ * Triggered automatically on every new measurement insert. Can be configured by the user in Data
+ * Management Settings.
+ *
+ * The JSON payload contains:
+ * - `timestamp`: epoch milliseconds
+ * - `id`: measurement id
+ * - `userId`: user id
+ * - one field per measurement value, keyed by the lowercase [MeasurementTypeKey] name (e.g.
+ * `weight`, `body_fat`, `water`, `muscle`)
+ */
+@Singleton
+class WebhookExportUseCases @Inject constructor(private val settingsFacade: SettingsFacade) {
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(10, TimeUnit.SECONDS)
+        .build()
+    private val keyById = MeasurementTypeKey.entries.associateBy { it.id }
+    private val TAG = "WebhookExportUseCases"
+
+    /** Sends a minimal test ping to [url] and returns a human-readable result string. */
+    suspend fun sendTestRequest(url: String): String = withContext(Dispatchers.IO) {
+        runCatching {
+            val body = JSONObject().apply {
+                put("test", true)
+                put("source", "openScale")
+            }.toString().toRequestBody("application/json".toMediaType())
+            val request = Request.Builder().url(url).post(body).build()
+            httpClient.newCall(request).execute().use { response ->
+                "HTTP ${response.code} ${response.message}"
+            }
+        }.getOrElse { e -> "Error: ${e.localizedMessage}" }
+    }
+
+    suspend fun exportOnInsert(measurement: Measurement, values: List<MeasurementValue>) {
+        val enabled = settingsFacade.webhookExportEnabled.first()
+        if (!enabled) return
+
+        val url = settingsFacade.webhookExportUrl.first()
+        if (url.isNullOrBlank()) return
+
+        val json = buildJson(measurement, values)
+
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder().url(url).post(body).build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        LogManager.w(TAG, "Webhook POST failed: HTTP ${response.code} for $url")
+                    } else {
+                        LogManager.d(TAG, "Webhook POST succeeded: HTTP ${response.code}")
+                    }
+                }
+            }
+                    .onFailure { e -> LogManager.e(TAG, "Webhook POST error for $url", e) }
+        }
+    }
+
+    private fun buildJson(measurement: Measurement, values: List<MeasurementValue>): JSONObject {
+        val obj = JSONObject()
+        obj.put("timestamp", measurement.timestamp)
+        obj.put("id", measurement.id)
+        obj.put("userId", measurement.userId)
+
+        for (v in values) {
+            val key = keyById[v.typeId]
+            val fieldName =
+                    if (key != null && key != MeasurementTypeKey.CUSTOM) {
+                        key.name.lowercase()
+                    } else {
+                        "custom_${v.typeId}"
+                    }
+            when {
+                v.floatValue != null -> obj.put(fieldName, v.floatValue.toDouble())
+                v.intValue != null -> obj.put(fieldName, v.intValue)
+                v.textValue != null -> obj.put(fieldName, v.textValue)
+                v.dateValue != null -> obj.put(fieldName, v.dateValue)
+            }
+        }
+        return obj
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -52,6 +54,7 @@ import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.AlertDialog
@@ -64,6 +67,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -83,67 +87,74 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import androidx.navigation.NavController
 import com.health.openscale.R
 import com.health.openscale.core.data.BackupInterval
+import com.health.openscale.core.data.GenderType
 import com.health.openscale.core.data.User
-import kotlinx.coroutines.launch
+import com.health.openscale.core.utils.CalculationUtils
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
-import androidx.core.net.toUri
-import com.health.openscale.core.data.GenderType
-import com.health.openscale.core.utils.CalculationUtils
+import kotlinx.coroutines.launch
 
-
-/**
- * Represents items in the data management settings list.
- */
+/** Represents items in the data management settings list. */
 sealed class DataManagementSettingListItem {
-    /**
-     * Represents an actionable item in the settings list.
-     */
+    /** Represents an actionable item in the settings list. */
     data class ActionItem(
-        val label: String,
-        val icon: ImageVector,
-        val onClick: () -> Unit,
-        val enabled: Boolean = true,
-        val isDestructive: Boolean = false,
-        val isLoading: Boolean = false
+            val label: String,
+            val icon: ImageVector,
+            val onClick: () -> Unit,
+            val enabled: Boolean = true,
+            val isDestructive: Boolean = false,
+            val isLoading: Boolean = false
     ) : DataManagementSettingListItem()
 }
 
 /**
- * Composable screen for managing application data.
- * Allows users to export/import data, backup/restore the database,
- * and manage automatic backup settings.
+ * Composable screen for managing application data. Allows users to export/import data,
+ * backup/restore the database, and manage automatic backup settings.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DataManagementSettingsScreen(
-    navController: NavController,
-    settingsViewModel: SettingsViewModel
+        navController: NavController,
+        settingsViewModel: SettingsViewModel
 ) {
     val users by settingsViewModel.allUsers.collectAsState()
-    val showUserSelectionDialogForExport by settingsViewModel.showUserSelectionDialogForExport.collectAsState()
-    val showUserSelectionDialogForImport by settingsViewModel.showUserSelectionDialogForImport.collectAsState()
+    val showUserSelectionDialogForExport by
+            settingsViewModel.showUserSelectionDialogForExport.collectAsState()
+    val showUserSelectionDialogForImport by
+            settingsViewModel.showUserSelectionDialogForImport.collectAsState()
 
     val isLoadingExport by settingsViewModel.isLoadingExport.collectAsState()
     val isLoadingImport by settingsViewModel.isLoadingImport.collectAsState()
     val isLoadingDeletion by settingsViewModel.isLoadingDeletion.collectAsState()
     val isLoadingBackup by settingsViewModel.isLoadingBackup.collectAsState()
     val isLoadingRestore by settingsViewModel.isLoadingRestore.collectAsState()
-    val isLoadingEntireDatabaseDeletion by settingsViewModel.isLoadingEntireDatabaseDeletion.collectAsState()
-    val showDeleteEntireDatabaseConfirmationDialog by settingsViewModel.showDeleteEntireDatabaseConfirmationDialog.collectAsState()
+    val isLoadingEntireDatabaseDeletion by
+            settingsViewModel.isLoadingEntireDatabaseDeletion.collectAsState()
+    val showDeleteEntireDatabaseConfirmationDialog by
+            settingsViewModel.showDeleteEntireDatabaseConfirmationDialog.collectAsState()
 
-    val isAnyOperationLoading = isLoadingExport || isLoadingImport || isLoadingDeletion ||
-            isLoadingBackup || isLoadingRestore || isLoadingEntireDatabaseDeletion
+    val isAnyOperationLoading =
+            isLoadingExport ||
+                    isLoadingImport ||
+                    isLoadingDeletion ||
+                    isLoadingBackup ||
+                    isLoadingRestore ||
+                    isLoadingEntireDatabaseDeletion
 
-    val showUserSelectionDialogForDelete by settingsViewModel.showUserSelectionDialogForDelete.collectAsState()
+    val showUserSelectionDialogForDelete by
+            settingsViewModel.showUserSelectionDialogForDelete.collectAsState()
     val userPendingDeletion by settingsViewModel.userPendingDeletion.collectAsState()
-    val showDeleteConfirmationDialog by settingsViewModel.showDeleteConfirmationDialog.collectAsState()
+    val showDeleteConfirmationDialog by
+            settingsViewModel.showDeleteConfirmationDialog.collectAsState()
     var showRestoreConfirmationDialog by rememberSaveable { mutableStateOf(false) }
 
     val context = LocalContext.current
@@ -154,145 +165,210 @@ fun DataManagementSettingsScreen(
     val autoBackupLocationUriString by settingsViewModel.autoBackupLocationUri.collectAsState()
     val autoBackupInterval by settingsViewModel.autoBackupInterval.collectAsState()
     val autoBackupCreateNewFile by settingsViewModel.autoBackupCreateNewFile.collectAsState()
-    val autoBackupLastSuccessfulTimestamp by settingsViewModel.autoBackupLastSuccessfulTimestamp.collectAsState()
+    val autoBackupLastSuccessfulTimestamp by
+            settingsViewModel.autoBackupLastSuccessfulTimestamp.collectAsState()
     val isAutoBackupLocationConfigured = autoBackupLocationUriString != null
 
     // Effective state: global switch is on AND a location is configured.
-    val isAutoBackupEffectivelyEnabled by remember(autoBackupGloballyEnabled, isAutoBackupLocationConfigured) {
-        mutableStateOf(autoBackupGloballyEnabled && isAutoBackupLocationConfigured)
-    }
-
-
-    val lastBackupStatusText by remember(
-        isAutoBackupEffectivelyEnabled,
-        autoBackupLocationUriString,
-        autoBackupGloballyEnabled,
-        autoBackupLastSuccessfulTimestamp,
-        context
-    ) {
-        mutableStateOf(
-            if (isAutoBackupEffectivelyEnabled) {
-                if (autoBackupLastSuccessfulTimestamp > 0L) {
-                    val timestamp = autoBackupLastSuccessfulTimestamp
-                    val date = Date(timestamp)
-                    val dateFormat = DateFormat.getDateTimeInstance(
-                        DateFormat.MEDIUM,
-                        DateFormat.SHORT,
-                        Locale.getDefault()
-                    )
-                    val formattedTime = dateFormat.format(date)
-                    context.getString(R.string.settings_last_backup_status_successful, formattedTime)
-                } else {
-                    context.getString(R.string.settings_last_backup_status_never)
-                }
-            } else if (autoBackupGloballyEnabled && !isAutoBackupLocationConfigured) {
-                context.getString(R.string.settings_backup_location_not_configured_for_auto)
-            } else {
-                context.getString(R.string.settings_auto_backups_disabled)
+    val isAutoBackupEffectivelyEnabled by
+            remember(autoBackupGloballyEnabled, isAutoBackupLocationConfigured) {
+                mutableStateOf(autoBackupGloballyEnabled && isAutoBackupLocationConfigured)
             }
-        )
-    }
 
-    val selectedBackupIntervalDisplay = remember(autoBackupInterval, context) {
-        autoBackupInterval.getDisplayName(context)
-    }
+    val lastBackupStatusText by
+            remember(
+                    isAutoBackupEffectivelyEnabled,
+                    autoBackupLocationUriString,
+                    autoBackupGloballyEnabled,
+                    autoBackupLastSuccessfulTimestamp,
+                    context
+            ) {
+                mutableStateOf(
+                        if (isAutoBackupEffectivelyEnabled) {
+                            if (autoBackupLastSuccessfulTimestamp > 0L) {
+                                val timestamp = autoBackupLastSuccessfulTimestamp
+                                val date = Date(timestamp)
+                                val dateFormat =
+                                        DateFormat.getDateTimeInstance(
+                                                DateFormat.MEDIUM,
+                                                DateFormat.SHORT,
+                                                Locale.getDefault()
+                                        )
+                                val formattedTime = dateFormat.format(date)
+                                context.getString(
+                                        R.string.settings_last_backup_status_successful,
+                                        formattedTime
+                                )
+                            } else {
+                                context.getString(R.string.settings_last_backup_status_never)
+                            }
+                        } else if (autoBackupGloballyEnabled && !isAutoBackupLocationConfigured) {
+                            context.getString(
+                                    R.string.settings_backup_location_not_configured_for_auto
+                            )
+                        } else {
+                            context.getString(R.string.settings_auto_backups_disabled)
+                        }
+                )
+            }
+
+    val selectedBackupIntervalDisplay =
+            remember(autoBackupInterval, context) { autoBackupInterval.getDisplayName(context) }
     var showBackupIntervalDialog by remember { mutableStateOf(false) }
 
-    val backupBehaviorSupportingText by remember(autoBackupCreateNewFile, context) {
-        mutableStateOf(
-            if (autoBackupCreateNewFile) context.getString(R.string.settings_backup_behavior_new_file)
-            else context.getString(R.string.settings_backup_behavior_overwrite)
-        )
-    }
-
-    val currentBackupLocationUserDisplay by remember(autoBackupLocationUriString, context) {
-        mutableStateOf(
-            if (autoBackupLocationUriString != null) {
-                try {
-                    DocumentFile.fromTreeUri(context, Uri.parse(autoBackupLocationUriString!!))?.name
-                        ?: context.getString(R.string.settings_backup_location_selected_folder)
-                } catch (e: Exception) {
-                    context.getString(R.string.settings_backup_location_error_accessing)
-                }
-            } else {
-                context.getString(R.string.settings_backup_location_not_configured)
+    val backupBehaviorSupportingText by
+            remember(autoBackupCreateNewFile, context) {
+                mutableStateOf(
+                        if (autoBackupCreateNewFile)
+                                context.getString(R.string.settings_backup_behavior_new_file)
+                        else context.getString(R.string.settings_backup_behavior_overwrite)
+                )
             }
-        )
-    }
 
-    val canOpenSelectedBackupLocation by remember(autoBackupLocationUriString) {
-        mutableStateOf(autoBackupLocationUriString != null)
-    }
+    val currentBackupLocationUserDisplay by
+            remember(autoBackupLocationUriString, context) {
+                mutableStateOf(
+                        if (autoBackupLocationUriString != null) {
+                            try {
+                                DocumentFile.fromTreeUri(
+                                                context,
+                                                Uri.parse(autoBackupLocationUriString!!)
+                                        )
+                                        ?.name
+                                        ?: context.getString(
+                                                R.string.settings_backup_location_selected_folder
+                                        )
+                            } catch (e: Exception) {
+                                context.getString(R.string.settings_backup_location_error_accessing)
+                            }
+                        } else {
+                            context.getString(R.string.settings_backup_location_not_configured)
+                        }
+                )
+            }
+
+    val canOpenSelectedBackupLocation by
+            remember(autoBackupLocationUriString) {
+                mutableStateOf(autoBackupLocationUriString != null)
+            }
+
+    // --- Webhook Export state ---
+    val webhookExportEnabled by settingsViewModel.webhookExportEnabled.collectAsState()
+    val webhookExportUrl by settingsViewModel.webhookExportUrl.collectAsState()
+    var webhookUrlDraft by
+            rememberSaveable(webhookExportUrl) { mutableStateOf(webhookExportUrl ?: "") }
 
     var activeSafActionUserId by remember { mutableStateOf<Int?>(null) }
 
-    val exportCsvLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("text/csv"),
-        onResult = { uri: Uri? ->
-            uri?.let { fileUri ->
-                activeSafActionUserId?.let { userId ->
-                    settingsViewModel.performCsvExport(userId, fileUri, context.contentResolver)
-                    activeSafActionUserId = null
-                }
-            }
-        }
-    )
-
-    val importCsvLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument(),
-        onResult = { uri: Uri? ->
-            uri?.let { fileUri ->
-                activeSafActionUserId?.let { userId ->
-                    settingsViewModel.performCsvImport(userId, fileUri, context.contentResolver)
-                    activeSafActionUserId = null
-                }
-            }
-        }
-    )
-
-    val manualBackupDbLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("*/*"), // Using generic MIME type for DB backup
-        onResult = { uri: Uri? ->
-            uri?.let { fileUri ->
-                settingsViewModel.performDatabaseBackup(fileUri, context.contentResolver)
-            }
-        }
-    )
-
-    val restoreDbLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument(),
-        onResult = { uri: Uri? ->
-            uri?.let { fileUri ->
-                // Confirmation dialog is shown before launching, restore directly
-                settingsViewModel.performDatabaseRestore(fileUri, context.contentResolver)
-            }
-        }
-    )
-
-    val selectAutoBackupDirectoryLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocumentTree(),
-        onResult = { uri: Uri? ->
-            if (uri != null) {
-                coroutineScope.launch {
-                    val takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                    context.contentResolver.takePersistableUriPermission(uri, takeFlags)
-                    settingsViewModel.setAutoBackupLocationUri(uri.toString())
-                    // If user selects a folder, enable auto backups globally if not already.
-                    if (!autoBackupGloballyEnabled) {
-                        settingsViewModel.setAutoBackupEnabled(true)
+    val exportCsvLauncher =
+            rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.CreateDocument("text/csv"),
+                    onResult = { uri: Uri? ->
+                        uri?.let { fileUri ->
+                            activeSafActionUserId?.let { userId ->
+                                settingsViewModel.performCsvExport(
+                                        userId,
+                                        fileUri,
+                                        context.contentResolver
+                                )
+                                activeSafActionUserId = null
+                            }
+                        }
                     }
-                }
-                Toast.makeText(context, context.getString(R.string.settings_backup_location_selected_toast,
-                    DocumentFile.fromTreeUri(context, uri)?.name ?: "Selected folder"), Toast.LENGTH_SHORT).show()
-            } else {
-                // User cancelled or no folder selected
-                if (!isAutoBackupLocationConfigured) { // Only if no location was configured before
-                    coroutineScope.launch { settingsViewModel.setAutoBackupEnabled(false) }
-                }
-                Toast.makeText(context, R.string.settings_backup_location_selection_cancelled, Toast.LENGTH_SHORT).show()
-            }
-        }
-    )
+            )
+
+    val importCsvLauncher =
+            rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.OpenDocument(),
+                    onResult = { uri: Uri? ->
+                        uri?.let { fileUri ->
+                            activeSafActionUserId?.let { userId ->
+                                settingsViewModel.performCsvImport(
+                                        userId,
+                                        fileUri,
+                                        context.contentResolver
+                                )
+                                activeSafActionUserId = null
+                            }
+                        }
+                    }
+            )
+
+    val manualBackupDbLauncher =
+            rememberLauncherForActivityResult(
+                    contract =
+                            ActivityResultContracts.CreateDocument(
+                                    "*/*"
+                            ), // Using generic MIME type for DB backup
+                    onResult = { uri: Uri? ->
+                        uri?.let { fileUri ->
+                            settingsViewModel.performDatabaseBackup(
+                                    fileUri,
+                                    context.contentResolver
+                            )
+                        }
+                    }
+            )
+
+    val restoreDbLauncher =
+            rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.OpenDocument(),
+                    onResult = { uri: Uri? ->
+                        uri?.let { fileUri ->
+                            // Confirmation dialog is shown before launching, restore directly
+                            settingsViewModel.performDatabaseRestore(
+                                    fileUri,
+                                    context.contentResolver
+                            )
+                        }
+                    }
+            )
+
+    val selectAutoBackupDirectoryLauncher =
+            rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.OpenDocumentTree(),
+                    onResult = { uri: Uri? ->
+                        if (uri != null) {
+                            coroutineScope.launch {
+                                val takeFlags =
+                                        Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                                context.contentResolver.takePersistableUriPermission(uri, takeFlags)
+                                settingsViewModel.setAutoBackupLocationUri(uri.toString())
+                                // If user selects a folder, enable auto backups globally if not
+                                // already.
+                                if (!autoBackupGloballyEnabled) {
+                                    settingsViewModel.setAutoBackupEnabled(true)
+                                }
+                            }
+                            Toast.makeText(
+                                            context,
+                                            context.getString(
+                                                    R.string
+                                                            .settings_backup_location_selected_toast,
+                                                    DocumentFile.fromTreeUri(context, uri)?.name
+                                                            ?: "Selected folder"
+                                            ),
+                                            Toast.LENGTH_SHORT
+                                    )
+                                    .show()
+                        } else {
+                            // User cancelled or no folder selected
+                            if (!isAutoBackupLocationConfigured
+                            ) { // Only if no location was configured before
+                                coroutineScope.launch {
+                                    settingsViewModel.setAutoBackupEnabled(false)
+                                }
+                            }
+                            Toast.makeText(
+                                            context,
+                                            R.string.settings_backup_location_selection_cancelled,
+                                            Toast.LENGTH_SHORT
+                                    )
+                                    .show()
+                        }
+                    }
+            )
 
     LaunchedEffect(key1 = settingsViewModel) {
         settingsViewModel.safEvent.collect { event ->
@@ -309,10 +385,17 @@ fun DataManagementSettingsScreen(
                     activeSafActionUserId = event.userId
                     if (event.actionId == SettingsViewModel.ACTION_ID_RESTORE_DB) {
                         // For DB restore, we show a confirmation dialog first.
-                        // The actual launch happens after confirmation. This SAF event is for when that's confirmed.
+                        // The actual launch happens after confirmation. This SAF event is for when
+                        // that's confirmed.
                         restoreDbLauncher.launch(arrayOf("*/*")) // Generic MIME type for DB files
                     } else {
-                        val mimeTypes = arrayOf("text/csv", "text/comma-separated-values", "application/csv", "text/plain")
+                        val mimeTypes =
+                                arrayOf(
+                                        "text/csv",
+                                        "text/comma-separated-values",
+                                        "application/csv",
+                                        "text/plain"
+                                )
                         importCsvLauncher.launch(mimeTypes)
                     }
                 }
@@ -320,76 +403,186 @@ fun DataManagementSettingsScreen(
         }
     }
 
-    val regularDataManagementItems = remember(users, isAnyOperationLoading, isLoadingExport, isLoadingImport, isLoadingBackup, isLoadingRestore, context) {
-        buildList {
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_export_measurements_csv), Icons.Default.FileDownload, { if (!isAnyOperationLoading) settingsViewModel.startExportProcess() }, users.isNotEmpty() && !isAnyOperationLoading, isLoading = isLoadingExport))
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_import_measurements_csv), Icons.Default.FileUpload, { if (!isAnyOperationLoading) settingsViewModel.startImportProcess() }, users.isNotEmpty() && !isAnyOperationLoading, isLoading = isLoadingImport))
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_backup_database), Icons.Default.CloudDownload, { if (!isAnyOperationLoading) settingsViewModel.startDatabaseBackup() }, !isAnyOperationLoading, isLoading = isLoadingBackup))
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_restore_database), Icons.Filled.CloudUpload, { if (!isAnyOperationLoading) showRestoreConfirmationDialog = true }, !isAnyOperationLoading, isLoading = isLoadingRestore))
-        }
-    }
+    val regularDataManagementItems =
+            remember(
+                    users,
+                    isAnyOperationLoading,
+                    isLoadingExport,
+                    isLoadingImport,
+                    isLoadingBackup,
+                    isLoadingRestore,
+                    context
+            ) {
+                buildList {
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(R.string.settings_export_measurements_csv),
+                                    Icons.Default.FileDownload,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                settingsViewModel.startExportProcess()
+                                    },
+                                    users.isNotEmpty() && !isAnyOperationLoading,
+                                    isLoading = isLoadingExport
+                            )
+                    )
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(R.string.settings_import_measurements_csv),
+                                    Icons.Default.FileUpload,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                settingsViewModel.startImportProcess()
+                                    },
+                                    users.isNotEmpty() && !isAnyOperationLoading,
+                                    isLoading = isLoadingImport
+                            )
+                    )
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(R.string.settings_backup_database),
+                                    Icons.Default.CloudDownload,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                settingsViewModel.startDatabaseBackup()
+                                    },
+                                    !isAnyOperationLoading,
+                                    isLoading = isLoadingBackup
+                            )
+                    )
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(R.string.settings_restore_database),
+                                    Icons.Filled.CloudUpload,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                showRestoreConfirmationDialog = true
+                                    },
+                                    !isAnyOperationLoading,
+                                    isLoading = isLoadingRestore
+                            )
+                    )
+                }
+            }
 
-    val destructiveDataManagementItems = remember(users, isAnyOperationLoading, isLoadingDeletion, isLoadingEntireDatabaseDeletion, context) {
-        buildList {
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_delete_all_measurement_data), Icons.Default.DeleteForever, { if (!isAnyOperationLoading) settingsViewModel.initiateDeleteAllUserDataProcess() }, users.isNotEmpty() && !isAnyOperationLoading, true, isLoadingDeletion))
-            add(DataManagementSettingListItem.ActionItem(context.getString(R.string.settings_delete_entire_database), Icons.Default.WarningAmber, { if (!isAnyOperationLoading) settingsViewModel.initiateDeleteEntireDatabaseProcess() }, !isAnyOperationLoading, true, isLoadingEntireDatabaseDeletion))
-        }
-    }
+    val destructiveDataManagementItems =
+            remember(
+                    users,
+                    isAnyOperationLoading,
+                    isLoadingDeletion,
+                    isLoadingEntireDatabaseDeletion,
+                    context
+            ) {
+                buildList {
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(
+                                            R.string.settings_delete_all_measurement_data
+                                    ),
+                                    Icons.Default.DeleteForever,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                settingsViewModel.initiateDeleteAllUserDataProcess()
+                                    },
+                                    users.isNotEmpty() && !isAnyOperationLoading,
+                                    true,
+                                    isLoadingDeletion
+                            )
+                    )
+                    add(
+                            DataManagementSettingListItem.ActionItem(
+                                    context.getString(R.string.settings_delete_entire_database),
+                                    Icons.Default.WarningAmber,
+                                    {
+                                        if (!isAnyOperationLoading)
+                                                settingsViewModel
+                                                        .initiateDeleteEntireDatabaseProcess()
+                                    },
+                                    !isAnyOperationLoading,
+                                    true,
+                                    isLoadingEntireDatabaseDeletion
+                            )
+                    )
+                }
+            }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-    ) {
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 8.dp)) {
         items(regularDataManagementItems.size) { index ->
             val item = regularDataManagementItems[index]
-            SettingsCardItem(item.label, icon = item.icon, onClick = item.onClick, enabled = item.enabled, isDestructive = item.isDestructive, isLoading = item.isLoading)
+            SettingsCardItem(
+                    item.label,
+                    icon = item.icon,
+                    onClick = item.onClick,
+                    enabled = item.enabled,
+                    isDestructive = item.isDestructive,
+                    isLoading = item.isLoading
+            )
         }
 
         item {
             Spacer(modifier = Modifier.height(24.dp))
-            Text(stringResource(R.string.settings_auto_backup_title), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, modifier = Modifier.padding(bottom = 8.dp))
-            HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
+            Text(
+                    stringResource(R.string.settings_auto_backup_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 8.dp)
+            )
+            HorizontalDivider(
+                    thickness = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            )
             Spacer(modifier = Modifier.height(8.dp))
         }
 
         // 1. Enable/Disable Automatic Backups (Toggle)
         item {
             SettingsCardItem(
-                label = stringResource(R.string.settings_enable_auto_backups),
-                onClick = {
-                    if (!isAnyOperationLoading) {
-                        val newCheckedState = !autoBackupGloballyEnabled
-                        if (newCheckedState && !isAutoBackupLocationConfigured) {
-                            selectAutoBackupDirectoryLauncher.launch(null) // URI (null) means "pick a new folder"
-                        } else {
-                            coroutineScope.launch { settingsViewModel.setAutoBackupEnabled(newCheckedState) }
-                        }
-                    }
-                },
-                enabled = !isAnyOperationLoading,
-                customLeadingContent = {
-                    Icon(
-                        Icons.Filled.Schedule,
-                        contentDescription = stringResource(R.string.content_desc_auto_backups_toggle),
-                        tint = if (isAutoBackupEffectivelyEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                trailingContent = {
-                    Switch(
-                        checked = autoBackupGloballyEnabled,
-                        onCheckedChange = { newCheckedState ->
-                            if (!isAnyOperationLoading) {
-                                if (newCheckedState && !isAutoBackupLocationConfigured) {
-                                    selectAutoBackupDirectoryLauncher.launch(null)
-                                } else {
-                                    coroutineScope.launch { settingsViewModel.setAutoBackupEnabled(newCheckedState) }
+                    label = stringResource(R.string.settings_enable_auto_backups),
+                    onClick = {
+                        if (!isAnyOperationLoading) {
+                            val newCheckedState = !autoBackupGloballyEnabled
+                            if (newCheckedState && !isAutoBackupLocationConfigured) {
+                                selectAutoBackupDirectoryLauncher.launch(
+                                        null
+                                ) // URI (null) means "pick a new folder"
+                            } else {
+                                coroutineScope.launch {
+                                    settingsViewModel.setAutoBackupEnabled(newCheckedState)
                                 }
                             }
-                        },
-                        enabled = !isAnyOperationLoading
-                    )
-                }
+                        }
+                    },
+                    enabled = !isAnyOperationLoading,
+                    customLeadingContent = {
+                        Icon(
+                                Icons.Filled.Schedule,
+                                contentDescription =
+                                        stringResource(R.string.content_desc_auto_backups_toggle),
+                                tint =
+                                        if (isAutoBackupEffectivelyEnabled)
+                                                MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                                checked = autoBackupGloballyEnabled,
+                                onCheckedChange = { newCheckedState ->
+                                    if (!isAnyOperationLoading) {
+                                        if (newCheckedState && !isAutoBackupLocationConfigured) {
+                                            selectAutoBackupDirectoryLauncher.launch(null)
+                                        } else {
+                                            coroutineScope.launch {
+                                                settingsViewModel.setAutoBackupEnabled(
+                                                        newCheckedState
+                                                )
+                                            }
+                                        }
+                                    }
+                                },
+                                enabled = !isAnyOperationLoading
+                        )
+                    }
             )
         }
 
@@ -397,50 +590,94 @@ fun DataManagementSettingsScreen(
         if (autoBackupGloballyEnabled) {
             item {
                 SettingsCardItem(
-                    label = stringResource(R.string.settings_backup_location_label),
-                    supportingText = currentBackupLocationUserDisplay,
-                    onClick = {
-                        if (!isAnyOperationLoading) {
-                            selectAutoBackupDirectoryLauncher.launch(null) // Allow changing/re-selecting
-                        }
-                    },
-                    enabled = !isAnyOperationLoading,
-                    customLeadingContent = { Icon(Icons.Filled.Folder, contentDescription = stringResource(R.string.content_desc_backup_location_icon)) },
-                    trailingContent = {
-                        Row(horizontalArrangement = Arrangement.End) {
-                            if (canOpenSelectedBackupLocation && autoBackupLocationUriString != null) {
-                                IconButton(
-                                    onClick = {
-                                        if (!isAnyOperationLoading) {
-                                            try {
-                                                val intent = Intent(Intent.ACTION_VIEW)
-                                                intent.setDataAndType(autoBackupLocationUriString!!.toUri(), "vnd.android.document/directory")
-                                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                                context.startActivity(intent)
-                                            } catch (e: ActivityNotFoundException) {
-                                                Toast.makeText(context, R.string.settings_backup_location_open_error_no_app, Toast.LENGTH_SHORT).show()
-                                            } catch (e: Exception) {
-                                                Toast.makeText(context, R.string.settings_backup_location_open_error, Toast.LENGTH_SHORT).show()
-                                            }
-                                        }
-                                    },
-                                    enabled = !isAnyOperationLoading
+                        label = stringResource(R.string.settings_backup_location_label),
+                        supportingText = currentBackupLocationUserDisplay,
+                        onClick = {
+                            if (!isAnyOperationLoading) {
+                                selectAutoBackupDirectoryLauncher.launch(
+                                        null
+                                ) // Allow changing/re-selecting
+                            }
+                        },
+                        enabled = !isAnyOperationLoading,
+                        customLeadingContent = {
+                            Icon(
+                                    Icons.Filled.Folder,
+                                    contentDescription =
+                                            stringResource(
+                                                    R.string.content_desc_backup_location_icon
+                                            )
+                            )
+                        },
+                        trailingContent = {
+                            Row(horizontalArrangement = Arrangement.End) {
+                                if (canOpenSelectedBackupLocation &&
+                                                autoBackupLocationUriString != null
                                 ) {
-                                    Icon(Icons.Filled.FolderOpen, contentDescription = stringResource(R.string.content_desc_open_backup_location_icon))
+                                    IconButton(
+                                            onClick = {
+                                                if (!isAnyOperationLoading) {
+                                                    try {
+                                                        val intent = Intent(Intent.ACTION_VIEW)
+                                                        intent.setDataAndType(
+                                                                autoBackupLocationUriString!!
+                                                                        .toUri(),
+                                                                "vnd.android.document/directory"
+                                                        )
+                                                        intent.addFlags(
+                                                                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                                        )
+                                                        context.startActivity(intent)
+                                                    } catch (e: ActivityNotFoundException) {
+                                                        Toast.makeText(
+                                                                        context,
+                                                                        R.string
+                                                                                .settings_backup_location_open_error_no_app,
+                                                                        Toast.LENGTH_SHORT
+                                                                )
+                                                                .show()
+                                                    } catch (e: Exception) {
+                                                        Toast.makeText(
+                                                                        context,
+                                                                        R.string
+                                                                                .settings_backup_location_open_error,
+                                                                        Toast.LENGTH_SHORT
+                                                                )
+                                                                .show()
+                                                    }
+                                                }
+                                            },
+                                            enabled = !isAnyOperationLoading
+                                    ) {
+                                        Icon(
+                                                Icons.Filled.FolderOpen,
+                                                contentDescription =
+                                                        stringResource(
+                                                                R.string
+                                                                        .content_desc_open_backup_location_icon
+                                                        )
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                        onClick = {
+                                            if (!isAnyOperationLoading) {
+                                                selectAutoBackupDirectoryLauncher.launch(null)
+                                            }
+                                        },
+                                        enabled = !isAnyOperationLoading
+                                ) {
+                                    Icon(
+                                            Icons.Filled.Edit,
+                                            contentDescription =
+                                                    stringResource(
+                                                            R.string
+                                                                    .content_desc_change_backup_location_icon
+                                                    )
+                                    )
                                 }
                             }
-                            IconButton(
-                                onClick = {
-                                    if (!isAnyOperationLoading) {
-                                        selectAutoBackupDirectoryLauncher.launch(null)
-                                    }
-                                },
-                                enabled = !isAnyOperationLoading
-                            ) {
-                                Icon(Icons.Filled.Edit, contentDescription = stringResource(R.string.content_desc_change_backup_location_icon))
-                            }
                         }
-                    }
                 )
             }
         }
@@ -449,57 +686,237 @@ fun DataManagementSettingsScreen(
         if (isAutoBackupEffectivelyEnabled) {
             item {
                 SettingsCardItem(
-                    label = stringResource(R.string.settings_last_backup_status_label),
-                    supportingText = lastBackupStatusText,
-                    onClick = { /* Could show more details or trigger a manual sync if needed */ },
-                    enabled = !isAnyOperationLoading,
-                    customLeadingContent = { Icon(Icons.Filled.Info, contentDescription = stringResource(R.string.content_desc_backup_status_icon)) }
+                        label = stringResource(R.string.settings_last_backup_status_label),
+                        supportingText = lastBackupStatusText,
+                        onClick = { /* Could show more details or trigger a manual sync if needed */
+                        },
+                        enabled = !isAnyOperationLoading,
+                        customLeadingContent = {
+                            Icon(
+                                    Icons.Filled.Info,
+                                    contentDescription =
+                                            stringResource(R.string.content_desc_backup_status_icon)
+                            )
+                        }
                 )
             }
             item {
                 SettingsCardItem(
-                    label = stringResource(R.string.settings_backup_interval_label),
-                    supportingText = selectedBackupIntervalDisplay,
-                    onClick = { if (!isAnyOperationLoading) showBackupIntervalDialog = true },
-                    enabled = !isAnyOperationLoading,
-                    customLeadingContent = { Icon(Icons.Filled.Schedule, contentDescription = stringResource(R.string.content_desc_backup_interval_icon)) },
-                    trailingContent = { Icon(Icons.Filled.ArrowDropDown, contentDescription = stringResource(R.string.content_desc_change_interval_icon)) }
+                        label = stringResource(R.string.settings_backup_interval_label),
+                        supportingText = selectedBackupIntervalDisplay,
+                        onClick = { if (!isAnyOperationLoading) showBackupIntervalDialog = true },
+                        enabled = !isAnyOperationLoading,
+                        customLeadingContent = {
+                            Icon(
+                                    Icons.Filled.Schedule,
+                                    contentDescription =
+                                            stringResource(
+                                                    R.string.content_desc_backup_interval_icon
+                                            )
+                            )
+                        },
+                        trailingContent = {
+                            Icon(
+                                    Icons.Filled.ArrowDropDown,
+                                    contentDescription =
+                                            stringResource(
+                                                    R.string.content_desc_change_interval_icon
+                                            )
+                            )
+                        }
                 )
             }
             item {
                 SettingsCardItem(
-                    label = stringResource(R.string.settings_backup_behavior_label),
-                    supportingText = backupBehaviorSupportingText,
-                    onClick = { if (!isAnyOperationLoading) {
-                        coroutineScope.launch { settingsViewModel.setAutoBackupCreateNewFile(!autoBackupCreateNewFile) }
-                    }},
-                    enabled = !isAnyOperationLoading,
-                    customLeadingContent = { Icon(Icons.Filled.SwapHoriz, contentDescription = stringResource(R.string.content_desc_backup_behavior_icon)) },
+                        label = stringResource(R.string.settings_backup_behavior_label),
+                        supportingText = backupBehaviorSupportingText,
+                        onClick = {
+                            if (!isAnyOperationLoading) {
+                                coroutineScope.launch {
+                                    settingsViewModel.setAutoBackupCreateNewFile(
+                                            !autoBackupCreateNewFile
+                                    )
+                                }
+                            }
+                        },
+                        enabled = !isAnyOperationLoading,
+                        customLeadingContent = {
+                            Icon(
+                                    Icons.Filled.SwapHoriz,
+                                    contentDescription =
+                                            stringResource(
+                                                    R.string.content_desc_backup_behavior_icon
+                                            )
+                            )
+                        },
+                        trailingContent = {
+                            Switch(
+                                    checked = autoBackupCreateNewFile,
+                                    onCheckedChange = { isChecked ->
+                                        if (!isAnyOperationLoading) {
+                                            coroutineScope.launch {
+                                                settingsViewModel.setAutoBackupCreateNewFile(
+                                                        isChecked
+                                                )
+                                            }
+                                        }
+                                    },
+                                    enabled = !isAnyOperationLoading
+                            )
+                        }
+                )
+            }
+        }
+
+        // --- Webhook Export Section ---
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                    stringResource(R.string.settings_webhook_export_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 8.dp)
+            )
+            HorizontalDivider(
+                    thickness = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            SettingsCardItem(
+                    label = stringResource(R.string.settings_webhook_export_enable_label),
+                    supportingText =
+                            stringResource(
+                                    if (webhookExportEnabled)
+                                            R.string.settings_webhook_export_enabled_hint
+                                    else R.string.settings_webhook_export_disabled_hint
+                            ),
+                    onClick = {
+                        coroutineScope.launch {
+                            settingsViewModel.setWebhookExportEnabled(!webhookExportEnabled)
+                        }
+                    },
+                    customLeadingContent = {
+                        Icon(
+                                Icons.Filled.Send,
+                                contentDescription =
+                                        stringResource(R.string.settings_webhook_export_title),
+                                tint =
+                                        if (webhookExportEnabled) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    },
                     trailingContent = {
                         Switch(
-                            checked = autoBackupCreateNewFile,
-                            onCheckedChange = { isChecked ->
-                                if (!isAnyOperationLoading) {
-                                    coroutineScope.launch { settingsViewModel.setAutoBackupCreateNewFile(isChecked) }
+                                checked = webhookExportEnabled,
+                                onCheckedChange = {
+                                    coroutineScope.launch {
+                                        settingsViewModel.setWebhookExportEnabled(it)
+                                    }
                                 }
-                            },
-                            enabled = !isAnyOperationLoading
                         )
                     }
+            )
+        }
+
+        item {
+            Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+                OutlinedTextField(
+                        value = webhookUrlDraft,
+                        onValueChange = {
+                            webhookUrlDraft = it
+                            coroutineScope.launch { settingsViewModel.setWebhookExportUrl(it) }
+                        },
+                        enabled = webhookExportEnabled,
+                        label = {
+                            Text(stringResource(R.string.settings_webhook_export_url_label))
+                        },
+                        placeholder = {
+                            Text(stringResource(R.string.settings_webhook_export_url_placeholder))
+                        },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth().padding(12.dp),
+                        keyboardOptions =
+                                KeyboardOptions(
+                                        keyboardType = KeyboardType.Uri,
+                                        imeAction = ImeAction.Done
+                                ),
+                        keyboardActions =
+                                KeyboardActions(
+                                        onDone = {
+                                            coroutineScope.launch {
+                                                settingsViewModel.setWebhookExportUrl(
+                                                        webhookUrlDraft
+                                                )
+                                            }
+                                        }
+                                ),
+                        trailingIcon = {
+                            IconButton(
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            settingsViewModel.setWebhookExportUrl(webhookUrlDraft)
+                                        }
+                                    }
+                            ) {
+                                Icon(
+                                        Icons.Filled.Edit,
+                                        contentDescription =
+                                                stringResource(
+                                                        R.string.settings_webhook_export_save_url
+                                                )
+                                )
+                            }
+                        }
                 )
+            }
+        }
+
+        if (webhookExportEnabled && webhookUrlDraft.isNotBlank()) {
+            item {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            val result = settingsViewModel.sendTestWebhookAndGetResult(webhookUrlDraft)
+                            Toast.makeText(context, result, Toast.LENGTH_LONG).show()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp)
+                ) {
+                    Icon(Icons.Filled.Send, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text(stringResource(R.string.settings_webhook_export_test_button))
+                }
             }
         }
 
         if (destructiveDataManagementItems.isNotEmpty()) {
             item {
                 Spacer(modifier = Modifier.height(24.dp))
-                Text(stringResource(R.string.settings_danger_zone), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(bottom = 8.dp))
-                HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
+                Text(
+                        stringResource(R.string.settings_danger_zone),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                )
+                HorizontalDivider(
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+                )
                 Spacer(modifier = Modifier.height(8.dp))
             }
             items(destructiveDataManagementItems.size) { index ->
                 val item = destructiveDataManagementItems[index]
-                SettingsCardItem(item.label, icon = item.icon, onClick = item.onClick, enabled = item.enabled, isDestructive = item.isDestructive, isLoading = item.isLoading)
+                SettingsCardItem(
+                        item.label,
+                        icon = item.icon,
+                        onClick = item.onClick,
+                        enabled = item.enabled,
+                        isDestructive = item.isDestructive,
+                        isLoading = item.isLoading
+                )
             }
         }
     }
@@ -507,167 +924,356 @@ fun DataManagementSettingsScreen(
     if (showBackupIntervalDialog) {
         val intervalEnumValues = remember { BackupInterval.entries.toList() }
         SelectionDialogEnum(
-            title = stringResource(R.string.dialog_title_select_backup_interval),
-            options = intervalEnumValues,
-            selectedOption = autoBackupInterval,
-            onOptionSelected = { selectedEnumInterval ->
-                coroutineScope.launch { settingsViewModel.setAutoBackupInterval(selectedEnumInterval) }
-            },
-            optionToDisplayName = { it.getDisplayName(context) },
-            onDismissRequest = { showBackupIntervalDialog = false }
+                title = stringResource(R.string.dialog_title_select_backup_interval),
+                options = intervalEnumValues,
+                selectedOption = autoBackupInterval,
+                onOptionSelected = { selectedEnumInterval ->
+                    coroutineScope.launch {
+                        settingsViewModel.setAutoBackupInterval(selectedEnumInterval)
+                    }
+                },
+                optionToDisplayName = { it.getDisplayName(context) },
+                onDismissRequest = { showBackupIntervalDialog = false }
         )
     }
 
     if (showDeleteEntireDatabaseConfirmationDialog) {
         AlertDialog(
-            onDismissRequest = { if (!isLoadingEntireDatabaseDeletion) settingsViewModel.cancelDeleteEntireDatabaseConfirmation() },
-            icon = { Icon(Icons.Filled.WarningAmber, contentDescription = stringResource(R.string.content_desc_warning_icon), tint = MaterialTheme.colorScheme.error) },
-            title = { Text(stringResource(R.string.dialog_title_delete_entire_database_confirmation), fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.error) },
-            text = { Text(stringResource(R.string.dialog_message_delete_entire_database_confirmation)) },
-            confirmButton = { TextButton({ settingsViewModel.confirmDeleteEntireDatabase() }, colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error), enabled = !isLoadingEntireDatabaseDeletion) { if (isLoadingEntireDatabaseDeletion) CircularProgressIndicator(Modifier.size(ButtonDefaults.IconSize), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.error) else Text(stringResource(R.string.button_yes_delete_all)) } },
-            dismissButton = { TextButton({ settingsViewModel.cancelDeleteEntireDatabaseConfirmation() }, enabled = !isLoadingEntireDatabaseDeletion) { Text(stringResource(R.string.cancel_button)) } }
+                onDismissRequest = {
+                    if (!isLoadingEntireDatabaseDeletion)
+                            settingsViewModel.cancelDeleteEntireDatabaseConfirmation()
+                },
+                icon = {
+                    Icon(
+                            Icons.Filled.WarningAmber,
+                            contentDescription = stringResource(R.string.content_desc_warning_icon),
+                            tint = MaterialTheme.colorScheme.error
+                    )
+                },
+                title = {
+                    Text(
+                            stringResource(
+                                    R.string.dialog_title_delete_entire_database_confirmation
+                            ),
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.error
+                    )
+                },
+                text = {
+                    Text(
+                            stringResource(
+                                    R.string.dialog_message_delete_entire_database_confirmation
+                            )
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                            { settingsViewModel.confirmDeleteEntireDatabase() },
+                            colors =
+                                    ButtonDefaults.textButtonColors(
+                                            contentColor = MaterialTheme.colorScheme.error
+                                    ),
+                            enabled = !isLoadingEntireDatabaseDeletion
+                    ) {
+                        if (isLoadingEntireDatabaseDeletion)
+                                CircularProgressIndicator(
+                                        Modifier.size(ButtonDefaults.IconSize),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.error
+                                )
+                        else Text(stringResource(R.string.button_yes_delete_all))
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                            { settingsViewModel.cancelDeleteEntireDatabaseConfirmation() },
+                            enabled = !isLoadingEntireDatabaseDeletion
+                    ) { Text(stringResource(R.string.cancel_button)) }
+                }
         )
     }
 
     if (showUserSelectionDialogForExport) {
-        UserSelectionDialog(users, { settingsViewModel.proceedWithExportForUser(it) }, { if (!isLoadingExport) settingsViewModel.cancelUserSelectionForExport() }, stringResource(R.string.dialog_title_export_select_user), !isLoadingExport, !isLoadingExport)
+        UserSelectionDialog(
+                users,
+                { settingsViewModel.proceedWithExportForUser(it) },
+                { if (!isLoadingExport) settingsViewModel.cancelUserSelectionForExport() },
+                stringResource(R.string.dialog_title_export_select_user),
+                !isLoadingExport,
+                !isLoadingExport
+        )
     }
 
     if (showUserSelectionDialogForImport) {
-        UserSelectionDialog(users, { settingsViewModel.proceedWithImportForUser(it) }, { if (!isLoadingImport) settingsViewModel.cancelUserSelectionForImport() }, stringResource(R.string.dialog_title_import_select_user), !isLoadingImport, !isLoadingImport)
+        UserSelectionDialog(
+                users,
+                { settingsViewModel.proceedWithImportForUser(it) },
+                { if (!isLoadingImport) settingsViewModel.cancelUserSelectionForImport() },
+                stringResource(R.string.dialog_title_import_select_user),
+                !isLoadingImport,
+                !isLoadingImport
+        )
     }
 
     if (showUserSelectionDialogForDelete) {
-        UserSelectionDialog(users, { settingsViewModel.proceedWithDeleteForUser(it) }, { if (!isLoadingDeletion) settingsViewModel.cancelUserSelectionForDelete() }, stringResource(R.string.dialog_title_delete_select_user), !isLoadingDeletion, !isLoadingDeletion)
+        UserSelectionDialog(
+                users,
+                { settingsViewModel.proceedWithDeleteForUser(it) },
+                { if (!isLoadingDeletion) settingsViewModel.cancelUserSelectionForDelete() },
+                stringResource(R.string.dialog_title_delete_select_user),
+                !isLoadingDeletion,
+                !isLoadingDeletion
+        )
     }
 
     if (showDeleteConfirmationDialog) {
         userPendingDeletion?.let { user ->
             AlertDialog(
-                onDismissRequest = { if (!isLoadingDeletion) settingsViewModel.cancelDeleteConfirmation() },
-                icon = { Icon(Icons.Filled.DeleteForever, contentDescription = stringResource(R.string.content_desc_delete_icon), tint = MaterialTheme.colorScheme.error) },
-                title = { Text(stringResource(R.string.dialog_title_delete_user_data_confirmation), fontWeight = FontWeight.Bold) },
-                text = { Text(stringResource(R.string.dialog_message_delete_user_data_confirmation, user.name)) },
-                confirmButton = { TextButton({ settingsViewModel.confirmActualDeletion() }, colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error), enabled = !isLoadingDeletion) { if (isLoadingDeletion) CircularProgressIndicator(Modifier.size(ButtonDefaults.IconSize), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.error) else Text(stringResource(R.string.button_yes_delete_all)) } },
-                dismissButton = { TextButton({ settingsViewModel.cancelDeleteConfirmation() }, enabled = !isLoadingDeletion) { Text(stringResource(R.string.cancel_button)) } }
+                    onDismissRequest = {
+                        if (!isLoadingDeletion) settingsViewModel.cancelDeleteConfirmation()
+                    },
+                    icon = {
+                        Icon(
+                                Icons.Filled.DeleteForever,
+                                contentDescription =
+                                        stringResource(R.string.content_desc_delete_icon),
+                                tint = MaterialTheme.colorScheme.error
+                        )
+                    },
+                    title = {
+                        Text(
+                                stringResource(R.string.dialog_title_delete_user_data_confirmation),
+                                fontWeight = FontWeight.Bold
+                        )
+                    },
+                    text = {
+                        Text(
+                                stringResource(
+                                        R.string.dialog_message_delete_user_data_confirmation,
+                                        user.name
+                                )
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(
+                                { settingsViewModel.confirmActualDeletion() },
+                                colors =
+                                        ButtonDefaults.textButtonColors(
+                                                contentColor = MaterialTheme.colorScheme.error
+                                        ),
+                                enabled = !isLoadingDeletion
+                        ) {
+                            if (isLoadingDeletion)
+                                    CircularProgressIndicator(
+                                            Modifier.size(ButtonDefaults.IconSize),
+                                            strokeWidth = 2.dp,
+                                            color = MaterialTheme.colorScheme.error
+                                    )
+                            else Text(stringResource(R.string.button_yes_delete_all))
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(
+                                { settingsViewModel.cancelDeleteConfirmation() },
+                                enabled = !isLoadingDeletion
+                        ) { Text(stringResource(R.string.cancel_button)) }
+                    }
             )
         }
     }
 
     if (showRestoreConfirmationDialog) {
         AlertDialog(
-            onDismissRequest = { if (!isLoadingRestore) showRestoreConfirmationDialog = false },
-            icon = { Icon(Icons.Filled.CloudUpload, contentDescription = stringResource(R.string.content_desc_restore_icon)) },
-            title = { Text(stringResource(R.string.dialog_title_restore_database_confirmation), fontWeight = FontWeight.Bold) },
-            text = { Text(stringResource(R.string.dialog_message_restore_database_confirmation)) },
-            confirmButton = { TextButton({ showRestoreConfirmationDialog = false; settingsViewModel.startDatabaseRestore() /* This now triggers SAF event */ }, colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error), enabled = !isLoadingRestore) { if (isLoadingRestore) CircularProgressIndicator(Modifier.size(ButtonDefaults.IconSize), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.error) else Text(stringResource(R.string.button_yes_restore)) } },
-            dismissButton = { TextButton({ showRestoreConfirmationDialog = false }, enabled = !isLoadingRestore) { Text(stringResource(R.string.cancel_button)) } }
+                onDismissRequest = { if (!isLoadingRestore) showRestoreConfirmationDialog = false },
+                icon = {
+                    Icon(
+                            Icons.Filled.CloudUpload,
+                            contentDescription = stringResource(R.string.content_desc_restore_icon)
+                    )
+                },
+                title = {
+                    Text(
+                            stringResource(R.string.dialog_title_restore_database_confirmation),
+                            fontWeight = FontWeight.Bold
+                    )
+                },
+                text = {
+                    Text(stringResource(R.string.dialog_message_restore_database_confirmation))
+                },
+                confirmButton = {
+                    TextButton(
+                            {
+                                showRestoreConfirmationDialog = false
+                                settingsViewModel
+                                        .startDatabaseRestore() /* This now triggers SAF event */
+                            },
+                            colors =
+                                    ButtonDefaults.textButtonColors(
+                                            contentColor = MaterialTheme.colorScheme.error
+                                    ),
+                            enabled = !isLoadingRestore
+                    ) {
+                        if (isLoadingRestore)
+                                CircularProgressIndicator(
+                                        Modifier.size(ButtonDefaults.IconSize),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.error
+                                )
+                        else Text(stringResource(R.string.button_yes_restore))
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                            { showRestoreConfirmationDialog = false },
+                            enabled = !isLoadingRestore
+                    ) { Text(stringResource(R.string.cancel_button)) }
+                }
         )
     }
 }
 
 @Composable
 fun SettingsCardItem(
-    label: String,
-    supportingText: String? = null,
-    icon: ImageVector? = null,
-    onClick: () -> Unit,
-    enabled: Boolean = true,
-    isDestructive: Boolean = false,
-    isLoading: Boolean = false,
-    customLeadingContent: (@Composable () -> Unit)? = null,
-    trailingContent: (@Composable () -> Unit)? = null
+        label: String,
+        supportingText: String? = null,
+        icon: ImageVector? = null,
+        onClick: () -> Unit,
+        enabled: Boolean = true,
+        isDestructive: Boolean = false,
+        isLoading: Boolean = false,
+        customLeadingContent: (@Composable () -> Unit)? = null,
+        trailingContent: (@Composable () -> Unit)? = null
 ) {
     val currentClickable = enabled && !isLoading
-    val baseTextColor = if (isDestructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+    val baseTextColor =
+            if (isDestructive) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.onSurface
     val textColor = if (!enabled) baseTextColor.copy(alpha = 0.38f) else baseTextColor
-    val baseIconColor = if (isDestructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+    val baseIconColor =
+            if (isDestructive) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.primary
     val iconColorToUse = if (!enabled) baseIconColor.copy(alpha = 0.38f) else baseIconColor
 
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 6.dp) // Consistent padding
-            .clickable(enabled = currentClickable, onClick = onClick)
+            modifier =
+                    Modifier.fillMaxWidth()
+                            .padding(vertical = 6.dp) // Consistent padding
+                            .clickable(enabled = currentClickable, onClick = onClick)
     ) {
         ListItem(
-            headlineContent = { Text(label, style = MaterialTheme.typography.bodyLarge, color = textColor) },
-            supportingContent = supportingText?.let { { Text(it, style = MaterialTheme.typography.bodyMedium, color = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)) } },
-            leadingContent = customLeadingContent ?: icon?.let {
-                {
-                    Box(contentAlignment = Alignment.Center, modifier = Modifier.size(24.dp)) { // Ensure icon and progress indicator are same size
-                        if (isLoading) CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp, color = if (isDestructive) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary)
-                        else Icon(it, contentDescription = label, tint = iconColorToUse)
-                    }
-                }
-            },
-            trailingContent = trailingContent
+                headlineContent = {
+                    Text(label, style = MaterialTheme.typography.bodyLarge, color = textColor)
+                },
+                supportingContent =
+                        supportingText?.let {
+                            {
+                                Text(
+                                        it,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color =
+                                                if (enabled)
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                                .copy(alpha = 0.38f)
+                                )
+                            }
+                        },
+                leadingContent = customLeadingContent
+                                ?: icon?.let {
+                                    {
+                                        Box(
+                                                contentAlignment = Alignment.Center,
+                                                modifier = Modifier.size(24.dp)
+                                        ) { // Ensure icon and progress indicator are same size
+                                            if (isLoading)
+                                                    CircularProgressIndicator(
+                                                            Modifier.size(20.dp),
+                                                            strokeWidth = 2.dp,
+                                                            color =
+                                                                    if (isDestructive)
+                                                                            MaterialTheme
+                                                                                    .colorScheme
+                                                                                    .error
+                                                                    else
+                                                                            MaterialTheme
+                                                                                    .colorScheme
+                                                                                    .primary
+                                                    )
+                                            else
+                                                    Icon(
+                                                            it,
+                                                            contentDescription = label,
+                                                            tint = iconColorToUse
+                                                    )
+                                        }
+                                    }
+                                },
+                trailingContent = trailingContent
         )
     }
 }
 
 /**
- * A generic selection dialog for Enums or any list of items
- * where each item needs a display name.
+ * A generic selection dialog for Enums or any list of items where each item needs a display name.
  */
 @Composable
 fun <T> SelectionDialogEnum(
-    title: String,
-    options: List<T>,
-    selectedOption: T,
-    onOptionSelected: (T) -> Unit,
-    optionToDisplayName: (T) -> String,
-    onDismissRequest: () -> Unit
+        title: String,
+        options: List<T>,
+        selectedOption: T,
+        onOptionSelected: (T) -> Unit,
+        optionToDisplayName: (T) -> String,
+        onDismissRequest: () -> Unit
 ) {
     AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text(title) },
-        text = {
-            Column(Modifier.selectableGroup()) {
-                options.forEach { option ->
-                    val displayName = optionToDisplayName(option)
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = (option == selectedOption),
-                                onClick = {
-                                    onOptionSelected(option)
-                                    onDismissRequest() // Dismiss after selection
-                                }
+            onDismissRequest = onDismissRequest,
+            title = { Text(title) },
+            text = {
+                Column(Modifier.selectableGroup()) {
+                    options.forEach { option ->
+                        val displayName = optionToDisplayName(option)
+                        Row(
+                                Modifier.fillMaxWidth()
+                                        .selectable(
+                                                selected = (option == selectedOption),
+                                                onClick = {
+                                                    onOptionSelected(option)
+                                                    onDismissRequest() // Dismiss after selection
+                                                }
+                                        )
+                                        .padding(vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                    selected = (option == selectedOption),
+                                    onClick = null // RadioButton is controlled by Row's selectable
                             )
-                            .padding(vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        RadioButton(
-                            selected = (option == selectedOption),
-                            onClick = null // RadioButton is controlled by Row's selectable
-                        )
-                        Text(
-                            text = displayName,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(start = 16.dp)
-                        )
+                            Text(
+                                    text = displayName,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(start = 16.dp)
+                            )
+                        }
                     }
                 }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismissRequest) {
+                    Text(stringResource(R.string.cancel_button))
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(stringResource(R.string.cancel_button))
-            }
-        }
     )
 }
 
 @Composable
 fun UserSelectionDialog(
-    users: List<User>,
-    onUserSelected: (userId: Int) -> Unit,
-    onDismiss: () -> Unit,
-    title: String,
-    confirmButtonEnabled: Boolean = true,
-    itemClickEnabled: Boolean = true
+        users: List<User>,
+        onUserSelected: (userId: Int) -> Unit,
+        onDismiss: () -> Unit,
+        title: String,
+        confirmButtonEnabled: Boolean = true,
+        itemClickEnabled: Boolean = true
 ) {
     if (users.isEmpty()) {
         LaunchedEffect(Unit) { onDismiss() }
@@ -677,74 +1283,74 @@ fun UserSelectionDialog(
     val context = LocalContext.current
 
     AlertDialog(
-        onDismissRequest = { if (confirmButtonEnabled) onDismiss() },
-        title = { Text(title, style = MaterialTheme.typography.titleLarge) },
-        text = {
-            LazyColumn {
-                items(users.size) { index ->
-                    val user = users[index]
+            onDismissRequest = { if (confirmButtonEnabled) onDismiss() },
+            title = { Text(title, style = MaterialTheme.typography.titleLarge) },
+            text = {
+                LazyColumn {
+                    items(users.size) { index ->
+                        val user = users[index]
 
-                    val age = remember(user.birthDate) {
-                        CalculationUtils.ageOn(System.currentTimeMillis(), user.birthDate)
-                    }
+                        val age =
+                                remember(user.birthDate) {
+                                    CalculationUtils.ageOn(
+                                            System.currentTimeMillis(),
+                                            user.birthDate
+                                    )
+                                }
 
-                    val (icon, tint) = when (user.gender) {
-                        GenderType.MALE ->
-                            Icons.Default.Face6 to MaterialTheme.colorScheme.primary
-                        GenderType.FEMALE ->
-                            Icons.Default.Face3 to MaterialTheme.colorScheme.secondary
-                        else ->
-                            Icons.Filled.AccountCircle to MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                        val (icon, tint) =
+                                when (user.gender) {
+                                    GenderType.MALE ->
+                                            Icons.Default.Face6 to MaterialTheme.colorScheme.primary
+                                    GenderType.FEMALE ->
+                                            Icons.Default.Face3 to
+                                                    MaterialTheme.colorScheme.secondary
+                                    else ->
+                                            Icons.Filled.AccountCircle to
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                }
 
-                    val textColor =
-                        if (itemClickEnabled) MaterialTheme.colorScheme.onSurface
-                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                    val iconTint =
-                        if (itemClickEnabled) tint
-                        else tint.copy(alpha = 0.38f)
+                        val textColor =
+                                if (itemClickEnabled) MaterialTheme.colorScheme.onSurface
+                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        val iconTint = if (itemClickEnabled) tint else tint.copy(alpha = 0.38f)
 
-                    ListItem(
-                        headlineContent = {
-                            Text(user.name, color = textColor)
-                        },
-                        supportingContent = {
-                            val genderName = user.gender.getDisplayName(context)
-                            Text(
-                                text = "${context.getString(R.string.user_settings_item_details_conditional, age, genderName)}",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        leadingContent = {
-                            Icon(
-                                icon,
-                                contentDescription = icon.name,
-                                tint = iconTint
-                            )
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable(enabled = itemClickEnabled) {
-                                onUserSelected(user.id)
-                            }
-                            .padding(vertical = 2.dp)
-                    )
-
-                    if (index < users.size - 1) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(horizontal = 12.dp),
-                            thickness = 1.dp,
-                            color = MaterialTheme.colorScheme.outlineVariant
+                        ListItem(
+                                headlineContent = { Text(user.name, color = textColor) },
+                                supportingContent = {
+                                    val genderName = user.gender.getDisplayName(context)
+                                    Text(
+                                            text =
+                                                    "${context.getString(R.string.user_settings_item_details_conditional, age, genderName)}",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                },
+                                leadingContent = {
+                                    Icon(icon, contentDescription = icon.name, tint = iconTint)
+                                },
+                                modifier =
+                                        Modifier.fillMaxWidth()
+                                                .clickable(enabled = itemClickEnabled) {
+                                                    onUserSelected(user.id)
+                                                }
+                                                .padding(vertical = 2.dp)
                         )
+
+                        if (index < users.size - 1) {
+                            HorizontalDivider(
+                                    modifier = Modifier.padding(horizontal = 12.dp),
+                                    thickness = 1.dp,
+                                    color = MaterialTheme.colorScheme.outlineVariant
+                            )
+                        }
                     }
                 }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss, enabled = confirmButtonEnabled) {
+                    Text(stringResource(R.string.cancel_button))
+                }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss, enabled = confirmButtonEnabled) {
-                Text(stringResource(R.string.cancel_button))
-            }
-        }
     )
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
@@ -258,6 +258,22 @@ fun DataManagementSettingsScreen(
     var webhookUrlDraft by
             rememberSaveable(webhookExportUrl) { mutableStateOf(webhookExportUrl ?: "") }
 
+    // --- InfluxDB Export state ---
+    val influxDbEnabled by settingsViewModel.influxDbExportEnabled.collectAsState()
+    val influxDbVersion by settingsViewModel.influxDbVersion.collectAsState()
+    val influxDbHost by settingsViewModel.influxDbHost.collectAsState()
+    val influxDbDatabase by settingsViewModel.influxDbDatabase.collectAsState()
+    val influxDbMeasurement by settingsViewModel.influxDbMeasurement.collectAsState()
+    val influxDbUsername by settingsViewModel.influxDbUsername.collectAsState()
+    val influxDbPassword by settingsViewModel.influxDbPassword.collectAsState()
+    // Draft states for InfluxDB fields (auto-save on change)
+    var influxHostDraft by rememberSaveable(influxDbHost) { mutableStateOf(influxDbHost) }
+    var influxDatabaseDraft by rememberSaveable(influxDbDatabase) { mutableStateOf(influxDbDatabase) }
+    var influxMeasurementDraft by rememberSaveable(influxDbMeasurement) { mutableStateOf(influxDbMeasurement) }
+    var influxUsernameDraft by rememberSaveable(influxDbUsername) { mutableStateOf(influxDbUsername) }
+    var influxPasswordDraft by rememberSaveable(influxDbPassword) { mutableStateOf(influxDbPassword) }
+
+
     var activeSafActionUserId by remember { mutableStateOf<Int?>(null) }
 
     val exportCsvLauncher =
@@ -887,6 +903,156 @@ fun DataManagementSettingsScreen(
                 ) {
                     Icon(Icons.Filled.Send, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
                     Text(stringResource(R.string.settings_webhook_export_test_button))
+                }
+            }
+        }
+
+        // --- InfluxDB Export Section ---
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                stringResource(R.string.settings_influxdb_export_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        item {
+            SettingsCardItem(
+                label = stringResource(R.string.settings_influxdb_export_enable_label),
+                supportingText = stringResource(
+                    if (influxDbEnabled) R.string.settings_influxdb_export_enabled_hint
+                    else R.string.settings_influxdb_export_disabled_hint
+                ),
+                onClick = { settingsViewModel.setInfluxDbExportEnabled(!influxDbEnabled) },
+                customLeadingContent = {
+                    Icon(
+                        Icons.Filled.CloudUpload,
+                        contentDescription = null,
+                        tint = if (influxDbEnabled) MaterialTheme.colorScheme.primary
+                               else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                },
+                trailingContent = {
+                    Switch(
+                        checked = influxDbEnabled,
+                        onCheckedChange = { settingsViewModel.setInfluxDbExportEnabled(it) }
+                    )
+                }
+            )
+        }
+
+        if (influxDbEnabled) {
+            // Version picker
+            item {
+                Card(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            stringResource(R.string.settings_influxdb_version_label),
+                            style = MaterialTheme.typography.labelMedium,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        Row(
+                            modifier = Modifier.selectableGroup().fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            listOf("v1", "v2").forEach { version ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .selectable(
+                                            selected = influxDbVersion == version,
+                                            onClick = { settingsViewModel.setInfluxDbVersion(version) }
+                                        )
+                                        .padding(end = 8.dp)
+                                ) {
+                                    RadioButton(
+                                        selected = influxDbVersion == version,
+                                        onClick = { settingsViewModel.setInfluxDbVersion(version) }
+                                    )
+                                    Text(version, modifier = Modifier.padding(start = 4.dp))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Host
+            item {
+                OutlinedTextField(
+                    value = influxHostDraft,
+                    onValueChange = { influxHostDraft = it; settingsViewModel.setInfluxDbHost(it) },
+                    label = { Text(stringResource(R.string.settings_influxdb_host_label)) },
+                    placeholder = { Text(stringResource(R.string.settings_influxdb_host_placeholder)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Next),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                )
+            }
+
+            // Database / Bucket
+            item {
+                OutlinedTextField(
+                    value = influxDatabaseDraft,
+                    onValueChange = { influxDatabaseDraft = it; settingsViewModel.setInfluxDbDatabase(it) },
+                    label = { Text(stringResource(R.string.settings_influxdb_database_label)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                )
+            }
+
+            // Measurement name
+            item {
+                OutlinedTextField(
+                    value = influxMeasurementDraft,
+                    onValueChange = { influxMeasurementDraft = it; settingsViewModel.setInfluxDbMeasurement(it) },
+                    label = { Text(stringResource(R.string.settings_influxdb_measurement_label)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                )
+            }
+
+            // Username + Password in a row
+                        item {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = influxUsernameDraft,
+                        onValueChange = { influxUsernameDraft = it; settingsViewModel.setInfluxDbUsername(it) },
+                        label = { Text(stringResource(R.string.settings_influxdb_username_label)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        modifier = Modifier.weight(1f).padding(vertical = 4.dp)
+                    )
+                    OutlinedTextField(
+                        value = influxPasswordDraft,
+                        onValueChange = { influxPasswordDraft = it; settingsViewModel.setInfluxDbPassword(it) },
+                        label = { Text(stringResource(R.string.settings_influxdb_password_label)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
+                        modifier = Modifier.weight(1f).padding(vertical = 4.dp)
+                    )
+                }
+            }
+
+            // Test button
+            item {
+                TextButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            val result = settingsViewModel.sendTestInfluxDbAndGetResult()
+                            Toast.makeText(context, result, Toast.LENGTH_LONG).show()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().padding(top = 4.dp, bottom = 8.dp)
+                ) {
+                    Icon(Icons.Filled.CloudUpload, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
+                    Text(stringResource(R.string.settings_influxdb_test_button))
                 }
             }
         }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/SettingsViewModel.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/SettingsViewModel.kt
@@ -29,7 +29,9 @@ import com.health.openscale.core.data.MeasurementType
 import com.health.openscale.core.data.User
 import com.health.openscale.core.facade.DataManagementFacade
 import com.health.openscale.core.facade.MeasurementFacade
+import com.health.openscale.core.facade.SettingsFacade
 import com.health.openscale.core.facade.UserFacade
+import com.health.openscale.core.usecase.WebhookExportUseCases
 import com.health.openscale.core.usecase.ImportReport
 import com.health.openscale.core.usecase.ReminderUseCase
 import com.health.openscale.core.utils.LogManager
@@ -55,12 +57,16 @@ import kotlinx.coroutines.launch
  * - Measurement types: [MeasurementFacade]
  */
 @HiltViewModel
-class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val userFacade: UserFacade,
-    private val dataManagementFacade: DataManagementFacade,
-    private val measurementFacade: MeasurementFacade,
-    private val reminderUseCase: ReminderUseCase
+class SettingsViewModel
+@Inject
+constructor(
+        @ApplicationContext private val context: Context,
+        private val userFacade: UserFacade,
+        private val dataManagementFacade: DataManagementFacade,
+        private val measurementFacade: MeasurementFacade,
+        private val reminderUseCase: ReminderUseCase,
+        private val settingsFacade: SettingsFacade,
+        private val webhookExportUseCases: WebhookExportUseCases
 ) : ViewModel() {
 
     companion object {
@@ -68,27 +74,32 @@ class SettingsViewModel @Inject constructor(
 
         const val ACTION_ID_EXPORT_USER_DATA = "export_user_data"
         const val ACTION_ID_IMPORT_USER_DATA = "import_user_data"
-        const val ACTION_ID_BACKUP_DB       = "backup_database"
-        const val ACTION_ID_RESTORE_DB      = "restore_database"
+        const val ACTION_ID_BACKUP_DB = "backup_database"
+        const val ACTION_ID_RESTORE_DB = "restore_database"
     }
 
     // --- Snackbar ---
-    private val _snackbarEvents = MutableSharedFlow<SnackbarEvent>(replay = 0, extraBufferCapacity = 1)
+    private val _snackbarEvents =
+            MutableSharedFlow<SnackbarEvent>(replay = 0, extraBufferCapacity = 1)
     val snackbarEvents = _snackbarEvents.asSharedFlow()
 
     private suspend fun showSnackbar(
-        resId: Int,
-        args: List<Any> = emptyList(),
-        duration: SnackbarDuration = SnackbarDuration.Short
+            resId: Int,
+            args: List<Any> = emptyList(),
+            duration: SnackbarDuration = SnackbarDuration.Short
     ) {
         _snackbarEvents.emit(
-            SnackbarEvent(messageResId = resId, messageFormatArgs = args, duration = duration)
+                SnackbarEvent(messageResId = resId, messageFormatArgs = args, duration = duration)
         )
     }
 
     // --- SAF events to the UI ---
     sealed class SafEvent {
-        data class RequestCreateFile(val suggestedName: String, val actionId: String, val userId: Int) : SafEvent()
+        data class RequestCreateFile(
+                val suggestedName: String,
+                val actionId: String,
+                val userId: Int
+        ) : SafEvent()
         data class RequestOpenFile(val actionId: String, val userId: Int) : SafEvent()
     }
     private val _safEvent = MutableSharedFlow<SafEvent>()
@@ -112,12 +123,14 @@ class SettingsViewModel @Inject constructor(
     val isLoadingDeletion: StateFlow<Boolean> = _isLoadingDeletion.asStateFlow()
 
     private val _isLoadingEntireDatabaseDeletion = MutableStateFlow(false)
-    val isLoadingEntireDatabaseDeletion: StateFlow<Boolean> = _isLoadingEntireDatabaseDeletion.asStateFlow()
+    val isLoadingEntireDatabaseDeletion: StateFlow<Boolean> =
+            _isLoadingEntireDatabaseDeletion.asStateFlow()
 
     // --- Users (UserFacade) ---
     val allUsers: StateFlow<List<User>> =
-        userFacade.observeAllUsers()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+            userFacade
+                    .observeAllUsers()
+                    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     suspend fun addUser(user: User): Long {
         return try {
@@ -152,19 +165,39 @@ class SettingsViewModel @Inject constructor(
 
     // --- Auto-backup (DataManagementFacade) ---
     val autoBackupEnabled =
-        dataManagementFacade.isAutoBackupEnabled.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+            dataManagementFacade.isAutoBackupEnabled.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    false
+            )
 
     val autoBackupLocationUri =
-        dataManagementFacade.autoBackupTargetUri.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+            dataManagementFacade.autoBackupTargetUri.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    null
+            )
 
     val autoBackupInterval =
-        dataManagementFacade.autoBackupInterval.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), BackupInterval.WEEKLY)
+            dataManagementFacade.autoBackupInterval.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    BackupInterval.WEEKLY
+            )
 
     val autoBackupCreateNewFile =
-        dataManagementFacade.isAutoBackupNewFileMode.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
+            dataManagementFacade.isAutoBackupNewFileMode.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    true
+            )
 
     val autoBackupLastSuccessfulTimestamp =
-        dataManagementFacade.autoBackupLastSuccessTimestamp.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0L)
+            dataManagementFacade.autoBackupLastSuccessTimestamp.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    0L
+            )
 
     fun setAutoBackupEnabled(enabled: Boolean) {
         viewModelScope.launch { dataManagementFacade.setAutoBackupEnabled(enabled) }
@@ -182,7 +215,37 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { dataManagementFacade.setAutoBackupNewFileMode(createNew) }
     }
 
-    // --- CSV import/export ---
+    // --- Webhook Export ---
+    val webhookExportEnabled =
+            settingsFacade.webhookExportEnabled.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    false
+            )
+
+    val webhookExportUrl =
+            settingsFacade.webhookExportUrl.stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(5_000),
+                    null
+            )
+
+    fun setWebhookExportEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsFacade.setWebhookExportEnabled(enabled) }
+    }
+
+    fun setWebhookExportUrl(url: String?) {
+        viewModelScope.launch { settingsFacade.setWebhookExportUrl(url) }
+    }
+
+    fun sendTestWebhook(url: String) {
+        viewModelScope.launch {
+            webhookExportUseCases.sendTestRequest(url)
+        }
+    }
+
+    suspend fun sendTestWebhookAndGetResult(url: String): String =
+        webhookExportUseCases.sendTestRequest(url)
     fun startExportProcess() {
         viewModelScope.launch {
             val users = allUsers.value
@@ -195,11 +258,11 @@ class SettingsViewModel @Inject constructor(
                     val safeName = user.name.replace("\\s+".toRegex(), "_").take(20)
                     val suggested = "openScale_export_${safeName}.csv"
                     _safEvent.emit(
-                        SafEvent.RequestCreateFile(
-                            suggested,
-                            ACTION_ID_EXPORT_USER_DATA,
-                            user.id
-                        )
+                            SafEvent.RequestCreateFile(
+                                    suggested,
+                                    ACTION_ID_EXPORT_USER_DATA,
+                                    user.id
+                            )
                     )
                 }
                 else -> {
@@ -213,12 +276,18 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoadingExport.value = true
             try {
-                val rows = dataManagementFacade.exportUserToCsv(userId, uri, contentResolver).getOrThrow()
+                val rows =
+                        dataManagementFacade
+                                .exportUserToCsv(userId, uri, contentResolver)
+                                .getOrThrow()
                 if (rows > 0) showSnackbar(R.string.export_successful)
                 else showSnackbar(R.string.export_error_no_exportable_values)
             } catch (e: Exception) {
                 LogManager.e(TAG, "CSV export error", e)
-                showSnackbar(R.string.export_error_generic, listOf(e.localizedMessage ?: "Unknown error"))
+                showSnackbar(
+                        R.string.export_error_generic,
+                        listOf(e.localizedMessage ?: "Unknown error")
+                )
             } finally {
                 _isLoadingExport.value = false
             }
@@ -234,12 +303,7 @@ class SettingsViewModel @Inject constructor(
                 }
                 1 -> {
                     val user = users.first()
-                    _safEvent.emit(
-                        SafEvent.RequestOpenFile(
-                            ACTION_ID_IMPORT_USER_DATA,
-                            user.id
-                        )
-                    )
+                    _safEvent.emit(SafEvent.RequestOpenFile(ACTION_ID_IMPORT_USER_DATA, user.id))
                 }
                 else -> {
                     _showUserSelectionDialogForImport.value = true
@@ -248,26 +312,53 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-
     fun performCsvImport(userId: Int, uri: Uri, contentResolver: ContentResolver) {
         viewModelScope.launch {
             _isLoadingImport.value = true
             try {
-                val report: ImportReport = dataManagementFacade.importUserFromCsv(userId, uri, contentResolver).getOrThrow()
+                val report: ImportReport =
+                        dataManagementFacade
+                                .importUserFromCsv(userId, uri, contentResolver)
+                                .getOrThrow()
                 val details = buildString {
                     val parts = mutableListOf<String>()
 
                     if (report.ignoredMeasurementsCount > 0) {
-                        parts.add(context.getString(R.string.import_summary_ignored_duplicated_timestamp, report.ignoredMeasurementsCount).removeSuffix("."))
+                        parts.add(
+                                context.getString(
+                                                R.string
+                                                        .import_summary_ignored_duplicated_timestamp,
+                                                report.ignoredMeasurementsCount
+                                        )
+                                        .removeSuffix(".")
+                        )
                     }
                     if (report.linesSkippedMissingDate > 0) {
-                        parts.add(context.getString(R.string.import_summary_skipped_missing_dates, report.linesSkippedMissingDate).removeSuffix("."))
+                        parts.add(
+                                context.getString(
+                                                R.string.import_summary_skipped_missing_dates,
+                                                report.linesSkippedMissingDate
+                                        )
+                                        .removeSuffix(".")
+                        )
                     }
                     if (report.linesSkippedDateParseError > 0) {
-                        parts.add(context.getString(R.string.import_summary_skipped_date_parse_errors, report.linesSkippedDateParseError).removeSuffix("."))
+                        parts.add(
+                                context.getString(
+                                                R.string.import_summary_skipped_date_parse_errors,
+                                                report.linesSkippedDateParseError
+                                        )
+                                        .removeSuffix(".")
+                        )
                     }
                     if (report.valuesSkippedParseError > 0) {
-                        parts.add(context.getString(R.string.import_summary_values_skipped_parse_errors, report.valuesSkippedParseError).removeSuffix("."))
+                        parts.add(
+                                context.getString(
+                                                R.string.import_summary_values_skipped_parse_errors,
+                                                report.valuesSkippedParseError
+                                        )
+                                        .removeSuffix(".")
+                        )
                     }
 
                     if (parts.isNotEmpty()) {
@@ -277,12 +368,21 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
                 if (details.isNotEmpty())
-                    showSnackbar(R.string.import_successful_records_with_details, listOf(report.importedMeasurementsCount, details))
+                        showSnackbar(
+                                R.string.import_successful_records_with_details,
+                                listOf(report.importedMeasurementsCount, details)
+                        )
                 else
-                    showSnackbar(R.string.import_successful_records, listOf(report.importedMeasurementsCount))
+                        showSnackbar(
+                                R.string.import_successful_records,
+                                listOf(report.importedMeasurementsCount)
+                        )
             } catch (e: Exception) {
                 LogManager.e(TAG, "CSV import error", e)
-                showSnackbar(R.string.import_error_generic, listOf(e.localizedMessage ?: "Unknown error"))
+                showSnackbar(
+                        R.string.import_error_generic,
+                        listOf(e.localizedMessage ?: "Unknown error")
+                )
             } finally {
                 _isLoadingImport.value = false
             }
@@ -293,7 +393,9 @@ class SettingsViewModel @Inject constructor(
     fun startDatabaseBackup() {
         viewModelScope.launch {
             val suggestedName = "openscale_backup_${System.currentTimeMillis()}.zip"
-            _safEvent.emit(SafEvent.RequestCreateFile(suggestedName, ACTION_ID_BACKUP_DB, userId = 0))
+            _safEvent.emit(
+                    SafEvent.RequestCreateFile(suggestedName, ACTION_ID_BACKUP_DB, userId = 0)
+            )
         }
     }
 
@@ -305,7 +407,10 @@ class SettingsViewModel @Inject constructor(
                 showSnackbar(R.string.backup_successful)
             } catch (e: Exception) {
                 LogManager.e(TAG, "Backup error", e)
-                showSnackbar(R.string.backup_error_generic, listOf(e.localizedMessage ?: "Unknown error"))
+                showSnackbar(
+                        R.string.backup_error_generic,
+                        listOf(e.localizedMessage ?: "Unknown error")
+                )
             } finally {
                 _isLoadingBackup.value = false
             }
@@ -326,7 +431,10 @@ class SettingsViewModel @Inject constructor(
                 showSnackbar(R.string.restore_successful)
             } catch (e: Exception) {
                 LogManager.e(TAG, "Restore error", e)
-                showSnackbar(R.string.restore_error_generic, listOf(e.localizedMessage ?: "Unknown error"))
+                showSnackbar(
+                        R.string.restore_error_generic,
+                        listOf(e.localizedMessage ?: "Unknown error")
+                )
             } finally {
                 _isLoadingRestore.value = false
             }
@@ -338,76 +446,95 @@ class SettingsViewModel @Inject constructor(
     }
 
     // --- Measurement types (MeasurementFacade) ---
-    fun addMeasurementType(type: MeasurementType) = viewModelScope.launch {
-        try {
-            measurementFacade.addMeasurementType(type).getOrThrow()
-            showSnackbar(R.string.measurement_type_added_successfully, listOf(type.name.orEmpty()))
-        } catch (e: Exception) {
-            LogManager.e(TAG, "addMeasurementType failed", e)
-            showSnackbar(R.string.measurement_type_added_error, listOf(type.name.orEmpty()))
-        }
-    }
-
-    fun updateMeasurementType(type: MeasurementType, showSnackbar: Boolean = true) = viewModelScope.launch {
-        try {
-            measurementFacade.updateMeasurementType(type).getOrThrow()
-            if (showSnackbar) {
-                showSnackbar(
-                    R.string.measurement_type_updated_successfully,
-                    listOf(type.name.orEmpty())
-                )
-            }
-        } catch (e: Exception) {
-            LogManager.e(TAG, "updateMeasurementType failed", e)
-            showSnackbar(R.string.measurement_type_updated_error, listOf(type.name.orEmpty()))
-        }
-    }
-
-    fun deleteMeasurementType(type: MeasurementType) = viewModelScope.launch {
-        try {
-            measurementFacade.deleteMeasurementType(type).getOrThrow()
-            showSnackbar(R.string.measurement_type_deleted_successfully, listOf(type.name.orEmpty()))
-        } catch (e: Exception) {
-            LogManager.e(TAG, "deleteMeasurementType failed", e)
-            showSnackbar(R.string.measurement_type_deleted_error, listOf(type.name.orEmpty()))
-        }
-    }
-
-    fun updateMeasurementTypeWithConversion(
-        originalType: MeasurementType,
-        updatedType: MeasurementType
-    ) = viewModelScope.launch {
-        try {
-            val report = measurementFacade
-                .updateTypeWithUnitConversion(originalType, updatedType)
-                .getOrThrow()
-
-            if (report.attempted) {
-                if (report.updatedCount > 0) {
+    fun addMeasurementType(type: MeasurementType) =
+            viewModelScope.launch {
+                try {
+                    measurementFacade.addMeasurementType(type).getOrThrow()
                     showSnackbar(
-                        R.string.measurement_type_updated_and_values_converted_successfully,
-                        listOf(updatedType.name.orEmpty(), report.updatedCount)
+                            R.string.measurement_type_added_successfully,
+                            listOf(type.name.orEmpty())
                     )
-                } else {
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "addMeasurementType failed", e)
+                    showSnackbar(R.string.measurement_type_added_error, listOf(type.name.orEmpty()))
+                }
+            }
+
+    fun updateMeasurementType(type: MeasurementType, showSnackbar: Boolean = true) =
+            viewModelScope.launch {
+                try {
+                    measurementFacade.updateMeasurementType(type).getOrThrow()
+                    if (showSnackbar) {
+                        showSnackbar(
+                                R.string.measurement_type_updated_successfully,
+                                listOf(type.name.orEmpty())
+                        )
+                    }
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "updateMeasurementType failed", e)
                     showSnackbar(
-                        R.string.measurement_type_updated_unit_changed_no_values_converted,
-                        listOf(updatedType.name.orEmpty())
+                            R.string.measurement_type_updated_error,
+                            listOf(type.name.orEmpty())
                     )
                 }
-            } else {
-                showSnackbar(
-                    R.string.measurement_type_updated_successfully,
-                    listOf(updatedType.name.orEmpty())
-                )
             }
-        } catch (e: Exception) {
-            LogManager.e(TAG, "updateMeasurementTypeWithConversion failed", e)
-            showSnackbar(
-                R.string.measurement_type_update_error_conversion_failed,
-                listOf(updatedType.name.orEmpty())
-            )
-        }
-    }
+
+    fun deleteMeasurementType(type: MeasurementType) =
+            viewModelScope.launch {
+                try {
+                    measurementFacade.deleteMeasurementType(type).getOrThrow()
+                    showSnackbar(
+                            R.string.measurement_type_deleted_successfully,
+                            listOf(type.name.orEmpty())
+                    )
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "deleteMeasurementType failed", e)
+                    showSnackbar(
+                            R.string.measurement_type_deleted_error,
+                            listOf(type.name.orEmpty())
+                    )
+                }
+            }
+
+    fun updateMeasurementTypeWithConversion(
+            originalType: MeasurementType,
+            updatedType: MeasurementType
+    ) =
+            viewModelScope.launch {
+                try {
+                    val report =
+                            measurementFacade
+                                    .updateTypeWithUnitConversion(originalType, updatedType)
+                                    .getOrThrow()
+
+                    if (report.attempted) {
+                        if (report.updatedCount > 0) {
+                            showSnackbar(
+                                    R.string
+                                            .measurement_type_updated_and_values_converted_successfully,
+                                    listOf(updatedType.name.orEmpty(), report.updatedCount)
+                            )
+                        } else {
+                            showSnackbar(
+                                    R.string
+                                            .measurement_type_updated_unit_changed_no_values_converted,
+                                    listOf(updatedType.name.orEmpty())
+                            )
+                        }
+                    } else {
+                        showSnackbar(
+                                R.string.measurement_type_updated_successfully,
+                                listOf(updatedType.name.orEmpty())
+                        )
+                    }
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "updateMeasurementTypeWithConversion failed", e)
+                    showSnackbar(
+                            R.string.measurement_type_update_error_conversion_failed,
+                            listOf(updatedType.name.orEmpty())
+                    )
+                }
+            }
 
     fun togglePinnedState(typeIds: List<Int>) {
         viewModelScope.launch {
@@ -415,7 +542,8 @@ class SettingsViewModel @Inject constructor(
             val allTypes = measurementFacade.getAllMeasurementTypes().first()
             val typesToUpdate = allTypes.filter { it.id in typeIds }
 
-            // Decide the target state based on the majority. If 50% or more are already pinned, unpin all. Otherwise, pin all.
+            // Decide the target state based on the majority. If 50% or more are already pinned,
+            // unpin all. Otherwise, pin all.
             val shouldPin = typesToUpdate.count { it.isPinned } < (typesToUpdate.size / 2.0)
 
             typesToUpdate.forEach { type ->
@@ -426,8 +554,8 @@ class SettingsViewModel @Inject constructor(
             // Show a single snackbar after the batch operation.
             val statusRes = if (shouldPin) R.string.status_pinned else R.string.status_unpinned
             showSnackbar(
-                resId = R.string.batch_update_status_report,
-                args = listOf(typeIds.size, context.getString(statusRes))
+                    resId = R.string.batch_update_status_report,
+                    args = listOf(typeIds.size, context.getString(statusRes))
             )
         }
     }
@@ -448,8 +576,8 @@ class SettingsViewModel @Inject constructor(
             }
             val statusRes = if (shouldEnable) R.string.status_enabled else R.string.status_disabled
             showSnackbar(
-                resId = R.string.batch_update_status_report,
-                args = listOf(typeIds.size, context.getString(statusRes))
+                    resId = R.string.batch_update_status_report,
+                    args = listOf(typeIds.size, context.getString(statusRes))
             )
         }
     }
@@ -460,39 +588,43 @@ class SettingsViewModel @Inject constructor(
             val allTypes = measurementFacade.getAllMeasurementTypes().first()
             val typesToUpdate = allTypes.filter { it.id in typeIds }
 
-            // If 50% or more are already on the right axis, move all to the left. Otherwise, move all to the right.
+            // If 50% or more are already on the right axis, move all to the left. Otherwise, move
+            // all to the right.
             val shouldBeOnRightAxis =
-                typesToUpdate.count { it.isOnRightYAxis } < (typesToUpdate.size / 2.0)
+                    typesToUpdate.count { it.isOnRightYAxis } < (typesToUpdate.size / 2.0)
 
             typesToUpdate.forEach { type ->
                 if (type.isOnRightYAxis != shouldBeOnRightAxis) {
                     updateMeasurementType(
-                        type.copy(isOnRightYAxis = shouldBeOnRightAxis),
-                        showSnackbar = false
+                            type.copy(isOnRightYAxis = shouldBeOnRightAxis),
+                            showSnackbar = false
                     )
                 }
             }
             val statusRes =
-                if (shouldBeOnRightAxis) R.string.status_axis_right else R.string.status_axis_left
+                    if (shouldBeOnRightAxis) R.string.status_axis_right
+                    else R.string.status_axis_left
             showSnackbar(
-                resId = R.string.batch_update_status_report,
-                args = listOf(typeIds.size, context.getString(statusRes))
+                    resId = R.string.batch_update_status_report,
+                    args = listOf(typeIds.size, context.getString(statusRes))
             )
         }
     }
 
     private val _showUserSelectionDialogForDelete = MutableStateFlow(false)
-    val showUserSelectionDialogForDelete: StateFlow<Boolean> = _showUserSelectionDialogForDelete.asStateFlow()
+    val showUserSelectionDialogForDelete: StateFlow<Boolean> =
+            _showUserSelectionDialogForDelete.asStateFlow()
 
     private val _userPendingDeletion = MutableStateFlow<User?>(null)
     val userPendingDeletion: StateFlow<User?> = _userPendingDeletion.asStateFlow()
 
     private val _showDeleteConfirmationDialog = MutableStateFlow(false)
-    val showDeleteConfirmationDialog: StateFlow<Boolean> = _showDeleteConfirmationDialog.asStateFlow()
+    val showDeleteConfirmationDialog: StateFlow<Boolean> =
+            _showDeleteConfirmationDialog.asStateFlow()
 
     private val _showDeleteEntireDatabaseConfirmationDialog = MutableStateFlow(false)
     val showDeleteEntireDatabaseConfirmationDialog: StateFlow<Boolean> =
-        _showDeleteEntireDatabaseConfirmationDialog.asStateFlow()
+            _showDeleteEntireDatabaseConfirmationDialog.asStateFlow()
 
     // Flags
     private val _showUserSelectionDialogForExport = MutableStateFlow(false)
@@ -502,27 +634,41 @@ class SettingsViewModel @Inject constructor(
     val showUserSelectionDialogForImport = _showUserSelectionDialogForImport.asStateFlow()
 
     // Dialog abbrechen
-    fun cancelUserSelectionForExport() { _showUserSelectionDialogForExport.value = false }
-    fun cancelUserSelectionForImport() { _showUserSelectionDialogForImport.value = false }
+    fun cancelUserSelectionForExport() {
+        _showUserSelectionDialogForExport.value = false
+    }
+    fun cancelUserSelectionForImport() {
+        _showUserSelectionDialogForImport.value = false
+    }
 
     // Auswahl übernehmen
-    fun proceedWithExportForUser(userId: Int) = viewModelScope.launch {
-        _showUserSelectionDialogForExport.value = false
-        val user = allUsers.value.firstOrNull { it.id == userId } ?: run {
-            showSnackbar(R.string.export_no_users_available); return@launch
-        }
-        val safeName = user.name.replace("\\s+".toRegex(), "_").take(20)
-        val suggested = "openScale_export_${safeName}.csv"
-        _safEvent.emit(SafEvent.RequestCreateFile(suggested, ACTION_ID_EXPORT_USER_DATA, user.id))
-    }
+    fun proceedWithExportForUser(userId: Int) =
+            viewModelScope.launch {
+                _showUserSelectionDialogForExport.value = false
+                val user =
+                        allUsers.value.firstOrNull { it.id == userId }
+                                ?: run {
+                                    showSnackbar(R.string.export_no_users_available)
+                                    return@launch
+                                }
+                val safeName = user.name.replace("\\s+".toRegex(), "_").take(20)
+                val suggested = "openScale_export_${safeName}.csv"
+                _safEvent.emit(
+                        SafEvent.RequestCreateFile(suggested, ACTION_ID_EXPORT_USER_DATA, user.id)
+                )
+            }
 
-    fun proceedWithImportForUser(userId: Int) = viewModelScope.launch {
-        _showUserSelectionDialogForImport.value = false
-        val user = allUsers.value.firstOrNull { it.id == userId } ?: run {
-            showSnackbar(R.string.import_no_users_available); return@launch
-        }
-        _safEvent.emit(SafEvent.RequestOpenFile(ACTION_ID_IMPORT_USER_DATA, user.id))
-    }
+    fun proceedWithImportForUser(userId: Int) =
+            viewModelScope.launch {
+                _showUserSelectionDialogForImport.value = false
+                val user =
+                        allUsers.value.firstOrNull { it.id == userId }
+                                ?: run {
+                                    showSnackbar(R.string.import_no_users_available)
+                                    return@launch
+                                }
+                _safEvent.emit(SafEvent.RequestOpenFile(ACTION_ID_IMPORT_USER_DATA, user.id))
+            }
 
     // --- User data delete flow ---
     fun initiateDeleteAllUserDataProcess() {
@@ -558,29 +704,32 @@ class SettingsViewModel @Inject constructor(
         _userPendingDeletion.value = null
     }
 
-    fun confirmActualDeletion() = viewModelScope.launch {
-        val user = _userPendingDeletion.value ?: run {
-            showSnackbar(R.string.delete_data_error_no_user_selected)
-            return@launch
-        }
+    fun confirmActualDeletion() =
+            viewModelScope.launch {
+                val user =
+                        _userPendingDeletion.value
+                                ?: run {
+                                    showSnackbar(R.string.delete_data_error_no_user_selected)
+                                    return@launch
+                                }
 
-        _isLoadingDeletion.value = true
-        try {
-            val deletedCount = userFacade.deleteAllMeasurementsForUser(user.id).getOrThrow()
-            if (deletedCount > 0) {
-                showSnackbar(R.string.delete_data_user_successful, listOf(user.name))
-            } else {
-                showSnackbar(R.string.delete_data_user_no_data_found, listOf(user.name))
+                _isLoadingDeletion.value = true
+                try {
+                    val deletedCount = userFacade.deleteAllMeasurementsForUser(user.id).getOrThrow()
+                    if (deletedCount > 0) {
+                        showSnackbar(R.string.delete_data_user_successful, listOf(user.name))
+                    } else {
+                        showSnackbar(R.string.delete_data_user_no_data_found, listOf(user.name))
+                    }
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "Delete all data for user failed", e)
+                    showSnackbar(R.string.delete_data_user_error, listOf(user.name))
+                } finally {
+                    _isLoadingDeletion.value = false
+                    _showDeleteConfirmationDialog.value = false
+                    _userPendingDeletion.value = null
+                }
             }
-        } catch (e: Exception) {
-            LogManager.e(TAG, "Delete all data for user failed", e)
-            showSnackbar(R.string.delete_data_user_error, listOf(user.name))
-        } finally {
-            _isLoadingDeletion.value = false
-            _showDeleteConfirmationDialog.value = false
-            _userPendingDeletion.value = null
-        }
-    }
 
     // --- Whole database delete flow ---
     fun initiateDeleteEntireDatabaseProcess() {
@@ -591,18 +740,19 @@ class SettingsViewModel @Inject constructor(
         _showDeleteEntireDatabaseConfirmationDialog.value = false
     }
 
-    fun confirmDeleteEntireDatabase() = viewModelScope.launch {
-        _isLoadingEntireDatabaseDeletion.value = true
-        try {
-            dataManagementFacade.wipeDatabase().getOrThrow()
+    fun confirmDeleteEntireDatabase() =
+            viewModelScope.launch {
+                _isLoadingEntireDatabaseDeletion.value = true
+                try {
+                    dataManagementFacade.wipeDatabase().getOrThrow()
 
-            showSnackbar(R.string.delete_db_successful, duration = SnackbarDuration.Long)
-        } catch (e: Exception) {
-            LogManager.e(TAG, "Wipe database failed", e)
-            showSnackbar(R.string.delete_db_error, duration = SnackbarDuration.Long)
-        } finally {
-            _isLoadingEntireDatabaseDeletion.value = false
-            _showDeleteEntireDatabaseConfirmationDialog.value = false
-        }
-    }
+                    showSnackbar(R.string.delete_db_successful, duration = SnackbarDuration.Long)
+                } catch (e: Exception) {
+                    LogManager.e(TAG, "Wipe database failed", e)
+                    showSnackbar(R.string.delete_db_error, duration = SnackbarDuration.Long)
+                } finally {
+                    _isLoadingEntireDatabaseDeletion.value = false
+                    _showDeleteEntireDatabaseConfirmationDialog.value = false
+                }
+            }
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/SettingsViewModel.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/SettingsViewModel.kt
@@ -31,6 +31,7 @@ import com.health.openscale.core.facade.DataManagementFacade
 import com.health.openscale.core.facade.MeasurementFacade
 import com.health.openscale.core.facade.SettingsFacade
 import com.health.openscale.core.facade.UserFacade
+import com.health.openscale.core.usecase.InfluxDbExportUseCases
 import com.health.openscale.core.usecase.WebhookExportUseCases
 import com.health.openscale.core.usecase.ImportReport
 import com.health.openscale.core.usecase.ReminderUseCase
@@ -66,7 +67,8 @@ constructor(
         private val measurementFacade: MeasurementFacade,
         private val reminderUseCase: ReminderUseCase,
         private val settingsFacade: SettingsFacade,
-        private val webhookExportUseCases: WebhookExportUseCases
+        private val webhookExportUseCases: WebhookExportUseCases,
+        private val influxDbExportUseCases: InfluxDbExportUseCases
 ) : ViewModel() {
 
     companion object {
@@ -246,6 +248,46 @@ constructor(
 
     suspend fun sendTestWebhookAndGetResult(url: String): String =
         webhookExportUseCases.sendTestRequest(url)
+
+    // --- InfluxDB Export ---
+    val influxDbExportEnabled = settingsFacade.influxDbExportEnabled.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+    val influxDbVersion = settingsFacade.influxDbVersion.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "v1")
+    val influxDbHost = settingsFacade.influxDbHost.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+    val influxDbDatabase = settingsFacade.influxDbDatabase.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+    val influxDbMeasurement = settingsFacade.influxDbMeasurement.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "koerpergewicht")
+    val influxDbUsername = settingsFacade.influxDbUsername.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+    val influxDbPassword = settingsFacade.influxDbPassword.stateIn(
+        viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    fun setInfluxDbExportEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsFacade.setInfluxDbExportEnabled(enabled) }
+    }
+    fun setInfluxDbVersion(version: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbVersion(version) }
+    }
+    fun setInfluxDbHost(host: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbHost(host) }
+    }
+    fun setInfluxDbDatabase(database: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbDatabase(database) }
+    }
+    fun setInfluxDbMeasurement(measurement: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbMeasurement(measurement) }
+    }
+    fun setInfluxDbUsername(username: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbUsername(username) }
+    }
+    fun setInfluxDbPassword(password: String) {
+        viewModelScope.launch { settingsFacade.setInfluxDbPassword(password) }
+    }
+    suspend fun sendTestInfluxDbAndGetResult(): String = influxDbExportUseCases.sendTestRequest()
+
     fun startExportProcess() {
         viewModelScope.launch {
             val users = allUsers.value

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -840,4 +840,28 @@
     <string name="settings_webhook_export_url_placeholder">https://ihr-endpunkt.beispiel.de/daten</string>
     <string name="settings_webhook_export_save_url">URL speichern</string>
     <string name="settings_webhook_export_test_button">Testanfrage senden</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -835,7 +835,7 @@
     <string name="settings_webhook_export_title">Webhook-Export</string>
     <string name="settings_webhook_export_enable_label">Webhook-Export aktivieren</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST wird bei jeder neuen Messung an die URL gesendet</string>
-    <string name="settings_webhook_export_disabled_hint">Aktivieren, um Messungen an eine benutzerdefinierte URL zu senden (InfluxDB, Supabase, usw.)</string>
+    <string name="settings_webhook_export_disabled_hint">Aktivieren, um Messungen an eine benutzerdefinierte URL zu senden</string>
     <string name="settings_webhook_export_url_label">Webhook-URL</string>
     <string name="settings_webhook_export_url_placeholder">https://ihr-endpunkt.beispiel.de/daten</string>
     <string name="settings_webhook_export_save_url">URL speichern</string>

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -841,27 +841,28 @@
     <string name="settings_webhook_export_save_url">URL speichern</string>
     <string name="settings_webhook_export_test_button">Testanfrage senden</string>
 
+    
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_export_enable_label">InfluxDB-Export aktivieren</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST wird bei jeder neuen Messung gesendet</string>
+    <string name="settings_influxdb_export_disabled_hint">Aktivieren, um Messungen direkt an InfluxDB zu senden</string>
     <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_label">Host-URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Datenbank (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Messungsname</string>
+    <string name="settings_influxdb_username_label">Benutzername (optional)</string>
+    <string name="settings_influxdb_password_label">Passwort (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Feld-Zuordnung</string>
+    <string name="settings_influxdb_field_mapping_hint">InfluxDB-Feldnamen anpassen, um vorhandene Grafana-Dashboards zu unterstützen</string>
+    <string name="settings_influxdb_field_weight_label">Feldname für Gewicht</string>
+    <string name="settings_influxdb_field_body_fat_label">Feldname für Körperfett</string>
+    <string name="settings_influxdb_field_water_label">Feldname für Wasser</string>
+    <string name="settings_influxdb_field_muscle_label">Feldname für Muskelmasse</string>
+    <string name="settings_influxdb_field_lbm_label">Feldname für Magermasse</string>
+    <string name="settings_influxdb_field_bone_label">Feldname für Knochenmasse</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Feldname für viszerales Fett</string>
+    <string name="settings_influxdb_test_button">Testpunkt senden</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-de/strings.xml
+++ b/android_app/app/src/main/res/values-de/strings.xml
@@ -830,4 +830,14 @@
     <string name="bt_sbf72_choice_slot_other_user">P%1$d: Verwendet von %2$s (Übernehmen?)</string>
     <string name="bt_sbf72_choice_slot_occupied_unmapped">P%1$d: Belegt (Nicht verknüpft)</string>
     <string name="bt_sbf72_choice_slot_create_new">P%1$d: \'%2$s\' hier erstellen</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook-Export</string>
+    <string name="settings_webhook_export_enable_label">Webhook-Export aktivieren</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST wird bei jeder neuen Messung an die URL gesendet</string>
+    <string name="settings_webhook_export_disabled_hint">Aktivieren, um Messungen an eine benutzerdefinierte URL zu senden (InfluxDB, Supabase, usw.)</string>
+    <string name="settings_webhook_export_url_label">Webhook-URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://ihr-endpunkt.beispiel.de/daten</string>
+    <string name="settings_webhook_export_save_url">URL speichern</string>
+    <string name="settings_webhook_export_test_button">Testanfrage senden</string>
 </resources>

--- a/android_app/app/src/main/res/values-el/strings.xml
+++ b/android_app/app/src/main/res/values-el/strings.xml
@@ -177,4 +177,14 @@
     <string name="user_detail_no_goals">Χωρίς στόχους</string>
     <string name="dialog_title_edit_goal">Επεξεργασία στόχου %1$s</string>
     <string name="dialog_title_add_goal">Επιλογή στόχου %1$s</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook Export</string>
+    <string name="settings_webhook_export_enable_label">Ενεργοποίηση webhook export</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST αποστέλλεται στη διεύθυνση URL για κάθε νέα μέτρηση</string>
+    <string name="settings_webhook_export_disabled_hint">Ενεργοποιήστε για αποστολή μετρήσεων σε προσαρμοσμένο URL (InfluxDB, Supabase, κ.λπ.)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Αποθήκευση URL</string>
+    <string name="settings_webhook_export_test_button">Αποστολή δοκιμαστικού αιτήματος</string>
 </resources>

--- a/android_app/app/src/main/res/values-el/strings.xml
+++ b/android_app/app/src/main/res/values-el/strings.xml
@@ -233,25 +233,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Ενεργοποίηση εξαγωγής InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">Το Line Protocol POST αποστέλλεται σε κάθε νέα μέτρηση</string>
+    <string name="settings_influxdb_export_disabled_hint">Ενεργοποιήστε για αποστολή μετρήσεων απευθείας στο InfluxDB</string>
+    <string name="settings_influxdb_version_label">Έκδοση InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL κεντρικού υπολογιστή</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Βάση δεδομένων (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Όνομα μέτρησης</string>
+    <string name="settings_influxdb_username_label">Όνομα χρήστη (προαιρετικό)</string>
+    <string name="settings_influxdb_password_label">Κωδικός πρόσβασης (προαιρετικό)</string>
+    <string name="settings_influxdb_field_mapping_title">Αντιστοίχιση πεδίων</string>
+    <string name="settings_influxdb_field_mapping_hint">Προσαρμόστε τα ονόματα πεδίων InfluxDB για τα υπάρχοντα dashboards Grafana σας</string>
+    <string name="settings_influxdb_field_weight_label">Όνομα πεδίου βάρους</string>
+    <string name="settings_influxdb_field_body_fat_label">Όνομα πεδίου σωματικού λίπους</string>
+    <string name="settings_influxdb_field_water_label">Όνομα πεδίου νερού</string>
+    <string name="settings_influxdb_field_muscle_label">Όνομα πεδίου μυών</string>
+    <string name="settings_influxdb_field_lbm_label">Όνομα πεδίου άλιπης μάζας</string>
+    <string name="settings_influxdb_field_bone_label">Όνομα πεδίου οστικής μάζας</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Όνομα πεδίου σπλαχνικού λίπους</string>
+    <string name="settings_influxdb_test_button">Αποστολή δοκιμαστικού σημείου</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-el/strings.xml
+++ b/android_app/app/src/main/res/values-el/strings.xml
@@ -182,7 +182,7 @@
     <string name="settings_webhook_export_title">Webhook Export</string>
     <string name="settings_webhook_export_enable_label">Ενεργοποίηση webhook export</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST αποστέλλεται στη διεύθυνση URL για κάθε νέα μέτρηση</string>
-    <string name="settings_webhook_export_disabled_hint">Ενεργοποιήστε για αποστολή μετρήσεων σε προσαρμοσμένο URL (InfluxDB, Supabase, κ.λπ.)</string>
+    <string name="settings_webhook_export_disabled_hint">Ενεργοποιήστε για αποστολή μετρήσεων σε προσαρμοσμένο URL</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Αποθήκευση URL</string>

--- a/android_app/app/src/main/res/values-el/strings.xml
+++ b/android_app/app/src/main/res/values-el/strings.xml
@@ -187,4 +187,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Αποθήκευση URL</string>
     <string name="settings_webhook_export_test_button">Αποστολή δοκιμαστικού αιτήματος</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -687,4 +687,14 @@
     <string name="settings_appearance_title">Apariencia</string>
     <string name="settings_dynamic_color_label">Colores dinámicos</string>
     <string name="settings_high_contrast_label">Alto contraste</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Exportación Webhook</string>
+    <string name="settings_webhook_export_enable_label">Activar exportación webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON enviado a la URL en cada nueva medición</string>
+    <string name="settings_webhook_export_disabled_hint">Activar para enviar mediciones a una URL personalizada (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">URL del Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://su-endpoint.ejemplo.com/datos</string>
+    <string name="settings_webhook_export_save_url">Guardar URL</string>
+    <string name="settings_webhook_export_test_button">Enviar solicitud de prueba</string>
 </resources>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -692,7 +692,7 @@
     <string name="settings_webhook_export_title">Exportación Webhook</string>
     <string name="settings_webhook_export_enable_label">Activar exportación webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON enviado a la URL en cada nueva medición</string>
-    <string name="settings_webhook_export_disabled_hint">Activar para enviar mediciones a una URL personalizada (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Activar para enviar mediciones a una URL personalizada</string>
     <string name="settings_webhook_export_url_label">URL del Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://su-endpoint.ejemplo.com/datos</string>
     <string name="settings_webhook_export_save_url">Guardar URL</string>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -697,4 +697,28 @@
     <string name="settings_webhook_export_url_placeholder">https://su-endpoint.ejemplo.com/datos</string>
     <string name="settings_webhook_export_save_url">Guardar URL</string>
     <string name="settings_webhook_export_test_button">Enviar solicitud de prueba</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-es/strings.xml
+++ b/android_app/app/src/main/res/values-es/strings.xml
@@ -698,27 +698,27 @@
     <string name="settings_webhook_export_save_url">Guardar URL</string>
     <string name="settings_webhook_export_test_button">Enviar solicitud de prueba</string>
 
-    <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
-    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+   <!-- InfluxDB Export Settings -->
+<string name="settings_influxdb_export_title">InfluxDB Export</string>
+<string name="settings_influxdb_export_enable_label">Activar exportación a InfluxDB</string>
+<string name="settings_influxdb_export_enabled_hint">Se envía un Line Protocol POST con cada nueva medición</string>
+<string name="settings_influxdb_export_disabled_hint">Activa para enviar mediciones directamente a InfluxDB</string>
+<string name="settings_influxdb_version_label">Versión de InfluxDB</string>
+<string name="settings_influxdb_host_label">URL del servidor</string>
+<string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+<string name="settings_influxdb_database_label">Base de datos (v1) / Bucket (v2)</string>
+<string name="settings_influxdb_measurement_label">Nombre de la medición</string>
+<string name="settings_influxdb_username_label">Usuario (opcional)</string>
+<string name="settings_influxdb_password_label">Contraseña (opcional)</string>
+<string name="settings_influxdb_field_mapping_title">Asignación de campos</string>
+<string name="settings_influxdb_field_mapping_hint">Personaliza los nombres de campos de InfluxDB para tus dashboards de Grafana</string>
+<string name="settings_influxdb_field_weight_label">Nombre del campo de peso</string>
+<string name="settings_influxdb_field_body_fat_label">Nombre del campo de grasa corporal</string>
+<string name="settings_influxdb_field_water_label">Nombre del campo de agua</string>
+<string name="settings_influxdb_field_muscle_label">Nombre del campo de músculo</string>
+<string name="settings_influxdb_field_lbm_label">Nombre del campo de masa magra</string>
+<string name="settings_influxdb_field_bone_label">Nombre del campo de masa ósea</string>
+<string name="settings_influxdb_field_visceral_fat_label">Nombre del campo de grasa visceral</string>
+<string name="settings_influxdb_test_button">Enviar punto de prueba</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-eu/strings.xml
+++ b/android_app/app/src/main/res/values-eu/strings.xml
@@ -13,4 +13,14 @@
     <string name="dialog_ok">Ados</string>
     <string name="saved">Gordeta</string>
     <string name="open_link_content_description">Zabaldu esteka</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook Esportazioa</string>
+    <string name="settings_webhook_export_enable_label">Gaitu webhook esportazioa</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST URL-ra bidaltzen da neurketa berri bakoitzean</string>
+    <string name="settings_webhook_export_disabled_hint">Gaitu neurketak URL pertsonalizatu batera bidaltzeko (InfluxDB, Supabase, etab.)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Gorde URL</string>
+    <string name="settings_webhook_export_test_button">Bidali proba-eskaera</string>
 </resources>

--- a/android_app/app/src/main/res/values-eu/strings.xml
+++ b/android_app/app/src/main/res/values-eu/strings.xml
@@ -18,7 +18,7 @@
     <string name="settings_webhook_export_title">Webhook Esportazioa</string>
     <string name="settings_webhook_export_enable_label">Gaitu webhook esportazioa</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST URL-ra bidaltzen da neurketa berri bakoitzean</string>
-    <string name="settings_webhook_export_disabled_hint">Gaitu neurketak URL pertsonalizatu batera bidaltzeko (InfluxDB, Supabase, etab.)</string>
+    <string name="settings_webhook_export_disabled_hint">Gaitu neurketak URL pertsonalizatu batera bidaltzeko</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Gorde URL</string>

--- a/android_app/app/src/main/res/values-eu/strings.xml
+++ b/android_app/app/src/main/res/values-eu/strings.xml
@@ -23,4 +23,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Gorde URL</string>
     <string name="settings_webhook_export_test_button">Bidali proba-eskaera</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-eu/strings.xml
+++ b/android_app/app/src/main/res/values-eu/strings.xml
@@ -69,25 +69,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Gaitu InfluxDB esportazioa</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST bidaltzen da neurri berri bakoitzean</string>
+    <string name="settings_influxdb_export_disabled_hint">Gaitu neurketak zuzenean InfluxDB-ra bidaltzeko</string>
+    <string name="settings_influxdb_version_label">InfluxDB bertsioa</string>
+    <string name="settings_influxdb_host_label">Ostalari URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Datu-basea (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Neurketa izena</string>
+    <string name="settings_influxdb_username_label">Erabiltzaile izena (aukerakoa)</string>
+    <string name="settings_influxdb_password_label">Pasahitza (aukerakoa)</string>
+    <string name="settings_influxdb_field_mapping_title">Eremu mapaketa</string>
+    <string name="settings_influxdb_field_mapping_hint">Pertsonalizatu InfluxDB eremu izenak zure Grafana panelekin bat etortzeko</string>
+    <string name="settings_influxdb_field_weight_label">Pisuaren eremu izena</string>
+    <string name="settings_influxdb_field_body_fat_label">Gorputz koipearen eremu izena</string>
+    <string name="settings_influxdb_field_water_label">Uraren eremu izena</string>
+    <string name="settings_influxdb_field_muscle_label">Giharren eremu izena</string>
+    <string name="settings_influxdb_field_lbm_label">Koipe gabeko masaren eremu izena</string>
+    <string name="settings_influxdb_field_bone_label">Hezur masaren eremu izena</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Barneko koipearen eremu izena</string>
+    <string name="settings_influxdb_test_button">Bidali proba puntua</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-fi/strings.xml
+++ b/android_app/app/src/main/res/values-fi/strings.xml
@@ -621,7 +621,7 @@
     <string name="settings_webhook_export_title">Webhook-vienti</string>
     <string name="settings_webhook_export_enable_label">Ota webhook-vienti käyttöön</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST lähetetään URL-osoitteeseen jokaisen uuden mittauksen yhteydessä</string>
-    <string name="settings_webhook_export_disabled_hint">Ota käyttöön lähettääksesi mittaukset mukautettuun URL-osoitteeseen (InfluxDB, Supabase jne.)</string>
+    <string name="settings_webhook_export_disabled_hint">Ota käyttöön lähettääksesi mittaukset mukautettuun URL-osoitteeseen</string>
     <string name="settings_webhook_export_url_label">Webhook-URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Tallenna URL</string>

--- a/android_app/app/src/main/res/values-fi/strings.xml
+++ b/android_app/app/src/main/res/values-fi/strings.xml
@@ -616,4 +616,14 @@
     <string name="bt_sbf72_choice_slot_other_user">P%1$d: %2$s:n käytössä (Otatko haltuusi?)</string>
     <string name="bt_sbf72_choice_slot_occupied_unmapped">P%1$d: Varattu (Ei linkitetty)</string>
     <string name="bt_sbf72_choice_slot_create_new">P%1$d: Luo \'%2$s\' täällä</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook-vienti</string>
+    <string name="settings_webhook_export_enable_label">Ota webhook-vienti käyttöön</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST lähetetään URL-osoitteeseen jokaisen uuden mittauksen yhteydessä</string>
+    <string name="settings_webhook_export_disabled_hint">Ota käyttöön lähettääksesi mittaukset mukautettuun URL-osoitteeseen (InfluxDB, Supabase jne.)</string>
+    <string name="settings_webhook_export_url_label">Webhook-URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Tallenna URL</string>
+    <string name="settings_webhook_export_test_button">Lähetä testipyyntö</string>
 </resources>

--- a/android_app/app/src/main/res/values-fi/strings.xml
+++ b/android_app/app/src/main/res/values-fi/strings.xml
@@ -627,27 +627,27 @@
     <string name="settings_webhook_export_save_url">Tallenna URL</string>
     <string name="settings_webhook_export_test_button">Lähetä testipyyntö</string>
 
-    <!-- InfluxDB Export Settings -->
+   <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Ota InfluxDB-vienti käyttöön</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST lähetetään jokaisen uuden mittauksen yhteydessä</string>
+    <string name="settings_influxdb_export_disabled_hint">Ota käyttöön lähettääksesi mittaukset suoraan InfluxDB:hen</string>
+    <string name="settings_influxdb_version_label">InfluxDB-versio</string>
+    <string name="settings_influxdb_host_label">Isäntä-URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Tietokanta (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Mittauksen nimi</string>
+    <string name="settings_influxdb_username_label">Käyttäjänimi (valinnainen)</string>
+    <string name="settings_influxdb_password_label">Salasana (valinnainen)</string>
+    <string name="settings_influxdb_field_mapping_title">Kenttien yhdistäminen</string>
+    <string name="settings_influxdb_field_mapping_hint">Mukauta InfluxDB-kenttien nimiä vastaamaan olemassa olevia Grafana-koontinäyttöjäsi</string>
+    <string name="settings_influxdb_field_weight_label">Painokentän nimi</string>
+    <string name="settings_influxdb_field_body_fat_label">Rasvaprosenttikentän nimi</string>
+    <string name="settings_influxdb_field_water_label">Vesikentän nimi</string>
+    <string name="settings_influxdb_field_muscle_label">Lihaskentän nimi</string>
+    <string name="settings_influxdb_field_lbm_label">Rasvattoman massan kentän nimi</string>
+    <string name="settings_influxdb_field_bone_label">Luumassakentän nimi</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Viskeraalisen rasvan kentän nimi</string>
+    <string name="settings_influxdb_test_button">Lähetä testipiste</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-fi/strings.xml
+++ b/android_app/app/src/main/res/values-fi/strings.xml
@@ -626,4 +626,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Tallenna URL</string>
     <string name="settings_webhook_export_test_button">Lähetä testipyyntö</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -663,11 +663,11 @@
 
     <!-- Webhook Export Settings -->
     <string name="settings_webhook_export_title">Export Webhook</string>
-    <string name="settings_webhook_export_enable_label">Activer l'export webhook</string>
-    <string name="settings_webhook_export_enabled_hint">POST JSON envoyé à l'URL à chaque nouvelle mesure</string>
+    <string name="settings_webhook_export_enable_label">Activer l\'export webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON envoyé à l\'URL à chaque nouvelle mesure</string>
     <string name="settings_webhook_export_disabled_hint">Activer pour envoyer les mesures vers une URL personnalisée (InfluxDB, Supabase, etc.)</string>
     <string name="settings_webhook_export_url_label">URL du Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://votre-endpoint.exemple.com/data</string>
-    <string name="settings_webhook_export_save_url">Enregistrer l'URL</string>
+    <string name="settings_webhook_export_save_url">Enregistrer l\'URL</string>
     <string name="settings_webhook_export_test_button">Envoyer une requête de test</string>
 </resources>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -670,4 +670,28 @@
     <string name="settings_webhook_export_url_placeholder">https://votre-endpoint.exemple.com/data</string>
     <string name="settings_webhook_export_save_url">Enregistrer l\'URL</string>
     <string name="settings_webhook_export_test_button">Envoyer une requête de test</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -672,26 +672,26 @@
     <string name="settings_webhook_export_test_button">Envoyer une requête de test</string>
 
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
-    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+<string name="settings_influxdb_export_title">InfluxDB Export</string>
+<string name="settings_influxdb_export_enable_label">Activer l\'export InfluxDB</string>
+<string name="settings_influxdb_export_enabled_hint">Un POST Line Protocol est envoyé à chaque nouvelle mesure</string>
+<string name="settings_influxdb_export_disabled_hint">Activer pour envoyer les mesures directement à InfluxDB</string>
+<string name="settings_influxdb_version_label">Version InfluxDB</string>
+<string name="settings_influxdb_host_label">URL du serveur</string>
+<string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+<string name="settings_influxdb_database_label">Base de données (v1) / Bucket (v2)</string>
+<string name="settings_influxdb_measurement_label">Nom de la mesure</string>
+<string name="settings_influxdb_username_label">Nom d\'utilisateur (optionnel)</string>
+<string name="settings_influxdb_password_label">Mot de passe (optionnel)</string>
+<string name="settings_influxdb_field_mapping_title">Correspondance des champs</string>
+<string name="settings_influxdb_field_mapping_hint">Personnalisez les noms de champs InfluxDB pour vos tableaux de bord Grafana existants</string>
+<string name="settings_influxdb_field_weight_label">Nom du champ poids</string>
+<string name="settings_influxdb_field_body_fat_label">Nom du champ masse grasse</string>
+<string name="settings_influxdb_field_water_label">Nom du champ eau</string>
+<string name="settings_influxdb_field_muscle_label">Nom du champ muscle</string>
+<string name="settings_influxdb_field_lbm_label">Nom du champ masse maigre</string>
+<string name="settings_influxdb_field_bone_label">Nom du champ masse osseuse</string>
+<string name="settings_influxdb_field_visceral_fat_label">Nom du champ graisse viscérale</string>
+<string name="settings_influxdb_test_button">Envoyer un point de test</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -665,7 +665,7 @@
     <string name="settings_webhook_export_title">Export Webhook</string>
     <string name="settings_webhook_export_enable_label">Activer l\'export webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON envoyé à l\'URL à chaque nouvelle mesure</string>
-    <string name="settings_webhook_export_disabled_hint">Activer pour envoyer les mesures vers une URL personnalisée (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Activer pour envoyer les mesures vers une URL personnalisée</string>
     <string name="settings_webhook_export_url_label">URL du Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://votre-endpoint.exemple.com/data</string>
     <string name="settings_webhook_export_save_url">Enregistrer l\'URL</string>

--- a/android_app/app/src/main/res/values-fr/strings.xml
+++ b/android_app/app/src/main/res/values-fr/strings.xml
@@ -660,4 +660,14 @@
     <string name="bt_sbf72_choice_slot_other_user">P%1$d : Utilisé par %2$s (Remplacer ?)</string>
     <string name="bt_sbf72_choice_slot_occupied_unmapped">P%1$d : Occupé (Pas lié)</string>
     <string name="bt_sbf72_choice_slot_create_new">P%1$d : Créer \'%2$s\' ici</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Export Webhook</string>
+    <string name="settings_webhook_export_enable_label">Activer l'export webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON envoyé à l'URL à chaque nouvelle mesure</string>
+    <string name="settings_webhook_export_disabled_hint">Activer pour envoyer les mesures vers une URL personnalisée (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">URL du Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://votre-endpoint.exemple.com/data</string>
+    <string name="settings_webhook_export_save_url">Enregistrer l'URL</string>
+    <string name="settings_webhook_export_test_button">Envoyer une requête de test</string>
 </resources>

--- a/android_app/app/src/main/res/values-it/strings.xml
+++ b/android_app/app/src/main/res/values-it/strings.xml
@@ -692,4 +692,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salva URL</string>
     <string name="settings_webhook_export_test_button">Invia richiesta di test</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-it/strings.xml
+++ b/android_app/app/src/main/res/values-it/strings.xml
@@ -686,7 +686,7 @@
     <!-- Webhook Export Settings -->
     <string name="settings_webhook_export_title">Esportazione Webhook</string>
     <string name="settings_webhook_export_enable_label">Abilita esportazione webhook</string>
-    <string name="settings_webhook_export_enabled_hint">POST JSON inviato all'URL ad ogni nuova misurazione</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON inviato all\'URL ad ogni nuova misurazione</string>
     <string name="settings_webhook_export_disabled_hint">Abilita per inviare le misurazioni a un URL personalizzato (InfluxDB, Supabase, ecc.)</string>
     <string name="settings_webhook_export_url_label">URL Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>

--- a/android_app/app/src/main/res/values-it/strings.xml
+++ b/android_app/app/src/main/res/values-it/strings.xml
@@ -695,25 +695,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Abilita esportazione InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">Un POST Line Protocol viene inviato ad ogni nuova misurazione</string>
+    <string name="settings_influxdb_export_disabled_hint">Abilita per inviare le misurazioni direttamente a InfluxDB</string>
+    <string name="settings_influxdb_version_label">Versione InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL host</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
     <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_measurement_label">Nome misurazione</string>
+    <string name="settings_influxdb_username_label">Nome utente (opzionale)</string>
+    <string name="settings_influxdb_password_label">Password (opzionale)</string>
+    <string name="settings_influxdb_field_mapping_title">Mappatura campi</string>
+    <string name="settings_influxdb_field_mapping_hint">Personalizza i nomi dei campi InfluxDB per i tuoi dashboard Grafana esistenti</string>
+    <string name="settings_influxdb_field_weight_label">Nome campo peso</string>
+    <string name="settings_influxdb_field_body_fat_label">Nome campo grasso corporeo</string>
+    <string name="settings_influxdb_field_water_label">Nome campo acqua</string>
+    <string name="settings_influxdb_field_muscle_label">Nome campo muscolo</string>
+    <string name="settings_influxdb_field_lbm_label">Nome campo massa magra</string>
+    <string name="settings_influxdb_field_bone_label">Nome campo massa ossea</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Nome campo grasso viscerale</string>
+    <string name="settings_influxdb_test_button">Invia punto di test</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-it/strings.xml
+++ b/android_app/app/src/main/res/values-it/strings.xml
@@ -687,7 +687,7 @@
     <string name="settings_webhook_export_title">Esportazione Webhook</string>
     <string name="settings_webhook_export_enable_label">Abilita esportazione webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON inviato all\'URL ad ogni nuova misurazione</string>
-    <string name="settings_webhook_export_disabled_hint">Abilita per inviare le misurazioni a un URL personalizzato (InfluxDB, Supabase, ecc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Abilita per inviare le misurazioni a un URL personalizzato</string>
     <string name="settings_webhook_export_url_label">URL Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salva URL</string>

--- a/android_app/app/src/main/res/values-it/strings.xml
+++ b/android_app/app/src/main/res/values-it/strings.xml
@@ -682,4 +682,14 @@
     <string name="aggregation_level_week">Settimana</string>
     <string name="aggregation_level_month">Mesi</string>
     <string name="aggregation_level_year">Anno</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Esportazione Webhook</string>
+    <string name="settings_webhook_export_enable_label">Abilita esportazione webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON inviato all'URL ad ogni nuova misurazione</string>
+    <string name="settings_webhook_export_disabled_hint">Abilita per inviare le misurazioni a un URL personalizzato (InfluxDB, Supabase, ecc.)</string>
+    <string name="settings_webhook_export_url_label">URL Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Salva URL</string>
+    <string name="settings_webhook_export_test_button">Invia richiesta di test</string>
 </resources>

--- a/android_app/app/src/main/res/values-iw/strings.xml
+++ b/android_app/app/src/main/res/values-iw/strings.xml
@@ -135,4 +135,14 @@
     <string name="measurement_type_hips">ירכיים</string>
     <string name="measurement_type_visceral_fat">שומן בטני</string>
     <string name="measurement_type_chest">חזה</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">ייצוא Webhook</string>
+    <string name="settings_webhook_export_enable_label">הפעל ייצוא webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON נשלח לכתובת ה-URL בכל מדידה חדשה</string>
+    <string name="settings_webhook_export_disabled_hint">הפעל לשליחת מדידות לכתובת URL מותאמת אישית (InfluxDB, Supabase וכו')</string>
+    <string name="settings_webhook_export_url_label">כתובת URL של Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">שמור URL</string>
+    <string name="settings_webhook_export_test_button">שלח בקשת בדיקה</string>
 </resources>

--- a/android_app/app/src/main/res/values-iw/strings.xml
+++ b/android_app/app/src/main/res/values-iw/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_webhook_export_title">ייצוא Webhook</string>
     <string name="settings_webhook_export_enable_label">הפעל ייצוא webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON נשלח לכתובת ה-URL בכל מדידה חדשה</string>
-    <string name="settings_webhook_export_disabled_hint">הפעל לשליחת מדידות לכתובת URL מותאמת אישית (InfluxDB, Supabase וכו\')</string>
+    <string name="settings_webhook_export_disabled_hint">הפעל לשליחת מדידות לכתובת URL מותאמת אישית</string>
     <string name="settings_webhook_export_url_label">כתובת URL של Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">שמור URL</string>

--- a/android_app/app/src/main/res/values-iw/strings.xml
+++ b/android_app/app/src/main/res/values-iw/strings.xml
@@ -189,27 +189,27 @@
     <string name="interval_weekly">Weekly</string>
     <string name="interval_monthly">Monthly</string>
 
-    <!-- InfluxDB Export Settings -->
+   <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">הפעל ייצוא ל-InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">POST של Line Protocol נשלח בכל מדידה חדשה</string>
+    <string name="settings_influxdb_export_disabled_hint">הפעל כדי לשלוח מדידות ישירות ל-InfluxDB</string>
+    <string name="settings_influxdb_version_label">גרסת InfluxDB</string>
+    <string name="settings_influxdb_host_label">כתובת URL של השרת</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">מסד נתונים (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">שם המדידה</string>
+    <string name="settings_influxdb_username_label">שם משתמש (אופציונלי)</string>
+    <string name="settings_influxdb_password_label">סיסמה (אופציונלי)</string>
+    <string name="settings_influxdb_field_mapping_title">מיפוי שדות</string>
+    <string name="settings_influxdb_field_mapping_hint">התאם אישית את שמות השדות ב-InfluxDB כדי להתאים ללוחות המחוונים הקיימים שלך ב-Grafana</string>
+    <string name="settings_influxdb_field_weight_label">שם שדה משקל</string>
+    <string name="settings_influxdb_field_body_fat_label">שם שדה אחוז שומן</string>
+    <string name="settings_influxdb_field_water_label">שם שדה מים</string>
+    <string name="settings_influxdb_field_muscle_label">שם שדה שריר</string>
+    <string name="settings_influxdb_field_lbm_label">שם שדה מסת גוף רזה</string>
+    <string name="settings_influxdb_field_bone_label">שם שדה מסת עצם</string>
+    <string name="settings_influxdb_field_visceral_fat_label">שם שדה שומן קרביים</string>
+    <string name="settings_influxdb_test_button">שלח נקודת בדיקה</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-iw/strings.xml
+++ b/android_app/app/src/main/res/values-iw/strings.xml
@@ -145,4 +145,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">שמור URL</string>
     <string name="settings_webhook_export_test_button">שלח בקשת בדיקה</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-iw/strings.xml
+++ b/android_app/app/src/main/res/values-iw/strings.xml
@@ -140,7 +140,7 @@
     <string name="settings_webhook_export_title">ייצוא Webhook</string>
     <string name="settings_webhook_export_enable_label">הפעל ייצוא webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON נשלח לכתובת ה-URL בכל מדידה חדשה</string>
-    <string name="settings_webhook_export_disabled_hint">הפעל לשליחת מדידות לכתובת URL מותאמת אישית (InfluxDB, Supabase וכו')</string>
+    <string name="settings_webhook_export_disabled_hint">הפעל לשליחת מדידות לכתובת URL מותאמת אישית (InfluxDB, Supabase וכו\')</string>
     <string name="settings_webhook_export_url_label">כתובת URL של Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">שמור URL</string>

--- a/android_app/app/src/main/res/values-ja/strings.xml
+++ b/android_app/app/src/main/res/values-ja/strings.xml
@@ -674,37 +674,27 @@
     <string name="s400_bind_key_error">バインドキーは32桁の16進文字でなければなりません</string>
     <string name="bt_s400_missing_bind_key">s400: バインドキーが設定されていません。Bluetooth設定に移動してBLEキーを入力してください。</string>
 
-    <!-- Webhook Export Settings -->
-    <string name="settings_webhook_export_title">Webhookエクスポート</string>
-    <string name="settings_webhook_export_enable_label">Webhookエクスポートを有効にする</string>
-    <string name="settings_webhook_export_enabled_hint">新しい測定ごとにJSON POSTがURLに送信されます</string>
-    <string name="settings_webhook_export_disabled_hint">カスタムURL（InfluxDB、Supabaseなど）に測定値を送信するために有効にする</string>
-    <string name="settings_webhook_export_url_label">Webhook URL</string>
-    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
-    <string name="settings_webhook_export_save_url">URLを保存</string>
-    <string name="settings_webhook_export_test_button">テストリクエストを送信</string>
-
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_title">InfluxDB エクスポート</string>
+    <string name="settings_influxdb_export_enable_label">InfluxDB エクスポートを有効にする</string>
+    <string name="settings_influxdb_export_enabled_hint">新しい測定のたびに Line Protocol POST が送信されます</string>
+    <string name="settings_influxdb_export_disabled_hint">有効にすると測定値が InfluxDB に直接送信されます</string>
+    <string name="settings_influxdb_version_label">InfluxDB バージョン</string>
+    <string name="settings_influxdb_host_label">ホスト URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">データベース (v1) / バケット (v2)</string>
+    <string name="settings_influxdb_measurement_label">メジャーメント名</string>
+    <string name="settings_influxdb_username_label">ユーザー名 (任意)</string>
+    <string name="settings_influxdb_password_label">パスワード (任意)</string>
+    <string name="settings_influxdb_field_mapping_title">フィールドマッピング</string>
+    <string name="settings_influxdb_field_mapping_hint">既存の Grafana ダッシュボードに合わせて InfluxDB フィールド名をカスタマイズ</string>
+    <string name="settings_influxdb_field_weight_label">体重フィールド名</string>
+    <string name="settings_influxdb_field_body_fat_label">体脂肪フィールド名</string>
+    <string name="settings_influxdb_field_water_label">水分フィールド名</string>
+    <string name="settings_influxdb_field_muscle_label">筋肉量フィールド名</string>
+    <string name="settings_influxdb_field_lbm_label">除脂肪体重フィールド名</string>
+    <string name="settings_influxdb_field_bone_label">骨量フィールド名</string>
+    <string name="settings_influxdb_field_visceral_fat_label">内臓脂肪フィールド名</string>
+    <string name="settings_influxdb_test_button">テストポイントを送信</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-ja/strings.xml
+++ b/android_app/app/src/main/res/values-ja/strings.xml
@@ -683,4 +683,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URLを保存</string>
     <string name="settings_webhook_export_test_button">テストリクエストを送信</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-ja/strings.xml
+++ b/android_app/app/src/main/res/values-ja/strings.xml
@@ -673,4 +673,14 @@
     <string name="s400_bind_key_description">Xiaomi S400スケールの復号にはBLEバインドキーが必要です。Xiaomi Cloud Tokens Extractorツールを使用して、このキーをXiaomi Cloudから抽出してください。</string>
     <string name="s400_bind_key_error">バインドキーは32桁の16進文字でなければなりません</string>
     <string name="bt_s400_missing_bind_key">s400: バインドキーが設定されていません。Bluetooth設定に移動してBLEキーを入力してください。</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhookエクスポート</string>
+    <string name="settings_webhook_export_enable_label">Webhookエクスポートを有効にする</string>
+    <string name="settings_webhook_export_enabled_hint">新しい測定ごとにJSON POSTがURLに送信されます</string>
+    <string name="settings_webhook_export_disabled_hint">カスタムURL（InfluxDB、Supabaseなど）に測定値を送信するために有効にする</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">URLを保存</string>
+    <string name="settings_webhook_export_test_button">テストリクエストを送信</string>
 </resources>

--- a/android_app/app/src/main/res/values-ko/strings.xml
+++ b/android_app/app/src/main/res/values-ko/strings.xml
@@ -10,4 +10,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL 저장</string>
     <string name="settings_webhook_export_test_button">테스트 요청 보내기</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-ko/strings.xml
+++ b/android_app/app/src/main/res/values-ko/strings.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook 내보내기</string>
+    <string name="settings_webhook_export_enable_label">Webhook 내보내기 활성화</string>
+    <string name="settings_webhook_export_enabled_hint">새 측정값마다 URL로 JSON POST가 전송됩니다</string>
+    <string name="settings_webhook_export_disabled_hint">사용자 지정 URL로 측정값을 전송하려면 활성화하세요 (InfluxDB, Supabase 등)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">URL 저장</string>
+    <string name="settings_webhook_export_test_button">테스트 요청 보내기</string>
 </resources>

--- a/android_app/app/src/main/res/values-ko/strings.xml
+++ b/android_app/app/src/main/res/values-ko/strings.xml
@@ -5,7 +5,7 @@
     <string name="settings_webhook_export_title">Webhook 내보내기</string>
     <string name="settings_webhook_export_enable_label">Webhook 내보내기 활성화</string>
     <string name="settings_webhook_export_enabled_hint">새 측정값마다 URL로 JSON POST가 전송됩니다</string>
-    <string name="settings_webhook_export_disabled_hint">사용자 지정 URL로 측정값을 전송하려면 활성화하세요 (InfluxDB, Supabase 등)</string>
+    <string name="settings_webhook_export_disabled_hint">사용자 지정 URL로 측정값을 전송하려면 활성화하세요</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL 저장</string>

--- a/android_app/app/src/main/res/values-ko/strings.xml
+++ b/android_app/app/src/main/res/values-ko/strings.xml
@@ -55,26 +55,26 @@
     <string name="interval_monthly">Monthly</string>
 
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_title">InfluxDB 내보내기</string>
+    <string name="settings_influxdb_export_enable_label">InfluxDB 내보내기 활성화</string>
+    <string name="settings_influxdb_export_enabled_hint">새 측정마다 Line Protocol POST가 전송됩니다</string>
+    <string name="settings_influxdb_export_disabled_hint">측정값을 InfluxDB로 직접 전송하려면 활성화하세요</string>
+    <string name="settings_influxdb_version_label">InfluxDB 버전</string>
+    <string name="settings_influxdb_host_label">호스트 URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">데이터베이스 (v1) / 버킷 (v2)</string>
+    <string name="settings_influxdb_measurement_label">측정 이름</string>
+    <string name="settings_influxdb_username_label">사용자 이름 (선택사항)</string>
+    <string name="settings_influxdb_password_label">비밀번호 (선택사항)</string>
+    <string name="settings_influxdb_field_mapping_title">필드 매핑</string>
+    <string name="settings_influxdb_field_mapping_hint">기존 Grafana 대시보드에 맞게 InfluxDB 필드 이름을 사용자 정의하세요</string>
+    <string name="settings_influxdb_field_weight_label">체중 필드 이름</string>
+    <string name="settings_influxdb_field_body_fat_label">체지방 필드 이름</string>
+    <string name="settings_influxdb_field_water_label">수분 필드 이름</string>
+    <string name="settings_influxdb_field_muscle_label">근육량 필드 이름</string>
+    <string name="settings_influxdb_field_lbm_label">제지방 체중 필드 이름</string>
+    <string name="settings_influxdb_field_bone_label">골량 필드 이름</string>
+    <string name="settings_influxdb_field_visceral_fat_label">내장지방 필드 이름</string>
+    <string name="settings_influxdb_test_button">테스트 포인트 전송</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-nl/strings.xml
+++ b/android_app/app/src/main/res/values-nl/strings.xml
@@ -5,7 +5,7 @@
     <string name="settings_webhook_export_title">Webhook-export</string>
     <string name="settings_webhook_export_enable_label">Webhook-export inschakelen</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST wordt bij elke nieuwe meting naar de URL verzonden</string>
-    <string name="settings_webhook_export_disabled_hint">Inschakelen om metingen naar een aangepaste URL te sturen (InfluxDB, Supabase, enz.)</string>
+    <string name="settings_webhook_export_disabled_hint">Inschakelen om metingen naar een aangepaste URL te sturen</string>
     <string name="settings_webhook_export_url_label">Webhook-URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL opslaan</string>

--- a/android_app/app/src/main/res/values-nl/strings.xml
+++ b/android_app/app/src/main/res/values-nl/strings.xml
@@ -10,4 +10,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL opslaan</string>
     <string name="settings_webhook_export_test_button">Testverzoek verzenden</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-nl/strings.xml
+++ b/android_app/app/src/main/res/values-nl/strings.xml
@@ -56,25 +56,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">InfluxDB-export inschakelen</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST wordt verzonden bij elke nieuwe meting</string>
+    <string name="settings_influxdb_export_disabled_hint">Inschakelen om metingen rechtstreeks naar InfluxDB te sturen</string>
+    <string name="settings_influxdb_version_label">InfluxDB versie</string>
+    <string name="settings_influxdb_host_label">Host-URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
     <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_measurement_label">Naam meting</string>
+    <string name="settings_influxdb_username_label">Gebruikersnaam (optioneel)</string>
+    <string name="settings_influxdb_password_label">Wachtwoord (optioneel)</string>
+    <string name="settings_influxdb_field_mapping_title">Veldtoewijzing</string>
+    <string name="settings_influxdb_field_mapping_hint">Pas InfluxDB-veldnamen aan voor uw bestaande Grafana-dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Veldnaam gewicht</string>
+    <string name="settings_influxdb_field_body_fat_label">Veldnaam lichaamsvet</string>
+    <string name="settings_influxdb_field_water_label">Veldnaam water</string>
+    <string name="settings_influxdb_field_muscle_label">Veldnaam spier</string>
+    <string name="settings_influxdb_field_lbm_label">Veldnaam vetvrije massa</string>
+    <string name="settings_influxdb_field_bone_label">Veldnaam botmassa</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Veldnaam visceraal vet</string>
+    <string name="settings_influxdb_test_button">Testpunt verzenden</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-nl/strings.xml
+++ b/android_app/app/src/main/res/values-nl/strings.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook-export</string>
+    <string name="settings_webhook_export_enable_label">Webhook-export inschakelen</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST wordt bij elke nieuwe meting naar de URL verzonden</string>
+    <string name="settings_webhook_export_disabled_hint">Inschakelen om metingen naar een aangepaste URL te sturen (InfluxDB, Supabase, enz.)</string>
+    <string name="settings_webhook_export_url_label">Webhook-URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">URL opslaan</string>
+    <string name="settings_webhook_export_test_button">Testverzoek verzenden</string>
 </resources>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -236,4 +236,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Zapisz URL</string>
     <string name="settings_webhook_export_test_button">Wyślij żądanie testowe</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -226,4 +226,14 @@
     <string name="formula_bf_deurenberg_1991">Deurenberg (1991)</string>
     <string name="formula_bf_deurenberg_1992">Deurenberg (1992)</string>
     <string name="formula_bf_eddy_1976">Eddy et al. (1976)</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Eksport Webhook</string>
+    <string name="settings_webhook_export_enable_label">Włącz eksport webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON wysyłany na URL przy każdym nowym pomiarze</string>
+    <string name="settings_webhook_export_disabled_hint">Włącz, aby wysyłać pomiary na niestandardowy URL (InfluxDB, Supabase itp.)</string>
+    <string name="settings_webhook_export_url_label">URL webhooka</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Zapisz URL</string>
+    <string name="settings_webhook_export_test_button">Wyślij żądanie testowe</string>
 </resources>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -282,25 +282,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Włącz eksport do InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">POST Line Protocol wysyłany przy każdym nowym pomiarze</string>
+    <string name="settings_influxdb_export_disabled_hint">Włącz, aby wysyłać pomiary bezpośrednio do InfluxDB</string>
+    <string name="settings_influxdb_version_label">Wersja InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL hosta</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Baza danych (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Nazwa pomiaru</string>
+    <string name="settings_influxdb_username_label">Nazwa użytkownika (opcjonalnie)</string>
+    <string name="settings_influxdb_password_label">Hasło (opcjonalnie)</string>
+    <string name="settings_influxdb_field_mapping_title">Mapowanie pól</string>
+    <string name="settings_influxdb_field_mapping_hint">Dostosuj nazwy pól InfluxDB do swoich dashboardów Grafana</string>
+    <string name="settings_influxdb_field_weight_label">Nazwa pola wagi</string>
+    <string name="settings_influxdb_field_body_fat_label">Nazwa pola tkanki tłuszczowej</string>
+    <string name="settings_influxdb_field_water_label">Nazwa pola wody</string>
+    <string name="settings_influxdb_field_muscle_label">Nazwa pola mięśni</string>
+    <string name="settings_influxdb_field_lbm_label">Nazwa pola beztłuszczowej masy ciała</string>
+    <string name="settings_influxdb_field_bone_label">Nazwa pola masy kostnej</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Nazwa pola tłuszczu trzewnego</string>
+    <string name="settings_influxdb_test_button">Wyślij punkt testowy</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-pl/strings.xml
+++ b/android_app/app/src/main/res/values-pl/strings.xml
@@ -231,7 +231,7 @@
     <string name="settings_webhook_export_title">Eksport Webhook</string>
     <string name="settings_webhook_export_enable_label">Włącz eksport webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON wysyłany na URL przy każdym nowym pomiarze</string>
-    <string name="settings_webhook_export_disabled_hint">Włącz, aby wysyłać pomiary na niestandardowy URL (InfluxDB, Supabase itp.)</string>
+    <string name="settings_webhook_export_disabled_hint">Włącz, aby wysyłać pomiary na niestandardowy URL</string>
     <string name="settings_webhook_export_url_label">URL webhooka</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Zapisz URL</string>

--- a/android_app/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android_app/app/src/main/res/values-pt-rBR/strings.xml
@@ -691,7 +691,7 @@
     <string name="settings_webhook_export_title">Exportação Webhook</string>
     <string name="settings_webhook_export_enable_label">Ativar exportação webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON enviado para a URL a cada nova medição</string>
-    <string name="settings_webhook_export_disabled_hint">Ativar para enviar medições para uma URL personalizada (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Ativar para enviar medições para uma URL personalizada</string>
     <string name="settings_webhook_export_url_label">URL do Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salvar URL</string>

--- a/android_app/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android_app/app/src/main/res/values-pt-rBR/strings.xml
@@ -696,4 +696,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salvar URL</string>
     <string name="settings_webhook_export_test_button">Enviar solicitação de teste</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android_app/app/src/main/res/values-pt-rBR/strings.xml
@@ -686,4 +686,14 @@
     <string name="settings_appearance_title">Aparência</string>
     <string name="settings_dynamic_color_label">Cores dinâmicas</string>
     <string name="settings_high_contrast_label">Alto contraste</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Exportação Webhook</string>
+    <string name="settings_webhook_export_enable_label">Ativar exportação webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON enviado para a URL a cada nova medição</string>
+    <string name="settings_webhook_export_disabled_hint">Ativar para enviar medições para uma URL personalizada (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">URL do Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Salvar URL</string>
+    <string name="settings_webhook_export_test_button">Enviar solicitação de teste</string>
 </resources>

--- a/android_app/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android_app/app/src/main/res/values-pt-rBR/strings.xml
@@ -699,25 +699,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Ativar exportação para InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">POST Line Protocol enviado a cada nova medição</string>
+    <string name="settings_influxdb_export_disabled_hint">Ative para enviar medições diretamente ao InfluxDB</string>
+    <string name="settings_influxdb_version_label">Versão do InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL do servidor</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Banco de dados (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Nome da medição</string>
+    <string name="settings_influxdb_username_label">Usuário (opcional)</string>
+    <string name="settings_influxdb_password_label">Senha (opcional)</string>
+    <string name="settings_influxdb_field_mapping_title">Mapeamento de campos</string>
+    <string name="settings_influxdb_field_mapping_hint">Personalize os nomes de campos do InfluxDB para seus dashboards do Grafana</string>
+    <string name="settings_influxdb_field_weight_label">Nome do campo de peso</string>
+    <string name="settings_influxdb_field_body_fat_label">Nome do campo de gordura corporal</string>
+    <string name="settings_influxdb_field_water_label">Nome do campo de água</string>
+    <string name="settings_influxdb_field_muscle_label">Nome do campo de músculo</string>
+    <string name="settings_influxdb_field_lbm_label">Nome do campo de massa magra</string>
+    <string name="settings_influxdb_field_bone_label">Nome do campo de massa óssea</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Nome do campo de gordura visceral</string>
+    <string name="settings_influxdb_test_button">Enviar ponto de teste</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-ro/strings.xml
+++ b/android_app/app/src/main/res/values-ro/strings.xml
@@ -687,4 +687,14 @@
     <string name="bt_sbf72_choice_slot_other_user">P%1$d: Folosit de %2$s (Preiei controlul?)</string>
     <string name="bt_sbf72_choice_slot_occupied_unmapped">P%1$d: Ocupat (nu e legat)</string>
     <string name="bt_sbf72_choice_slot_create_new">P%1$d: Creează \'%2$s\' here</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Export Webhook</string>
+    <string name="settings_webhook_export_enable_label">Activează exportul webhook</string>
+    <string name="settings_webhook_export_enabled_hint">POST JSON trimis la URL la fiecare măsurătoare nouă</string>
+    <string name="settings_webhook_export_disabled_hint">Activează pentru a trimite măsurătorile la un URL personalizat (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">URL Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Salvează URL</string>
+    <string name="settings_webhook_export_test_button">Trimite cerere de test</string>
 </resources>

--- a/android_app/app/src/main/res/values-ro/strings.xml
+++ b/android_app/app/src/main/res/values-ro/strings.xml
@@ -692,7 +692,7 @@
     <string name="settings_webhook_export_title">Export Webhook</string>
     <string name="settings_webhook_export_enable_label">Activează exportul webhook</string>
     <string name="settings_webhook_export_enabled_hint">POST JSON trimis la URL la fiecare măsurătoare nouă</string>
-    <string name="settings_webhook_export_disabled_hint">Activează pentru a trimite măsurătorile la un URL personalizat (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Activează pentru a trimite măsurătorile la un URL personalizat</string>
     <string name="settings_webhook_export_url_label">URL Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salvează URL</string>

--- a/android_app/app/src/main/res/values-ro/strings.xml
+++ b/android_app/app/src/main/res/values-ro/strings.xml
@@ -700,25 +700,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Activează exportul InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">POST Line Protocol trimis la fiecare nouă măsurătoare</string>
+    <string name="settings_influxdb_export_disabled_hint">Activați pentru a trimite măsurătorile direct la InfluxDB</string>
+    <string name="settings_influxdb_version_label">Versiune InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL gazdă</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Bază de date (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Numele măsurătorii</string>
+    <string name="settings_influxdb_username_label">Nume utilizator (opțional)</string>
+    <string name="settings_influxdb_password_label">Parolă (opțional)</string>
+    <string name="settings_influxdb_field_mapping_title">Maparea câmpurilor</string>
+    <string name="settings_influxdb_field_mapping_hint">Personalizați numele câmpurilor InfluxDB pentru dashboard-urile Grafana existente</string>
+    <string name="settings_influxdb_field_weight_label">Numele câmpului greutate</string>
+    <string name="settings_influxdb_field_body_fat_label">Numele câmpului grăsime corporală</string>
+    <string name="settings_influxdb_field_water_label">Numele câmpului apă</string>
+    <string name="settings_influxdb_field_muscle_label">Numele câmpului mușchi</string>
+    <string name="settings_influxdb_field_lbm_label">Numele câmpului masă slabă</string>
+    <string name="settings_influxdb_field_bone_label">Numele câmpului masă osoasă</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Numele câmpului grăsime viscerală</string>
+    <string name="settings_influxdb_test_button">Trimite punct de test</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-ro/strings.xml
+++ b/android_app/app/src/main/res/values-ro/strings.xml
@@ -697,4 +697,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Salvează URL</string>
     <string name="settings_webhook_export_test_button">Trimite cerere de test</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-ru/strings.xml
+++ b/android_app/app/src/main/res/values-ru/strings.xml
@@ -686,25 +686,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Включить экспорт в InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST отправляется при каждом новом измерении</string>
+    <string name="settings_influxdb_export_disabled_hint">Включите для отправки измерений напрямую в InfluxDB</string>
+    <string name="settings_influxdb_version_label">Версия InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL сервера</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">База данных (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Название измерения</string>
+    <string name="settings_influxdb_username_label">Имя пользователя (необязательно)</string>
+    <string name="settings_influxdb_password_label">Пароль (необязательно)</string>
+    <string name="settings_influxdb_field_mapping_title">Сопоставление полей</string>
+    <string name="settings_influxdb_field_mapping_hint">Настройте имена полей InfluxDB для существующих дашбордов Grafana</string>
+    <string name="settings_influxdb_field_weight_label">Название поля веса</string>
+    <string name="settings_influxdb_field_body_fat_label">Название поля жира</string>
+    <string name="settings_influxdb_field_water_label">Название поля воды</string>
+    <string name="settings_influxdb_field_muscle_label">Название поля мышц</string>
+    <string name="settings_influxdb_field_lbm_label">Название поля сухой массы</string>
+    <string name="settings_influxdb_field_bone_label">Название поля костной массы</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Название поля висцерального жира</string>
+    <string name="settings_influxdb_test_button">Отправить тестовую точку</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-ru/strings.xml
+++ b/android_app/app/src/main/res/values-ru/strings.xml
@@ -678,7 +678,7 @@
     <string name="settings_webhook_export_title">Экспорт Webhook</string>
     <string name="settings_webhook_export_enable_label">Включить экспорт webhook</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST отправляется на URL при каждом новом измерении</string>
-    <string name="settings_webhook_export_disabled_hint">Включите для отправки измерений на пользовательский URL (InfluxDB, Supabase и др.)</string>
+    <string name="settings_webhook_export_disabled_hint">Включите для отправки измерений на пользовательский URL</string>
     <string name="settings_webhook_export_url_label">URL Webhook</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Сохранить URL</string>

--- a/android_app/app/src/main/res/values-ru/strings.xml
+++ b/android_app/app/src/main/res/values-ru/strings.xml
@@ -683,4 +683,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Сохранить URL</string>
     <string name="settings_webhook_export_test_button">Отправить тестовый запрос</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-ru/strings.xml
+++ b/android_app/app/src/main/res/values-ru/strings.xml
@@ -673,4 +673,14 @@
     <string name="s400_bind_key_description">Для расшифровки весов Xiaomi S400 требуется ключ привязки BLE. Извлеките этот ключ из Xiaomi Cloud с помощью инструмента Xiaomi Cloud Tokens Extractor.</string>
     <string name="s400_bind_key_error">Ключ привязки должен содержать ровно 32 шестнадцатеричных символа</string>
     <string name="bt_s400_missing_bind_key">S400: Ключ привязки не настроен. Перейдите в настройки Bluetooth, чтобы ввести свой ключ BLE.</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Экспорт Webhook</string>
+    <string name="settings_webhook_export_enable_label">Включить экспорт webhook</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST отправляется на URL при каждом новом измерении</string>
+    <string name="settings_webhook_export_disabled_hint">Включите для отправки измерений на пользовательский URL (InfluxDB, Supabase и др.)</string>
+    <string name="settings_webhook_export_url_label">URL Webhook</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Сохранить URL</string>
+    <string name="settings_webhook_export_test_button">Отправить тестовый запрос</string>
 </resources>

--- a/android_app/app/src/main/res/values-sl/strings.xml
+++ b/android_app/app/src/main/res/values-sl/strings.xml
@@ -683,4 +683,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Shrani URL</string>
     <string name="settings_webhook_export_test_button">Pošlji testno zahtevo</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-sl/strings.xml
+++ b/android_app/app/src/main/res/values-sl/strings.xml
@@ -678,7 +678,7 @@
     <string name="settings_webhook_export_title">Izvoz Webhook</string>
     <string name="settings_webhook_export_enable_label">Omogoči izvoz webhook</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST se pošlje na URL ob vsaki novi meritvi</string>
-    <string name="settings_webhook_export_disabled_hint">Omogoči za pošiljanje meritev na URL po meri (InfluxDB, Supabase itd.)</string>
+    <string name="settings_webhook_export_disabled_hint">Omogoči za pošiljanje meritev na URL po meri</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Shrani URL</string>

--- a/android_app/app/src/main/res/values-sl/strings.xml
+++ b/android_app/app/src/main/res/values-sl/strings.xml
@@ -685,26 +685,26 @@
     <string name="settings_webhook_export_test_button">Pošlji testno zahtevo</string>
 
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_title">InfluxDB izvoz</string>
+    <string name="settings_influxdb_export_enable_label">Omogoči izvoz InfluxDB</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST se pošlje ob vsaki novi meritvi</string>
+    <string name="settings_influxdb_export_disabled_hint">Omogočite za pošiljanje meritev neposredno v InfluxDB</string>
+    <string name="settings_influxdb_version_label">Različica InfluxDB</string>
+    <string name="settings_influxdb_host_label">URL gostitelja</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Baza podatkov (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Ime meritve</string>
+    <string name="settings_influxdb_username_label">Uporabniško ime (neobvezno)</string>
+    <string name="settings_influxdb_password_label">Geslo (neobvezno)</string>
+    <string name="settings_influxdb_field_mapping_title">Preslikava polj</string>
+    <string name="settings_influxdb_field_mapping_hint">Prilagodite imena polj InfluxDB za obstoječe Grafana nadzorne plošče</string>
+    <string name="settings_influxdb_field_weight_label">Ime polja za težo</string>
+    <string name="settings_influxdb_field_body_fat_label">Ime polja za telesno maščobo</string>
+    <string name="settings_influxdb_field_water_label">Ime polja za vodo</string>
+    <string name="settings_influxdb_field_muscle_label">Ime polja za mišice</string>
+    <string name="settings_influxdb_field_lbm_label">Ime polja za pusto maso</string>
+    <string name="settings_influxdb_field_bone_label">Ime polja za kostno maso</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Ime polja za visceralno maščobo</string>
+    <string name="settings_influxdb_test_button">Pošlji testno točko</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-sl/strings.xml
+++ b/android_app/app/src/main/res/values-sl/strings.xml
@@ -673,4 +673,14 @@
     <string name="bt_warn_write_failed_status">Pisanje na %1$s spodletelo: %2$s</string>
     <string name="bt_warn_notify_state_failed_status">Obvestilo o stanju ni uspelo za %1$s: %2$s</string>
     <string name="bt_error_no_user_selected">Ni izbran noben uporabnik</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Izvoz Webhook</string>
+    <string name="settings_webhook_export_enable_label">Omogoči izvoz webhook</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST se pošlje na URL ob vsaki novi meritvi</string>
+    <string name="settings_webhook_export_disabled_hint">Omogoči za pošiljanje meritev na URL po meri (InfluxDB, Supabase itd.)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Shrani URL</string>
+    <string name="settings_webhook_export_test_button">Pošlji testno zahtevo</string>
 </resources>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -697,4 +697,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Spara URL</string>
     <string name="settings_webhook_export_test_button">Skicka testförfrågan</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -700,25 +700,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">Aktivera InfluxDB-export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST skickas vid varje ny mätning</string>
+    <string name="settings_influxdb_export_disabled_hint">Aktivera för att skicka mätningar direkt till InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB-version</string>
+    <string name="settings_influxdb_host_label">Värd-URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Databas (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Mätningsnamn</string>
+    <string name="settings_influxdb_username_label">Användarnamn (valfritt)</string>
+    <string name="settings_influxdb_password_label">Lösenord (valfritt)</string>
+    <string name="settings_influxdb_field_mapping_title">Fältkoppling</string>
+    <string name="settings_influxdb_field_mapping_hint">Anpassa InfluxDB-fältnamn för dina befintliga Grafana-dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Fältnamn för vikt</string>
+    <string name="settings_influxdb_field_body_fat_label">Fältnamn för kroppsfett</string>
+    <string name="settings_influxdb_field_water_label">Fältnamn för vatten</string>
+    <string name="settings_influxdb_field_muscle_label">Fältnamn för muskel</string>
+    <string name="settings_influxdb_field_lbm_label">Fältnamn för mager kroppsmassa</string>
+    <string name="settings_influxdb_field_bone_label">Fältnamn för benmassa</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Fältnamn för visceralt fett</string>
+    <string name="settings_influxdb_test_button">Skicka testpunkt</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -687,4 +687,14 @@
     <string name="settings_appearance_title">Utseende</string>
     <string name="settings_dynamic_color_label">Dynamiska färger</string>
     <string name="auto_connect_on_startup_title">automatisk anslutning vid uppstart</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook-export</string>
+    <string name="settings_webhook_export_enable_label">Aktivera webhook-export</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST skickas till URL vid varje ny mätning</string>
+    <string name="settings_webhook_export_disabled_hint">Aktivera för att skicka mätningar till en anpassad URL (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">Webhook-URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Spara URL</string>
+    <string name="settings_webhook_export_test_button">Skicka testförfrågan</string>
 </resources>

--- a/android_app/app/src/main/res/values-sv/strings.xml
+++ b/android_app/app/src/main/res/values-sv/strings.xml
@@ -692,7 +692,7 @@
     <string name="settings_webhook_export_title">Webhook-export</string>
     <string name="settings_webhook_export_enable_label">Aktivera webhook-export</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST skickas till URL vid varje ny mätning</string>
-    <string name="settings_webhook_export_disabled_hint">Aktivera för att skicka mätningar till en anpassad URL (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Aktivera för att skicka mätningar till en anpassad URL</string>
     <string name="settings_webhook_export_url_label">Webhook-URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Spara URL</string>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -164,4 +164,65 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL\'yi Kaydet</string>
     <string name="settings_webhook_export_test_button">Test isteği gönder</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -158,10 +158,10 @@
     <!-- Webhook Export Settings -->
     <string name="settings_webhook_export_title">Webhook Dışa Aktarma</string>
     <string name="settings_webhook_export_enable_label">Webhook dışa aktarmayı etkinleştir</string>
-    <string name="settings_webhook_export_enabled_hint">Her yeni ölçümde URL'ye JSON POST gönderilir</string>
-    <string name="settings_webhook_export_disabled_hint">Ölçümleri özel bir URL'ye göndermek için etkinleştirin (InfluxDB, Supabase, vb.)</string>
+    <string name="settings_webhook_export_enabled_hint">Her yeni ölçümde URL\'ye JSON POST gönderilir</string>
+    <string name="settings_webhook_export_disabled_hint">Ölçümleri özel bir URL\'ye göndermek için etkinleştirin (InfluxDB, Supabase, vb.)</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
-    <string name="settings_webhook_export_save_url">URL'yi Kaydet</string>
+    <string name="settings_webhook_export_save_url">URL\'yi Kaydet</string>
     <string name="settings_webhook_export_test_button">Test isteği gönder</string>
 </resources>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -154,4 +154,14 @@
     <string name="setting_smoothing_alpha">Alfa</string>
     <string name="setting_smoothing_window_size">Pencere boyutu</string>
     <string name="dialog_message_restore_database_confirmation">Mevcut veritabanının üzerine yedek dosya yazmak istediğinizden emin misiniz? Kaydedilmemiş tüm mevcut veriler kaybolacaktır. Geri yükleme işleminden sonra uygulamanın yeniden başlatılması gerekebilir.</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook Dışa Aktarma</string>
+    <string name="settings_webhook_export_enable_label">Webhook dışa aktarmayı etkinleştir</string>
+    <string name="settings_webhook_export_enabled_hint">Her yeni ölçümde URL'ye JSON POST gönderilir</string>
+    <string name="settings_webhook_export_disabled_hint">Ölçümleri özel bir URL'ye göndermek için etkinleştirin (InfluxDB, Supabase, vb.)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">URL'yi Kaydet</string>
+    <string name="settings_webhook_export_test_button">Test isteği gönder</string>
 </resources>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -159,7 +159,7 @@
     <string name="settings_webhook_export_title">Webhook Dışa Aktarma</string>
     <string name="settings_webhook_export_enable_label">Webhook dışa aktarmayı etkinleştir</string>
     <string name="settings_webhook_export_enabled_hint">Her yeni ölçümde URL\'ye JSON POST gönderilir</string>
-    <string name="settings_webhook_export_disabled_hint">Ölçümleri özel bir URL\'ye göndermek için etkinleştirin (InfluxDB, Supabase, vb.)</string>
+    <string name="settings_webhook_export_disabled_hint">Ölçümleri özel bir URL\'ye göndermek için etkinleştirin</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">URL\'yi Kaydet</string>

--- a/android_app/app/src/main/res/values-tr/strings.xml
+++ b/android_app/app/src/main/res/values-tr/strings.xml
@@ -204,25 +204,25 @@
 
     <!-- InfluxDB Export Settings -->
     <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_enable_label">InfluxDB dışa aktarmayı etkinleştir</string>
+    <string name="settings_influxdb_export_enabled_hint">Her yeni ölçümde Line Protocol POST gönderilir</string>
+    <string name="settings_influxdb_export_disabled_hint">Ölçümleri doğrudan InfluxDB\'ye göndermek için etkinleştirin</string>
+    <string name="settings_influxdb_version_label">InfluxDB Sürümü</string>
+    <string name="settings_influxdb_host_label">Sunucu URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">Veritabanı (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Ölçüm adı</string>
+    <string name="settings_influxdb_username_label">Kullanıcı adı (isteğe bağlı)</string>
+    <string name="settings_influxdb_password_label">Şifre (isteğe bağlı)</string>
+    <string name="settings_influxdb_field_mapping_title">Alan Eşleştirme</string>
+    <string name="settings_influxdb_field_mapping_hint">Mevcut Grafana panolarınızla eşleşmesi için InfluxDB alan adlarını özelleştirin</string>
+    <string name="settings_influxdb_field_weight_label">Ağırlık alan adı</string>
+    <string name="settings_influxdb_field_body_fat_label">Vücut yağı alan adı</string>
+    <string name="settings_influxdb_field_water_label">Su alan adı</string>
+    <string name="settings_influxdb_field_muscle_label">Kas alan adı</string>
+    <string name="settings_influxdb_field_lbm_label">Yağsız kütle alan adı</string>
+    <string name="settings_influxdb_field_bone_label">Kemik kütlesi alan adı</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visseral yağ alan adı</string>
+    <string name="settings_influxdb_test_button">Test noktası gönder</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rCN/strings.xml
@@ -687,7 +687,7 @@
     <string name="settings_webhook_export_title">Webhook 导出</string>
     <string name="settings_webhook_export_enable_label">启用 Webhook 导出</string>
     <string name="settings_webhook_export_enabled_hint">每次新测量时向 URL 发送 JSON POST</string>
-    <string name="settings_webhook_export_disabled_hint">启用以将测量数据发送到自定义 URL（InfluxDB、Supabase 等）</string>
+    <string name="settings_webhook_export_disabled_hint">启用以将测量数据发送到自定义 URL</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">保存 URL</string>

--- a/android_app/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rCN/strings.xml
@@ -682,4 +682,14 @@
     <string name="aggregation_level_week">周</string>
     <string name="aggregation_level_month">月</string>
     <string name="aggregation_level_year">年</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook 导出</string>
+    <string name="settings_webhook_export_enable_label">启用 Webhook 导出</string>
+    <string name="settings_webhook_export_enabled_hint">每次新测量时向 URL 发送 JSON POST</string>
+    <string name="settings_webhook_export_disabled_hint">启用以将测量数据发送到自定义 URL（InfluxDB、Supabase 等）</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">保存 URL</string>
+    <string name="settings_webhook_export_test_button">发送测试请求</string>
 </resources>

--- a/android_app/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rCN/strings.xml
@@ -692,4 +692,28 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">保存 URL</string>
     <string name="settings_webhook_export_test_button">发送测试请求</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rCN/strings.xml
@@ -694,26 +694,26 @@
     <string name="settings_webhook_export_test_button">发送测试请求</string>
 
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_title">InfluxDB 导出</string>
+    <string name="settings_influxdb_export_enable_label">启用 InfluxDB 导出</string>
+    <string name="settings_influxdb_export_enabled_hint">每次新测量时发送 Line Protocol POST</string>
+    <string name="settings_influxdb_export_disabled_hint">启用后将测量数据直接发送到 InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB 版本</string>
+    <string name="settings_influxdb_host_label">主机 URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">数据库 (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">测量名称</string>
+    <string name="settings_influxdb_username_label">用户名（可选）</string>
+    <string name="settings_influxdb_password_label">密码（可选）</string>
+    <string name="settings_influxdb_field_mapping_title">字段映射</string>
+    <string name="settings_influxdb_field_mapping_hint">自定义 InfluxDB 字段名称以匹配现有的 Grafana 仪表板</string>
+    <string name="settings_influxdb_field_weight_label">体重字段名称</string>
+    <string name="settings_influxdb_field_body_fat_label">体脂字段名称</string>
+    <string name="settings_influxdb_field_water_label">水分字段名称</string>
+    <string name="settings_influxdb_field_muscle_label">肌肉量字段名称</string>
+    <string name="settings_influxdb_field_lbm_label">去脂体重字段名称</string>
+    <string name="settings_influxdb_field_bone_label">骨量字段名称</string>
+    <string name="settings_influxdb_field_visceral_fat_label">内脏脂肪字段名称</string>
+    <string name="settings_influxdb_test_button">发送测试点</string>
 
 </resources>

--- a/android_app/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rTW/strings.xml
@@ -61,7 +61,7 @@
     <string name="settings_webhook_export_title">Webhook 匯出</string>
     <string name="settings_webhook_export_enable_label">啟用 Webhook 匯出</string>
     <string name="settings_webhook_export_enabled_hint">每次新測量時向 URL 發送 JSON POST</string>
-    <string name="settings_webhook_export_disabled_hint">啟用以將測量資料傳送至自訂 URL（InfluxDB、Supabase 等）</string>
+    <string name="settings_webhook_export_disabled_hint">啟用以將測量資料傳送至自訂 URL</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">儲存 URL</string>

--- a/android_app/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rTW/strings.xml
@@ -66,4 +66,71 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">儲存 URL</string>
     <string name="settings_webhook_export_test_button">傳送測試請求</string>
+
+    <!-- Log Export -->
+    <string name="log_export_success">Log file exported successfully.</string>
+    <string name="log_export_error">Error exporting log file.</string>
+    <string name="log_export_no_file">No log file found to export.</string>
+    <string name="log_export_no_file_to_export">No log file available to export.</string>
+    <string name="log_export_cancelled">Export cancelled.</string>
+    <string name="log_export_no_app_error">No suitable app found to export the file.</string>
+    <string name="export_log_file_button">Export Log File</string>
+    <!-- Auto Backup Settings -->
+    <string name="settings_auto_backup_title">Automatic Backups</string>
+    <string name="settings_enable_auto_backups">Enable automatic backups</string>
+    <string name="content_desc_auto_backups_toggle">Toggle automatic backups</string>
+    <string name="settings_last_backup_status_label">Last backup status</string>
+    <string name="content_desc_backup_status_icon">Backup status information</string>
+    <string name="settings_backup_location_label">Backup location</string>
+    <string name="content_desc_backup_location_icon">Backup location setting</string>
+    <string name="content_desc_open_backup_location_icon">Open backup location</string>
+    <string name="content_desc_change_backup_location_icon">Change backup location</string>
+    <string name="settings_backup_interval_label">Backup interval</string>
+    <string name="content_desc_backup_interval_icon">Backup interval setting</string>
+    <string name="content_desc_change_interval_icon">Change backup interval</string>
+    <string name="settings_backup_behavior_label">Backup Behavior</string>
+    <string name="content_desc_backup_behavior_icon">Backup behavior setting</string>
+    <string name="settings_last_backup_status_placeholder">Last backup: %1$s</string>
+    <string name="settings_auto_backups_disabled">Automatic backups disabled</string>
+    <string name="settings_backup_behavior_new_file">Always create a new backup file</string>
+    <string name="settings_backup_behavior_overwrite">Overwrite existing backup file</string>
+    <string name="settings_backup_location_default">Default: App-specific folder</string>
+    <string name="settings_backup_location_not_configured">Backup location not configured</string>
+    <string name="settings_backup_location_not_configured_for_auto">Location not configured. Automatic backups paused.</string>
+    <string name="settings_backup_location_error_accessing">Error accessing backup location</string>
+    <string name="settings_backup_location_select_action">Select Backup Location</string>
+    <string name="settings_backup_location_selected_folder">Selected folder</string>
+    <string name="settings_backup_location_open_error_no_app">No application found to open the folder.</string>
+    <string name="settings_backup_location_open_error">Could not open backup location.</string>
+    <string name="settings_backup_location_selected_toast">Backup location set to: %1$s</string>
+    <string name="settings_backup_location_selection_cancelled">Folder selection cancelled. Automatic backup not enabled.</string>
+    <string name="settings_last_backup_status_successful">Last backup: %1$s</string>
+    <string name="settings_last_backup_status_never">Last backup: Never</string>
+    <string name="interval_daily">Daily</string>
+    <string name="interval_weekly">Weekly</string>
+    <string name="interval_monthly">Monthly</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
+
 </resources>

--- a/android_app/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rTW/strings.xml
@@ -56,4 +56,14 @@
     <string name="gender_male">男性</string>
     <string name="gender_female">女性</string>
     <string name="amputation_hand">手</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook 匯出</string>
+    <string name="settings_webhook_export_enable_label">啟用 Webhook 匯出</string>
+    <string name="settings_webhook_export_enabled_hint">每次新測量時向 URL 發送 JSON POST</string>
+    <string name="settings_webhook_export_disabled_hint">啟用以將測量資料傳送至自訂 URL（InfluxDB、Supabase 等）</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">儲存 URL</string>
+    <string name="settings_webhook_export_test_button">傳送測試請求</string>
 </resources>

--- a/android_app/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android_app/app/src/main/res/values-zh-rTW/strings.xml
@@ -111,26 +111,26 @@
     <string name="interval_monthly">Monthly</string>
 
     <!-- InfluxDB Export Settings -->
-    <string name="settings_influxdb_export_title">InfluxDB Export</string>
-    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
-    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
-    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
-    <string name="settings_influxdb_version_label">InfluxDB Version</string>
-    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_export_title">InfluxDB 匯出</string>
+    <string name="settings_influxdb_export_enable_label">啟用 InfluxDB 匯出</string>
+    <string name="settings_influxdb_export_enabled_hint">每次新測量時傳送 Line Protocol POST</string>
+    <string name="settings_influxdb_export_disabled_hint">啟用後將測量資料直接傳送至 InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB 版本</string>
+    <string name="settings_influxdb_host_label">主機 URL</string>
     <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
-    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
-    <string name="settings_influxdb_measurement_label">Measurement name</string>
-    <string name="settings_influxdb_username_label">Username (optional)</string>
-    <string name="settings_influxdb_password_label">Password (optional)</string>
-    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
-    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
-    <string name="settings_influxdb_field_weight_label">Weight field name</string>
-    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
-    <string name="settings_influxdb_field_water_label">Water field name</string>
-    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
-    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
-    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
-    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
-    <string name="settings_influxdb_test_button">Send Test Point</string>
+    <string name="settings_influxdb_database_label">資料庫 (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">測量名稱</string>
+    <string name="settings_influxdb_username_label">使用者名稱（選填）</string>
+    <string name="settings_influxdb_password_label">密碼（選填）</string>
+    <string name="settings_influxdb_field_mapping_title">欄位對應</string>
+    <string name="settings_influxdb_field_mapping_hint">自訂 InfluxDB 欄位名稱以符合現有的 Grafana 儀表板</string>
+    <string name="settings_influxdb_field_weight_label">體重欄位名稱</string>
+    <string name="settings_influxdb_field_body_fat_label">體脂欄位名稱</string>
+    <string name="settings_influxdb_field_water_label">水分欄位名稱</string>
+    <string name="settings_influxdb_field_muscle_label">肌肉量欄位名稱</string>
+    <string name="settings_influxdb_field_lbm_label">去脂體重欄位名稱</string>
+    <string name="settings_influxdb_field_bone_label">骨量欄位名稱</string>
+    <string name="settings_influxdb_field_visceral_fat_label">內臟脂肪欄位名稱</string>
+    <string name="settings_influxdb_test_button">傳送測試點</string>
 
 </resources>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -886,7 +886,7 @@
     <string name="settings_webhook_export_title">Webhook Export</string>
     <string name="settings_webhook_export_enable_label">Enable webhook export</string>
     <string name="settings_webhook_export_enabled_hint">JSON POST sent to the URL on every new measurement</string>
-    <string name="settings_webhook_export_disabled_hint">Enable to send measurements to a custom URL (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_disabled_hint">Enable to send measurements to a custom URL</string>
     <string name="settings_webhook_export_url_label">Webhook URL</string>
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Save URL</string>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -891,4 +891,27 @@
     <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
     <string name="settings_webhook_export_save_url">Save URL</string>
     <string name="settings_webhook_export_test_button">Send Test Request</string>
+
+    <!-- InfluxDB Export Settings -->
+    <string name="settings_influxdb_export_title">InfluxDB Export</string>
+    <string name="settings_influxdb_export_enable_label">Enable InfluxDB export</string>
+    <string name="settings_influxdb_export_enabled_hint">Line Protocol POST sent on every new measurement</string>
+    <string name="settings_influxdb_export_disabled_hint">Enable to send measurements directly to InfluxDB</string>
+    <string name="settings_influxdb_version_label">InfluxDB Version</string>
+    <string name="settings_influxdb_host_label">Host URL</string>
+    <string name="settings_influxdb_host_placeholder">http://192.168.1.100:8086</string>
+    <string name="settings_influxdb_database_label">Database (v1) / Bucket (v2)</string>
+    <string name="settings_influxdb_measurement_label">Measurement name</string>
+    <string name="settings_influxdb_username_label">Username (optional)</string>
+    <string name="settings_influxdb_password_label">Password (optional)</string>
+    <string name="settings_influxdb_field_mapping_title">Field Mapping</string>
+    <string name="settings_influxdb_field_mapping_hint">Customize InfluxDB field names to match your existing Grafana dashboards</string>
+    <string name="settings_influxdb_field_weight_label">Weight field name</string>
+    <string name="settings_influxdb_field_body_fat_label">Body fat field name</string>
+    <string name="settings_influxdb_field_water_label">Water field name</string>
+    <string name="settings_influxdb_field_muscle_label">Muscle field name</string>
+    <string name="settings_influxdb_field_lbm_label">Lean body mass field name</string>
+    <string name="settings_influxdb_field_bone_label">Bone mass field name</string>
+    <string name="settings_influxdb_field_visceral_fat_label">Visceral fat field name</string>
+    <string name="settings_influxdb_test_button">Send Test Point</string>
 </resources>

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -881,4 +881,14 @@
     <string name="bt_sbf72_choice_slot_other_user">P%1$d: Used by %2$s (Take over?)</string>
     <string name="bt_sbf72_choice_slot_occupied_unmapped">P%1$d: Occupied (Not linked)</string>
     <string name="bt_sbf72_choice_slot_create_new">P%1$d: Create \'%2$s\' here</string>
+
+    <!-- Webhook Export Settings -->
+    <string name="settings_webhook_export_title">Webhook Export</string>
+    <string name="settings_webhook_export_enable_label">Enable webhook export</string>
+    <string name="settings_webhook_export_enabled_hint">JSON POST sent to the URL on every new measurement</string>
+    <string name="settings_webhook_export_disabled_hint">Enable to send measurements to a custom URL (InfluxDB, Supabase, etc.)</string>
+    <string name="settings_webhook_export_url_label">Webhook URL</string>
+    <string name="settings_webhook_export_url_placeholder">https://your-endpoint.example.com/data</string>
+    <string name="settings_webhook_export_save_url">Save URL</string>
+    <string name="settings_webhook_export_test_button">Send Test Request</string>
 </resources>

--- a/android_app/gradle/libs.versions.toml
+++ b/android_app/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ kotlinCsv = "1.10.0"
 blessedKotlin = "3.0.12"
 truth = "1.4.5"
 bouncycastle = "1.83"
+okhttp = "4.12.0"
 
 
 [libraries]
@@ -69,6 +70,7 @@ kotlin-csv-jvm = { group = "com.github.doyaaaaaken", name = "kotlin-csv-jvm", ve
 blessed-kotlin = { group = "com.github.weliem", name = "blessed-kotlin", version.ref = "blessedKotlin" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 
 
 [plugins]


### PR DESCRIPTION
This PR adds the ability to export weight and body metrics data to an InfluxDB instance.

## Changes
- Added `InfluxDbExportUseCases.kt` with the core export logic
- Added InfluxDB connection settings to `SettingsFacade.kt` and `SettingsViewModel.kt`
- Added export option to the Data Management settings screen (`DataManagementSettingsScreen.kt`)
- Added webhook support for triggering exports
- Added localization strings for the new UI elements (de, el, es, eu, fi, fr, it, and more)
- Updated README with InfluxDB export documentation

## Supported versions
Both InfluxDB v1 and v2 (including InfluxDB Cloud) are supported.

## How it works
Users can configure an InfluxDB connection (URL, token, bucket, org) in the app settings and export their measurements directly to InfluxDB.