### PR TITLE
security: restrict READ_WRITE_DATA permission to signature level

### DIFF
--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:name="${applicationId}.READ_WRITE_DATA"
         android:description="@string/permission_read_write_data_description"
         android:label="@string/permission_read_write_data_label"
-        android:protectionLevel="dangerous" />
+        android:protectionLevel="signature" />
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false"/>
 


### PR DESCRIPTION
## Summary
- Changes `android:protectionLevel` on the `READ_WRITE_DATA` custom permission from `dangerous` to `signature`
- Prevents any installed third-party app from requesting and receiving this permission at install time
- Access is now limited to apps signed with the same certificate (official sync companions)

## Security Impact
The exported `DatabaseProvider` ContentProvider was previously accessible to **any** installed app that declared the permission in its manifest — no user interaction required. With `signature`, only apps sharing the openScale signing certificate can access health data via the provider.

## Test plan
- [ ] Verify official sync companion app still connects to the ContentProvider normally
- [ ] Verify a test app with a different signing key is denied access to the provider