### PR TITLE
Fix sign extension bug in EtekcityESF551Handler byte-to-uint conversion

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityESF551Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityESF551Handler.kt
@@ -109,10 +109,12 @@ class EtekcityESF551Handler : ScaleDeviceHandler() {
             return null
         }
 
-        val weightRaw = data[10].toUInt() or data[11].toUInt().shl(8) or data[12].toUInt().shl(16)
+        val weightRaw = data[10].toUByte().toUInt() or
+                data[11].toUByte().toUInt().shl(8) or
+                data[12].toUByte().toUInt().shl(16)
         val weightKg = weightRaw.toDouble() / 1000.0
-        val impedance = (data[13].toUInt() or data[14].toUInt().shl(8)).toDouble()
-//        val displayUnit = WeightUnit.fromInt(data[21].toInt())
+        val impedance = (data[13].toUByte().toUInt() or data[14].toUByte().toUInt().shl(8)).toDouble()
+        //        val displayUnit = WeightUnit.fromInt(data[21].toInt())
         val measurement = ScaleMeasurement(
             userId = user.id,
             dateTime = Date(),


### PR DESCRIPTION
### Problem

`Byte.toUInt()` sign-extends through `Int` before converting to `UInt`. Any byte with bit 7 set (value ≥ 128) has its upper bits filled with 1s, producing a massively inflated value when the bytes are ORed together. The bug only surfaces when any of the relevant bytes has bit 7 set (value ≥ 128), making it weight-dependent and inconsistent across users.

### Observed failure

Full BLE notification payload (22 bytes):
`A5 02 4D 10 00 5C 01 61 A1 00 A2 2E 02 0F 02 6B BF 22 6A 01 01 01`

| Field | Expected | Actual (buggy) |
|---|---|---|
| weightRaw | `0x022EA2` = 142,242 | `0xFFFFFFA2` = 4,294,967,202 |
| weightKg | 142.242 kg (313.6 lbs) | 4,294,967.0 kg |
| impedance | 527 Ω | 527 Ω (coincidentally correct — both bytes < 0x80) |

### Fix

Replace `toUInt()` with `toUByte().toUInt()`. `toUByte()` zero-extends rather than sign-extends, keeping the upper bits clean before shift and OR operations.