### PR TITLE
Fix BLE scan interruption during configuration changes

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/BluetoothScreen.kt
@@ -140,7 +140,7 @@ fun BluetoothScreen(
     DisposableEffect(Unit) {
         onDispose {
             pendingScan = false
-            bluetoothViewModel.requestStopDeviceScan()
+
         }
     }
 


### PR DESCRIPTION
Fixes BLE scanning being interrupted during device rotation/configuration changes.

Previously, rotating the device during an active BLE scan caused the scan to stop immediately before the configured timeout completed.

Root Cause

'BluetoothScreen.kt' stopped scanning inside 'DisposableEffect.onDispose():'
bluetoothViewModel.requestStopDeviceScan()

During configuration changes/activity recreation, the composable is temporarily disposed, which triggered scan termination even though the user was still actively on the Bluetooth screen.

Fix:
Remove the forced scan stop from 'onDispose()' so scans are not interrupted during configuration changes.

Validation

Tested manually on Android Emulator API 34:

* BLE scan now survives device rotation
* Scan no longer stops after ~2 seconds
* No infinite scanning observed after leaving the screen
* No scan leak observed after app close/navigation
* Existing scan timeout behavior still works correctly

Fixes #1379
