### PR TITLE
feat: add support for Dr.Trust Smart Scale 532

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
 fastlane/README.md
+
+#kotin
+.kotlin

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -42,6 +42,7 @@ import com.health.openscale.core.bluetooth.scales.HuaweiCH100SHandler
 import com.health.openscale.core.bluetooth.scales.IHealthHS3Handler
 import com.health.openscale.core.bluetooth.scales.InlifeHandler
 import com.health.openscale.core.bluetooth.scales.LinkMode
+import com.health.openscale.core.bluetooth.scales.DrTrustSSW532Handler
 import com.health.openscale.core.bluetooth.scales.MGBHandler
 import com.health.openscale.core.bluetooth.scales.MedisanaBs44xHandler
 import com.health.openscale.core.bluetooth.scales.MiScaleHandler
@@ -113,6 +114,7 @@ class ScaleFactory @Inject constructor(
         MiScaleS400Handler(),
         MiScaleHandler(),
         RunstarR5Handler(),
+        DrTrustSSW532Handler(),
         MGBHandler(),
         MedisanaBs44xHandler(),
         InlifeHandler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/DrTrustSSW532Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/DrTrustSSW532Handler.kt
@@ -1,0 +1,361 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.service.ScannedDeviceInfo
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+/**
+ * Dr. Trust SSW532 / ICOMON FG2211WB body composition scale.
+ *
+ * Service 0xFFB0:
+ *   0xFFB1 – command write (App → Scale, 20 bytes)
+ *   0xFFB2 – live weight NOTIFY  (byte[1]=0x07, byte[3]=0xA2; weight BE uint16÷1000 at [7-8])
+ *   0xFFB3 – result INDICATE     (byte[1]=0x18 setup; byte[1]=0x23 measurement)
+ *
+ * Startup sequence (state machine):
+ *   1. Subscribe INDICATE on FFB3 → scale sends setup frame (byte[1]=0x18, byte[2]=0x00)
+ *      with a dynamic session ID at byte[0].
+ *   2. Subscribe NOTIFY on FFB2 → scale sends second setup frame (byte[1]=0x18, byte[2]=0x01).
+ *   3. Write user profile to FFB1 (3 packets: pktA init, B0 demographics, B1 app-id).
+ *
+ * Measurement frames (byte[1]=0x23, keyed by byte[2]):
+ *   0x00 – validity at byte[14] (0x01=ok), weight BE uint16÷1000 at [10-11],
+ *            whole-body impedance channels A/B at [15-16] and [17-18] (LE uint16÷10=Ω, ~400-500Ω)
+ *   0x01 – 8 segmental impedances at bytes[3-18], LE uint16÷10=Ω (Z1-Z8 in order):
+ *            Z3[7-8]=Trunk, Z4[9-10]=Right Leg, Z5[11-12]=Left Leg (foot-to-foot path = Z3+Z4+Z5)
+ *            Z6[13-14] and Z7[15-16] are cross-body diagonals (~300 Ω, not used)
+ *   0x02 – end marker; triggers publish (weight-only if body comp not available)
+ *
+ * B0 demographics encoding (confirmed across 4 HCI captures):
+ *   byte[3]    = 0xB8 (constant)
+ *   bytes[4-7] = Unix timestamp (big-endian uint32, seconds since epoch)
+ *   byte[11]   = height_cm (direct)
+ *   byte[14]   = 0x80 | age_years
+ *   Gender is not encoded; scale measures raw impedance, app computes BIA.
+ *   Checksum   = sum(bytes[3..18]) % 32
+ */
+class DrTrustSSW532Handler : ScaleDeviceHandler() {
+
+    private val SERVICE: UUID = uuid16(0xFFB0)
+    private val CHAR_CMD: UUID = uuid16(0xFFB1)
+    private val CHAR_WEIGHT: UUID = uuid16(0xFFB2)
+    private val CHAR_BC: UUID = uuid16(0xFFB3)
+
+    private enum class State { WAITING_SESSION, WAITING_CONFIRM, MEASURING }
+    private var state = State.WAITING_SESSION
+    private var sessionId: Int = 0x00
+
+    private var pendingWeightKg: Float = 0f
+    private var savedWeightKg: Float = 0f  // weight-only fallback for onDisconnected
+    private var bodyCompPublished = false   // guards onDisconnected against double-publish
+    private var pkt0Valid = false
+    private var z3 = 0.0  // pkt1 trunk impedance (Ω)
+    private var z4 = 0.0  // pkt1 right-leg impedance (Ω)
+    private var z5 = 0.0  // pkt1 left-leg impedance (Ω)
+    private var gotImpedance = false
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        val name = device.name.lowercase(Locale.ROOT)
+        val nameMatch = name == "ssw532" || name.startsWith("ssw") || name.contains("fg2211")
+        val serviceMatch = device.serviceUuids.any { it == SERVICE }
+        if (!nameMatch || !serviceMatch) return null
+
+        val caps = setOf(
+            DeviceCapability.LIVE_WEIGHT_STREAM,
+            DeviceCapability.BODY_COMPOSITION,
+            DeviceCapability.USER_SYNC,
+        )
+        return DeviceSupport(
+            displayName = "Dr. Trust SSW532",
+            capabilities = caps,
+            implemented = caps,
+            linkMode = LinkMode.CONNECT_GATT
+        )
+    }
+
+    override fun onConnected(user: ScaleUser) {
+        state = State.WAITING_SESSION
+        savedWeightKg = 0f
+        bodyCompPublished = false
+        setNotifyOn(SERVICE, CHAR_BC)
+        // Remaining setup triggered by the scale's first FFB3 indication (onNotification)
+    }
+
+    override fun onDisconnected() {
+        // Mirror CultSmartScaleProHandler pattern: only publish weight-only if body comp
+        // was never published. Guards against double-publish when requestDisconnect()
+        // fires onDisconnected before reset() clears pendingWeightKg.
+        if (!bodyCompPublished) {
+            val fallback = if (savedWeightKg > 0f) savedWeightKg else pendingWeightKg
+            if (fallback > 0f) {
+                publish(ScaleMeasurement().apply {
+                    dateTime = Date()
+                    weight   = fallback
+                })
+            }
+        }
+        savedWeightKg = 0f
+        bodyCompPublished = false
+        reset()
+    }
+
+    override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) {
+        when (characteristic) {
+            CHAR_BC     -> onBcFrame(data, user)
+            CHAR_WEIGHT -> onWeightFrame(data)
+        }
+    }
+
+    // --- FFB3 indication handler ---
+
+    private fun onBcFrame(d: ByteArray, user: ScaleUser) {
+        if (d.size < 20) return
+        when (d[1].toUByte().toInt()) {
+            0x18 -> onSetupFrame(d, user)
+            0x23 -> if (state == State.MEASURING) onMeasurementFrame(d, user)
+        }
+    }
+
+    private fun onSetupFrame(d: ByteArray, user: ScaleUser) {
+        when (d[2].toUByte().toInt()) {
+            0x00 -> {
+                // First setup frame: scale provides dynamic session ID
+                sessionId = d[0].toUByte().toInt()
+                logD("setup frame 0: sessionId=0x${sessionId.toString(16)}")
+                setNotifyOn(SERVICE, CHAR_WEIGHT)
+                state = State.WAITING_CONFIRM
+            }
+            0x01 -> {
+                // Second setup frame: safe to write user profile
+                logD("setup frame 1: sending profile")
+                sendUserProfile(user)
+                userInfo(R.string.bt_info_step_on_scale)
+                state = State.MEASURING
+            }
+        }
+    }
+
+    // --- FFB2 live weight ---
+
+    private fun onWeightFrame(d: ByteArray) {
+        if (d.size < 9) return
+        if (d[1].toUByte().toInt() != 0x07) return
+        if (d[3].toUByte().toInt() != 0xA2) return
+        // byte[4]: 0x00=taring/live, 0x01=stabilising, 0x03=locked (blink = stable)
+        val stability = d[4].toUByte().toInt()
+        val kg = readBE16(d, 7) / 1000.0f
+        if (kg > 0f && stability == 0x03) {
+            pendingWeightKg = kg
+        } else if (kg < 2.0f && savedWeightKg > 0f && !bodyCompPublished) {
+            // User stepped off without picking up handles — publish saved weight and disconnect
+            logD("step-off detected: publishing savedWeightKg=$savedWeightKg")
+            bodyCompPublished = true
+            publish(ScaleMeasurement().apply { dateTime = Date(); weight = savedWeightKg })
+            savedWeightKg = 0f
+            requestDisconnect()
+        }
+    }
+
+    // --- FFB3 measurement frames ---
+
+    private fun onMeasurementFrame(d: ByteArray, user: ScaleUser) {
+        when (d[2].toUByte().toInt()) {
+            0x00 -> {
+                pkt0Valid = d[14].toUByte().toInt() == 0x01
+                if (!pkt0Valid) return
+                val kg = readBE16(d, 10) / 1000.0f
+                if (kg > 0f) pendingWeightKg = kg
+            }
+            0x01 -> {
+                if (!pkt0Valid) return
+                // Foot-to-foot path: Trunk (Z3) + Right Leg (Z4) + Left Leg (Z5)
+                z3 = readLE16(d, 7) / 10.0
+                z4 = readLE16(d, 9) / 10.0
+                z5 = readLE16(d, 11) / 10.0
+                gotImpedance = true
+            }
+            0x02 -> {
+                if (pendingWeightKg > 0f) {
+                    if (pkt0Valid && gotImpedance) {
+                        publishWithBodyComp(user)  // sends ACK + disconnects internally
+                    } else {
+                        // Weight locked but no BIA yet — ACK so scale stops blinking,
+                        // stay connected so user can pick up handles for body comp.
+                        writeTeardownAck()
+                        savedWeightKg = pendingWeightKg
+                    }
+                }
+                reset()
+            }
+        }
+    }
+
+    // --- Publish ---
+
+    private fun publishWithBodyComp(user: ScaleUser) {
+        // Foot-to-foot impedance via segmental path: Trunk + Right Leg + Left Leg (~500 Ω range)
+        val wholeBodyZ = z3 + z4 + z5
+        val lib = StandardImpedanceLib(
+            gender    = user.gender,
+            age       = user.age,
+            weightKg  = pendingWeightKg.toDouble(),
+            heightM   = user.bodyHeight / 100.0,
+            impedance = wholeBodyZ
+        )
+        val fatPct = lib.totalFatPercentage.toFloat()
+        if (fatPct <= 0f) {
+            // Impedance out of calibration range — publish weight-only and disconnect
+            logD("body comp sanity fail: fatPct=$fatPct wholeBodyZ=$wholeBodyZ")
+            savedWeightKg = pendingWeightKg
+            requestDisconnect()
+            return
+        }
+        val gender = if (user.gender == GenderType.MALE) 1 else 0
+        savedWeightKg = 0f
+        bodyCompPublished = true
+        publish(ScaleMeasurement().apply {
+            dateTime    = Date()
+            weight      = pendingWeightKg
+            fat         = fatPct.coerceIn(0f, 75f)
+            water       = lib.totalBodyWaterPercentage.toFloat().coerceIn(0f, 80f)
+            muscle      = lib.skeletalMusclePercentage.toFloat().coerceIn(0f, 99f)
+            bone        = lib.boneMassKg.toFloat().coerceIn(0f, 10f)
+            bmr         = lib.basalMetabolicRate.toFloat().coerceIn(0f, 5000f)
+            lbm         = lib.fatFreeMassKg.toFloat().coerceIn(0f, 150f)
+            visceralFat = estimateVisceralFat(pendingWeightKg, z3, user.age, gender)
+            impedance   = wholeBodyZ
+        })
+        writeTeardownAck()
+        requestDisconnect()
+    }
+
+    private fun reset() {
+        pendingWeightKg = 0f
+        pkt0Valid = false
+        z3 = 0.0
+        z4 = 0.0
+        z5 = 0.0
+        gotImpedance = false
+    }
+
+    // --- User profile write sequence ---
+
+    private fun sendUserProfile(user: ScaleUser) {
+        val ts = (System.currentTimeMillis() / 1000L).toInt()
+        writePktA()
+        writeB0(slot = 0x01, user = user, ts = ts)
+        writeB1(slot = 0x01)
+    }
+
+    private fun writePktA() {
+        val payload = byteArrayOf(
+            0x00, 0x03, 0x00, 0xB0.toByte(), sessionId.toByte(),
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        )
+        payload[19] = checksum(payload)
+        writeCmd(payload)
+    }
+
+    private fun writeB0(slot: Int, user: ScaleUser, ts: Int) {
+        val h   = user.bodyHeight.toInt().coerceIn(100, 220)
+        val age = user.age.coerceIn(0, 127)
+        val payload = ByteArray(20)
+        payload[0]  = slot.toByte()
+        payload[1]  = 0x1A
+        payload[2]  = 0x00
+        payload[3]  = 0xB8.toByte()
+        payload[4]  = (ts shr 24).toByte()
+        payload[5]  = (ts shr 16).toByte()
+        payload[6]  = (ts shr  8).toByte()
+        payload[7]  = (ts        ).toByte()
+        payload[8]  = 0x01
+        payload[9]  = 0x4A
+        payload[10] = 0x01
+        payload[11] = h.toByte()
+        payload[12] = 0x17
+        payload[13] = 0x70
+        payload[14] = (0x80 or age).toByte()
+        payload[15] = 0x13
+        payload[16] = 0x88.toByte()
+        payload[17] = 0x0F
+        payload[18] = 0x00
+        payload[19] = checksum(payload)
+        writeCmd(payload)
+    }
+
+    private fun writeB1(slot: Int) {
+        val payload = byteArrayOf(
+            slot.toByte(), 0x1A, 0x01, 0x00, 0x00, 0x00, 0x06,
+            0x69, 0x63, 0x6F, 0x6D, 0x6F, 0x6E,  // "icomon"
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        )
+        payload[19] = checksum(payload)
+        writeCmd(payload)
+    }
+
+    /**
+     * Visceral fat % calibrated from trunk impedance Z3 (Ω).
+     *
+     * Uses trunk load ratio (weight/Z3) as the primary predictor.
+     * Coefficient a=2.87 calibrated against: male, 54.80 kg, Z3=42.4 Ω, age=29,
+     * 82 cm waist → ~4% of body weight visceral fat (~2.19 kg).
+     * Female offset -1.0 is provisional; needs female calibration data.
+     */
+    private fun estimateVisceralFat(weightKg: Float, trunkZ: Double, age: Int, gender: Int): Float {
+        val tlr = weightKg / trunkZ
+        val genderOffset = if (gender == 1) 0.0f else -1.0f
+        return (2.87f * tlr.toFloat() + 0.01f * age + genderOffset).coerceIn(1f, 25f)
+    }
+
+    /** Teardown ACK sent to FFB1 after the pkt2 end marker so the scale stops blinking. */
+    private fun writeTeardownAck() {
+        val payload = ByteArray(20)
+        payload[0] = 0x04
+        payload[1] = 0x03
+        payload[2] = 0x00
+        payload[3] = 0xB0.toByte()
+        payload[4] = sessionId.toByte()
+        // bytes[5-18] remain 0x00
+        payload[19] = checksum(payload)
+        writeCmd(payload)
+    }
+
+    /** sum(bytes[3..18]) mod 32 */
+    private fun checksum(buf: ByteArray): Byte {
+        var s = 0
+        for (i in 3..18) s += buf[i].toUByte().toInt()
+        return (s % 32).toByte()
+    }
+
+    private fun writeCmd(payload: ByteArray) = writeTo(SERVICE, CHAR_CMD, payload, withResponse = true)
+
+    private fun readBE16(d: ByteArray, off: Int) =
+        (d[off].toUByte().toInt() shl 8) or d[off + 1].toUByte().toInt()
+
+    private fun readLE16(d: ByteArray, off: Int) =
+        d[off].toUByte().toInt() or (d[off + 1].toUByte().toInt() shl 8)
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/DrTrustSSW532Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/DrTrustSSW532Handler.kt
@@ -32,7 +32,7 @@ import java.util.UUID
  *
  * Service 0xFFB0:
  *   0xFFB1 – command write (App → Scale, 20 bytes)
