### PR TITLE
fix: allow saved devices without a name

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -470,7 +470,7 @@ class SettingsFacadeImpl @Inject constructor(
             val hint        = array[4] as String?
             val manDataJson = array[5] as String?
 
-            if (addr.isNullOrBlank() || name.isNullOrBlank()) {
+            if (addr.isNullOrBlank()) {
                 null
             } else {
                 // Convert to UUID list with stable ordering to keep distinctUntilChanged effective
@@ -491,7 +491,7 @@ class SettingsFacadeImpl @Inject constructor(
                 }
 
                 ScannedDeviceInfo(
-                    name = name,
+                    name = name ?: "",
                     address = addr,
                     rssi = rssi,
                     serviceUuids = uuids,


### PR DESCRIPTION
fixes #1362 by allowing a saved device's name to be empty. In that case the name is set to an empty string in `SettingsFacadeImpl.observeSavedDevice()`.