### PR TITLE
enhancement: chart toggle, scrollable chart, and measurement card col…

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/facade/SettingsFacade.kt
@@ -1,6 +1,7 @@
 /*
  * openScale
  * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ * Copyright (C) 2026 openScale+ Dharmendra Gupta
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,6 +78,8 @@ object SettingsPreferenceKeys {
     // Settings for specific UI components
     val SELECTED_TYPES_TABLE = stringSetPreferencesKey("selected_types_table") // IDs of measurement types selected for the data table
     val MY_GOALS_EXPANDED_OVERVIEW = booleanPreferencesKey("my_goals_expanded")
+    val SHOW_OVERVIEW_CHART = booleanPreferencesKey("show_overview_chart")
+    val OVERVIEW_CHART_SCROLLABLE = booleanPreferencesKey("overview_chart_scrollable")
 
     // Saved Bluetooth Scale
     val SAVED_BLUETOOTH_DEVICE_ADDRESS        = stringPreferencesKey("saved_bluetooth_device_address")
@@ -183,6 +186,12 @@ interface SettingsFacade {
 
     val myGoalsExpandedOverview: Flow<Boolean>
     suspend fun setMyGoalsExpandedOverview(isExpanded: Boolean)
+
+    val showOverviewChart: Flow<Boolean>
+    suspend fun setShowOverviewChart(show: Boolean)
+
+    val overviewChartScrollable: Flow<Boolean>
+    suspend fun setOverviewChartScrollable(scrollable: Boolean)
 
     fun observeSplitterWeight(keyPrefix: String, defaultValue: Float): Flow<Float>
     suspend fun setSplitterWeight(keyPrefix : String, weight: Float)
@@ -364,6 +373,24 @@ class SettingsFacadeImpl @Inject constructor(
     override suspend fun setHapticOnMeasurement(value: Boolean) {
         LogManager.d(TAG, "Setting hapticOnMeasurement to: $value")
         saveSetting(SettingsPreferenceKeys.HAPTIC_ON_MEASUREMENT.name, value)
+    }
+
+    override val showOverviewChart: Flow<Boolean> = observeSetting(
+        SettingsPreferenceKeys.SHOW_OVERVIEW_CHART.name,
+        true
+    )
+
+    override suspend fun setShowOverviewChart(show: Boolean) {
+        saveSetting(SettingsPreferenceKeys.SHOW_OVERVIEW_CHART.name, show)
+    }
+
+    override val overviewChartScrollable: Flow<Boolean> = observeSetting(
+        SettingsPreferenceKeys.OVERVIEW_CHART_SCROLLABLE.name,
+        false
+    )
+
+    override suspend fun setOverviewChartScrollable(scrollable: Boolean) {
+        saveSetting(SettingsPreferenceKeys.OVERVIEW_CHART_SCROLLABLE.name, scrollable)
     }
 
     override val useDynamicColor: Flow<Boolean> = observeSetting(

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/overview/OverviewScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/overview/OverviewScreen.kt
@@ -1,6 +1,7 @@
 /*
  * openScale
  * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ * Copyright (C) 2026 openScale+ Dharmendra Gupta
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -211,6 +212,8 @@ fun OverviewScreen(
         remember { mutableStateOf(emptyList<UserGoals>()) }
     }
     val isGoalsSectionExpanded by sharedViewModel.myGoalsExpandedOverview.collectAsState(initial = true)
+    val showOverviewChart by sharedViewModel.showOverviewChart.collectAsState(initial = true)
+    val overviewChartScrollable by sharedViewModel.overviewChartScrollable.collectAsState(initial = false)
     val userEvalContext        by sharedViewModel.userEvaluationContext.collectAsState()
     val currentSelectedUser   by sharedViewModel.selectedUser.collectAsState()
 
@@ -355,85 +358,94 @@ fun OverviewScreen(
                                 }
                             }
 
-                            // ── Chart + divider + goals (hidden in drill-down) ────────
-                            if (!isDrillDown) {
-                                Box(modifier = Modifier.weight(localSplitterWeight)) {
-                                    MeasurementChart(
-                                        sharedViewModel   = sharedViewModel,
-                                        screenContextName = SettingsPreferenceKeys.OVERVIEW_SCREEN_CONTEXT,
-                                        showFilterControls = true,
-                                        modifier          = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                                        showYAxis         = false,
-                                        onPointSelected   = { selectedTs ->
-                                            if (isAggregated) {
-                                                // AggregatedMeasurement carries pre-computed period bounds —
-                                                // no need to call periodBoundsFor().
-                                                val idx = aggregatedItems.indexOfFirst { item ->
-                                                    selectedTs in item.periodStartMillis until item.periodEndMillis
-                                                }
-                                                if (idx >= 0) {
-                                                    val itemTs = aggregatedItems[idx]
-                                                        .enriched.measurementWithValues.measurement.timestamp
-                                                    scope.launch {
-                                                        listState.smartScrollTo(idx)
-                                                        highlightedMeasurementId =
-                                                            aggregatedItems[idx].enriched.measurementWithValues.measurement.id
-                                                        currentSelectedAggregatedTs = itemTs
-                                                        delay(600)
-                                                        highlightedMeasurementId = null
-                                                    }
-                                                }
-                                            } else {
-                                                val listForFind = aggregatedItems.map {
-                                                    it.enriched.measurementWithValues
-                                                }
-                                                sharedViewModel
-                                                    .findClosestMeasurement(selectedTs, listForFind)
-                                                    ?.let { (targetIndex, mwv) ->
-                                                        val targetId = mwv.measurement.id
-                                                        scope.launch {
-                                                            listState.smartScrollTo(targetIndex)
-                                                            highlightedMeasurementId          = targetId
-                                                            currentSelectedMeasurementId      = targetId
-                                                            delay(600)
-                                                            if (highlightedMeasurementId == targetId)
-                                                                highlightedMeasurementId = null
-                                                        }
-                                                    }
-                                            }
-                                        },
-                                    )
-                                }
+                            // Chart offset: when chart is inside LazyColumn as item 0, measurements shift by 1.
+                            val chartScrollOffset = if (showOverviewChart && !isDrillDown && overviewChartScrollable) 1 else 0
 
-                                // Draggable divider
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .pointerInput(Unit) {
-                                            detectDragGestures(
-                                                onDrag    = { change, dragAmount ->
-                                                    change.consume()
-                                                    localSplitterWeight =
-                                                        (localSplitterWeight + dragAmount.y / 2000f)
-                                                            .coerceIn(0.01f, 0.8f)
-                                                },
-                                                onDragEnd = {
-                                                    scope.launch {
-                                                        sharedViewModel.setSplitterWeight(
-                                                            SettingsPreferenceKeys.OVERVIEW_SCREEN_CONTEXT,
-                                                            localSplitterWeight,
-                                                        )
-                                                    }
-                                                },
-                                            )
-                                        },
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    HorizontalDivider(
-                                        thickness = 1.dp,
-                                        color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
-                                    )
+                            // Shared point-selection handler used by both fixed and scrollable chart.
+                            val onChartPointSelected: (Long) -> Unit = { selectedTs ->
+                                if (isAggregated) {
+                                    // AggregatedMeasurement carries pre-computed period bounds —
+                                    // no need to call periodBoundsFor().
+                                    val idx = aggregatedItems.indexOfFirst { item ->
+                                        selectedTs in item.periodStartMillis until item.periodEndMillis
+                                    }
+                                    if (idx >= 0) {
+                                        val itemTs = aggregatedItems[idx]
+                                            .enriched.measurementWithValues.measurement.timestamp
+                                        scope.launch {
+                                            listState.smartScrollTo(idx + chartScrollOffset)
+                                            highlightedMeasurementId =
+                                                aggregatedItems[idx].enriched.measurementWithValues.measurement.id
+                                            currentSelectedAggregatedTs = itemTs
+                                            delay(600)
+                                            highlightedMeasurementId = null
+                                        }
+                                    }
+                                } else {
+                                    val listForFind = aggregatedItems.map {
+                                        it.enriched.measurementWithValues
+                                    }
+                                    sharedViewModel
+                                        .findClosestMeasurement(selectedTs, listForFind)
+                                        ?.let { (targetIndex, mwv) ->
+                                            val targetId = mwv.measurement.id
+                                            scope.launch {
+                                                listState.smartScrollTo(targetIndex + chartScrollOffset)
+                                                highlightedMeasurementId          = targetId
+                                                currentSelectedMeasurementId      = targetId
+                                                delay(600)
+                                                if (highlightedMeasurementId == targetId)
+                                                    highlightedMeasurementId = null
+                                            }
+                                        }
                                 }
+                            }
+
+                            // ── Chart + divider + goals (hidden in drill-down or when toggled off) ──
+                            if (!isDrillDown && showOverviewChart) {
+                                // Fixed chart with draggable splitter (hidden when scrollable mode is on)
+                                if (!overviewChartScrollable) {
+                                    Box(modifier = Modifier.weight(localSplitterWeight)) {
+                                        MeasurementChart(
+                                            sharedViewModel    = sharedViewModel,
+                                            screenContextName  = SettingsPreferenceKeys.OVERVIEW_SCREEN_CONTEXT,
+                                            showFilterControls = true,
+                                            modifier           = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                                            showYAxis          = false,
+                                            onPointSelected    = onChartPointSelected,
+                                        )
+                                    }
+
+                                    // Draggable divider
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .pointerInput(Unit) {
+                                                detectDragGestures(
+                                                    onDrag    = { change, dragAmount ->
+                                                        change.consume()
+                                                        localSplitterWeight =
+                                                            (localSplitterWeight + dragAmount.y / 2000f)
+                                                                .coerceIn(0.01f, 0.8f)
+                                                    },
+                                                    onDragEnd = {
+                                                        scope.launch {
+                                                            sharedViewModel.setSplitterWeight(
+                                                                SettingsPreferenceKeys.OVERVIEW_SCREEN_CONTEXT,
+                                                                localSplitterWeight,
+                                                            )
+                                                        }
+                                                    },
+                                                )
+                                            },
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        HorizontalDivider(
+                                            thickness = 1.dp,
+                                            color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                                        )
+                                    }
+                                } // end fixed chart + divider block
 
                                 // Goals section
                                 if (userGoals.isNotEmpty()) {
@@ -553,11 +565,30 @@ fun OverviewScreen(
                             LazyColumn(
                                 state                 = listState,
                                 modifier              = Modifier
-                                    .weight(if (isDrillDown) 1f else 1f - localSplitterWeight)
+                                    .weight(if (isDrillDown || !showOverviewChart || overviewChartScrollable) 1f else 1f - localSplitterWeight)
                                     .fillMaxSize()
                                     .padding(horizontal = 16.dp, vertical = 8.dp),
                                 verticalArrangement   = Arrangement.spacedBy(12.dp),
                             ) {
+                                // Scrollable chart as the first list item.
+                                // Needs an explicit height because LazyColumn has unbounded height
+                                // and MeasurementChart uses weight() modifiers internally.
+                                if (!isDrillDown && showOverviewChart && overviewChartScrollable) {
+                                    item(key = "overview_chart") {
+                                        MeasurementChart(
+                                            sharedViewModel    = sharedViewModel,
+                                            screenContextName  = SettingsPreferenceKeys.OVERVIEW_SCREEN_CONTEXT,
+                                            showFilterControls = true,
+                                            modifier           = Modifier
+                                                .fillMaxWidth()
+                                                .height(260.dp)
+                                                .padding(bottom = 8.dp),
+                                            showYAxis          = false,
+                                            onPointSelected    = onChartPointSelected,
+                                        )
+                                    }
+                                }
+
                                 itemsIndexed(
                                     items = aggregatedItems,
                                     key   = { _, item ->
@@ -566,7 +597,7 @@ fun OverviewScreen(
                                         else
                                             item.enriched.measurementWithValues.measurement.id
                                     },
-                                ) { _, aggItem ->
+                                ) { index, aggItem ->
                                     val enrichedItem = aggItem.enriched
                                     val ts           = enrichedItem.measurementWithValues.measurement.timestamp
 
@@ -620,6 +651,7 @@ fun OverviewScreen(
                                             onDelete                  = { measurementToDelete = aggItem },
                                             isHighlighted             = (highlightedMeasurementId ==
                                                     enrichedItem.measurementWithValues.measurement.id),
+                                            initiallyExpanded         = index == 0,
                                         )
                                     }
                                 }
@@ -738,6 +770,7 @@ fun MeasurementCard(
     isAggregated: Boolean = false,
     rawCount: Int = 1,
     aggregatedPeriodLabel: String = "",
+    initiallyExpanded: Boolean = false,
 ) {
     val surfaceAtElevation = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
     val isLightSurface     = surfaceAtElevation.luminance() > 0.5f
@@ -759,7 +792,7 @@ fun MeasurementCard(
         }
     }
 
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
 
     val pinnedValues = remember(processedValuesForDisplay) {
         processedValuesForDisplay.filter { it.currentValue.type.isPinned && it.currentValue.type.isEnabled }
@@ -820,7 +853,7 @@ fun MeasurementCard(
                             tint               = actionIconColor,
                         )
                     }
-                    if (nonPinnedValues.isNotEmpty() && pinnedValues.isEmpty()) {
+                    if (allActiveProcessedValues.isNotEmpty()) {
                         IconButton(
                             onClick  = { isExpanded = !isExpanded },
                             modifier = Modifier.size(iconButtonSize),
@@ -836,71 +869,41 @@ fun MeasurementCard(
                 }
             }
 
-            Column(
-                modifier = Modifier.padding(
-                    start   = 16.dp,
-                    end     = 16.dp,
-                    top     = if (pinnedValues.isNotEmpty()) 8.dp else 0.dp,
-                    bottom  = 0.dp,
-                ),
-            ) {
-                if (pinnedValues.isNotEmpty()) {
-                    Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
-                        pinnedValues.forEach { valueWithTrend ->
-                            MeasurementRowExpandable(
-                                sharedViewModel       = sharedViewModel,
-                                valueWithTrend        = valueWithTrend,
-                                userEvaluationContext = userEvaluationContext,
-                                measuredAtMillis      = measuredAtMillis,
-                                expandedTypeIds       = expandedTypeIds,
-                                valuePrefix           = if (isAggregated && rawCount > 1) "⌀ " else "",
-                            )
-                        }
+            // All values hidden when collapsed; toggled by the header icon and the bottom button.
+            AnimatedVisibility(visible = isExpanded) {
+                Column(
+                    modifier = Modifier.padding(
+                        start   = 16.dp,
+                        end     = 16.dp,
+                        top     = 8.dp,
+                        bottom  = 0.dp,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(0.dp),
+                ) {
+                    (pinnedValues + nonPinnedValues).forEach { valueWithTrend ->
+                        MeasurementRowExpandable(
+                            sharedViewModel       = sharedViewModel,
+                            valueWithTrend        = valueWithTrend,
+                            userEvaluationContext = userEvaluationContext,
+                            measuredAtMillis      = measuredAtMillis,
+                            expandedTypeIds       = expandedTypeIds,
+                            valuePrefix           = if (isAggregated && rawCount > 1) "⌀ " else "",
+                        )
                     }
                 }
             }
 
-            if (nonPinnedValues.isNotEmpty()) {
-                AnimatedVisibility(visible = isExpanded || pinnedValues.isEmpty()) {
-                    Column(
-                        modifier            = Modifier.padding(start = 16.dp, end = 16.dp),
-                        verticalArrangement = Arrangement.spacedBy(0.dp),
-                    ) {
-                        nonPinnedValues.forEach { valueWithTrend ->
-                            MeasurementRowExpandable(
-                                sharedViewModel       = sharedViewModel,
-                                valueWithTrend        = valueWithTrend,
-                                userEvaluationContext = userEvaluationContext,
-                                measuredAtMillis      = measuredAtMillis,
-                                expandedTypeIds       = expandedTypeIds,
-                                valuePrefix           = if (isAggregated && rawCount > 1) "⌀ " else "",
-                            )
-                        }
-                    }
-                }
-            }
-
-            if (nonPinnedValues.isNotEmpty() && (pinnedValues.isNotEmpty() || !isExpanded)) {
-                if (isExpanded || pinnedValues.isNotEmpty()) {
-                    HorizontalDivider(
-                        modifier = Modifier.padding(
-                            top    = if (isExpanded && nonPinnedValues.isNotEmpty()) 4.dp
-                            else if (pinnedValues.isNotEmpty()) 8.dp else 0.dp,
-                            bottom = 0.dp,
-                        ),
-                    )
-                }
+            if (allActiveProcessedValues.isNotEmpty() && isExpanded) {
+                HorizontalDivider(modifier = Modifier.padding(top = 4.dp))
                 TextButton(
                     onClick   = { isExpanded = !isExpanded },
                     modifier  = Modifier.fillMaxWidth().height(48.dp),
                     shape     = MaterialTheme.shapes.extraSmall,
                 ) {
                     Icon(
-                        imageVector        = if (isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                        imageVector        = Icons.Filled.ExpandLess,
                         tint               = MaterialTheme.colorScheme.secondary,
-                        contentDescription = stringResource(
-                            if (isExpanded) R.string.action_show_less_desc else R.string.action_show_more_desc
-                        ),
+                        contentDescription = stringResource(R.string.action_show_less_desc),
                     )
                 }
             }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/GeneralSettingsScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/GeneralSettingsScreen.kt
@@ -1,6 +1,7 @@
 /*
  * openScale
  * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ * Copyright (C) 2026 openScale+ Dharmendra Gupta
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,6 +47,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Assessment
 import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Info
@@ -128,6 +130,8 @@ fun GeneralSettingsScreen(
     val hapticsEnabled by sharedViewModel.hapticOnMeasurement.collectAsState(initial = false)
     val useDynamicColor by sharedViewModel.useDynamicColor.collectAsState(initial = false)
     val useHighContrast by sharedViewModel.useHighContrast.collectAsState(initial = false)
+    val showOverviewChart by sharedViewModel.showOverviewChart.collectAsState(initial = true)
+    val overviewChartScrollable by sharedViewModel.overviewChartScrollable.collectAsState(initial = false)
 
     val selectedLanguage: SupportedLanguage = remember(currentLanguageCode, supportedLanguagesEnumEntries) {
         val systemDefault = SupportedLanguage.getDefault().code
@@ -388,6 +392,38 @@ fun GeneralSettingsScreen(
                 scope.launch { sharedViewModel.setHighContrast(enabled) }
             }
         )
+
+        SettingsGroup(
+            leadingIcon = {
+                Icon(
+                    imageVector        = Icons.Filled.Assessment,
+                    contentDescription = null,
+                    tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            title           = stringResource(R.string.settings_show_overview_chart),
+            checked         = showOverviewChart,
+            onCheckedChange = { show ->
+                scope.launch { sharedViewModel.setShowOverviewChart(show) }
+            }
+        )
+
+        if (showOverviewChart) {
+            SettingsGroup(
+                leadingIcon = {
+                    Icon(
+                        imageVector        = Icons.Filled.Assessment,
+                        contentDescription = null,
+                        tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                title           = stringResource(R.string.settings_chart_scrollable),
+                checked         = overviewChartScrollable,
+                onCheckedChange = { scrollable ->
+                    scope.launch { sharedViewModel.setOverviewChartScrollable(scrollable) }
+                }
+            )
+        }
 
         // ---- Haptic section ----
         SettingsSectionTitle(text = stringResource(R.string.settings_feedback_title))

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -589,6 +589,8 @@
     <string name="settings_appearance_title">Appearance</string>
     <string name="settings_dynamic_color_label">Dynamic colors</string>
     <string name="settings_high_contrast_label">High contrast</string>
+    <string name="settings_show_overview_chart">Show chart on overview</string>
+    <string name="settings_chart_scrollable">Scrollable chart</string>
 
     <string name="monday_short">Mon</string>
     <string name="tuesday_short">Tue</string>


### PR DESCRIPTION
# PR: Overview Chart & Measurement Card UX Improvements

**Branch:** `enhancements/UI`

---

## Overview

This PR introduces three user-facing improvements to the overview screen.

---

## Changes

### 1. Chart show/hide toggle

Added a toggle in **Settings → Appearance** to show or hide the chart on the overview screen.

- Default: **on**
- When disabled, the measurement list takes full screen height
- Setting persisted via DataStore key `show_overview_chart`

---

### 2. Scrollable chart mode

Added a second toggle (only visible when chart is enabled) to switch between two chart modes:

| Mode | Behaviour |
|------|-----------|
| **Fixed** (default) | Chart stays pinned above the list with a draggable splitter to resize |
| **Scrollable** | Chart becomes the first item in the measurement list and scrolls with it |

**Technical note:** when scrollable, the chart is rendered with a fixed height of `260dp` because `LazyColumn` items have unbounded height and `MeasurementChart` uses `weight()` modifiers internally that require a bounded parent.

Setting persisted via DataStore key `overview_chart_scrollable`.

---

### 3. Measurement card collapse

Reworked expand/collapse behaviour on measurement cards:

- **Collapsed state** now hides all parameters — previously pinned values (e.g. weight) always showed regardless of expand state, making cards appear never fully collapsed
- **Latest measurement** (index 0) auto-expands on load — gives an immediate summary of the most recent entry
- **All previous measurements** start collapsed — keeps the list clean and scannable
- Expand/collapse controlled by:
  - Chevron icon in the card header (always visible)
  - Collapse button at the bottom of an expanded card


---

### 5. Copyright

Added `Copyright (C) 2026 openScale+ Dharmendra Gupta` to all modified Kotlin files alongside the original copyright header, per GPL v3.

---

## Files Changed

| File | Change |
|------|--------|
| `SettingsFacade.kt` | Added `overviewChartScrollable` Flow + setter + DataStore key |
| `OverviewScreen.kt` | Chart toggle, scrollable chart item, card collapse fix, copyright |
| `GeneralSettingsScreen.kt` | Two new toggles under Appearance, copyright |
| `strings.xml` | Added `settings_chart_scrollable` string |

---

## Settings Keys Added

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `show_overview_chart` | Boolean | `true` | Show/hide chart on overview |
| `overview_chart_scrollable` | Boolean | `false` | Fixed vs scrollable chart mode |

---

## Test Plan

- [ ] Chart shows by default on overview
- [ ] Toggling **Show chart on overview** off hides chart, list takes full height
- [ ] **Scrollable chart** toggle only appears when chart is enabled
- [ ] Scrollable mode: chart appears as first item in list and scrolls with it
- [ ] Fixed mode: chart stays pinned with draggable splitter
- [ ] Latest measurement card is expanded on load
- [ ] All other measurement cards start collapsed
- [ ] Expanding a card shows all parameters (pinned + non-pinned)
- [ ] Collapse button at bottom of expanded card works
- [ ] Header chevron toggles expand/collapse