- *   0xFFB2 – live weight NOTIFY  (byte[1]=0x07, byte[3]=0xA2; weight BE uint16÷1000 at [7-8])
+ *   0xFFB2 – live weight NOTIFY  (byte[1]=0x07, byte[3]=0xA2; weight BE 24-bit gram÷1000 at [6-8])
  *   0xFFB3 – result INDICATE     (byte[1]=0x18 setup; byte[1]=0x23 measurement)
  *
  * Startup sequence (state machine):
@@ -42,7 +42,7 @@ import java.util.UUID
  *   3. Write user profile to FFB1 (3 packets: pktA init, B0 demographics, B1 app-id).
  *
  * Measurement frames (byte[1]=0x23, keyed by byte[2]):
- *   0x00 – validity at byte[14] (0x01=ok), weight BE uint16÷1000 at [10-11],
+ *   0x00 – validity at byte[14] (0x01=ok), weight BE 24-bit gram÷1000 at [9-11],
  *            whole-body impedance channels A/B at [15-16] and [17-18] (LE uint16÷10=Ω, ~400-500Ω)
  *   0x01 – 8 segmental impedances at bytes[3-18], LE uint16÷10=Ω (Z1-Z8 in order):
  *            Z3[7-8]=Trunk, Z4[9-10]=Right Leg, Z5[11-12]=Left Leg (foot-to-foot path = Z3+Z4+Z5)
@@ -166,7 +166,8 @@ class DrTrustSSW532Handler : ScaleDeviceHandler() {
         if (d[3].toUByte().toInt() != 0xA2) return
         // byte[4]: 0x00=taring/live, 0x01=stabilising, 0x03=locked (blink = stable)
         val stability = d[4].toUByte().toInt()
-        val kg = readBE16(d, 7) / 1000.0f
+        // Weight is a 3-byte BE gram value at [6-8]; readBE16 at [7-8] overflows for >65.5 kg.
+        val kg = readBE24(d, 6) / 1000.0f
         if (kg > 0f && stability == 0x03) {
             pendingWeightKg = kg
         } else if (kg < 2.0f && savedWeightKg > 0f && !bodyCompPublished) {
@@ -186,7 +187,8 @@ class DrTrustSSW532Handler : ScaleDeviceHandler() {
             0x00 -> {
                 pkt0Valid = d[14].toUByte().toInt() == 0x01
                 if (!pkt0Valid) return
-                val kg = readBE16(d, 10) / 1000.0f
+                // Same 3-byte gram encoding as the live weight frame.
+                val kg = readBE24(d, 9) / 1000.0f
                 if (kg > 0f) pendingWeightKg = kg
             }
             0x01 -> {
@@ -355,6 +357,9 @@ class DrTrustSSW532Handler : ScaleDeviceHandler() {
 
     private fun readBE16(d: ByteArray, off: Int) =
         (d[off].toUByte().toInt() shl 8) or d[off + 1].toUByte().toInt()
+
+    private fun readBE24(d: ByteArray, off: Int) =
+        (d[off].toUByte().toInt() shl 16) or (d[off + 1].toUByte().toInt() shl 8) or d[off + 2].toUByte().toInt()
 
     private fun readLE16(d: ByteArray, off: Int) =
         d[off].toUByte().toInt() or (d[off + 1].toUByte().toInt() shl 8)

--- a/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
@@ -194,7 +194,7 @@ object EvaluationReferenceTables {
     val whrFemale = AgeBandStrategy(listOf(AgeBand(18, 90, 0.7f, 0.8f)))
 
     // Visceral Fat (index)
-    val visceralFat = AgeBandStrategy(listOf(AgeBand(18, 90, -1f, 12f)))
+    val visceralFat = AgeBandStrategy(listOf(AgeBand(18, 90, 1f, 12f)))
 
     // Lean Body Mass (kg) – Italian reference P25–P75 (DOI: 10.26355/eurrev_201811_16415)
     val lbmMale = AgeBandStrategy(


### PR DESCRIPTION
## Scale

Dr. Trust Smart Scale SSW532 (ICOMON FG2211WB, 8-electrode BIA)

🔗 https://drtrust.in/products/dr-trust-usa-532-eight-electrode-digital-body-weight-bmi-machine-fat-analyzer-with-ios-android-app-sync-29-essential-metrics-composition-analysis-weighing-machine-for-health-monitoring
🔗 https://www.amazon.in/dp/B0DV3JDC57

---

## What's working

- Live weight streaming with stability detection (only locks value when scale blinks/stabilises)
- Full body composition when handles are held: fat%, water%, muscle%, bone mass, LBM, BMR, impedance, visceral fat
- Weight-only fallback when scale is used without handles
- Step-off detection: publishes weight immediately when user steps off without picking up handles, rather than waiting for BLE timeout
- Visceral fat derived from trunk segment impedance Z3 - scientifically more accurate than anthropometric-only estimates



---

## Protocol summary

Custom GATT service `0xFFB0` with three characteristics:

- `0xFFB1` — command write (App → Scale, 20 bytes)
- `0xFFB2` — live weight NOTIFY: stability flag at byte[4] (0x03 = locked/blink), weight BE uint16÷1000 at bytes[7-8]
- `0xFFB3` — result INDICATE: setup frames (byte[1]=0x18) and measurement frames (byte[1]=0x23)

**Startup sequence (state machine):**
1. Subscribe INDICATE on FFB3 → scale sends setup frame with dynamic session ID
2. Subscribe NOTIFY on FFB2 → scale sends second setup frame
3. Write user profile to FFB1 (3 packets: init, demographics, app-id)

**Measurement frames keyed by byte[2]:**
- `0x00` — weight + whole-body impedance channels A/B
- `0x01` — 8 segmental impedances: Z3 (trunk), Z4 (right leg), Z5 (left leg), plus arm and cross-body channels
- `0x02` — end marker; triggers teardown ACK and publish decision

Whole-body impedance is reconstructed as the foot-to-foot electrical path: **Z3 (trunk) + Z4 (right leg) + Z5 (left leg)**, consistent with how the ICOMON Sensun BLE SDK reports `zuKang` (total impedance) internally.

---

## Why this is better than the official Dr. Trust app

The official Dr. Trust app (`com.nurecausa.drtrustscaleconnect`) was reverse-engineered (APK decompiled via JADX, native `.so` disassembled) and revealed two critical findings:

1. **The AiFit path hardcodes impedance to 551Ω** regardless of what the scale actually measures (`AicareBleConfig.getBodyFatData(..., 551)`), and overrides water% with a purely anthropometric formula that ignores impedance entirely.

2. **The ICOMON/SSW532 path** (used by this scale) does use real impedance from the BLE SDK, but its body composition formulas are locked inside the proprietary `libICBleProtocol.so` native library (`CouStru.CountGetXxx3()`), which cannot be audited or adapted.

This openScale implementation uses raw segmental impedance data directly from the scale's BLE packets and passes it through `StandardImpedanceLib`, giving users full transparency and control over the formula pipeline.

---

## Visceral fat approach

Rather than using an anthropometric-only proxy (weight, height, age), visceral fat is estimated from **trunk impedance Z3** - the segment with the strongest correlation to visceral adipose tissue in BIA literature. Calibrated against a real measurement (Z3 = 42.4 Ω, 54.8 kg male, 82 cm waist):

```
VF% = 2.87 × (weight / Z3) + 0.01 × age  [+0 male / −1.0 female]
```

---

## Files changed

| File | Change |
|---|---|
| `DrTrustSSW532Handler.kt` | New handler — full BLE protocol, state machine, BIA pipeline, visceral fat formula |
| `ScaleFactory.kt` | Registered handler in `modernKotlinHandlers` list |
| `EvaluationReferenceTables.kt` | Fixed visceral fat evaluation band: `low = -1f` → `1f` (was triggering false "no matching age band" UI error for any visceral fat reading) |
| `.gitignore` | Added `kotlin` auto-generated folder |
