### PR TITLE
Accept comma decimal separator in number input (issue #1410)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/utils/LocaleUtils.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/utils/LocaleUtils.kt
@@ -181,4 +181,14 @@ object LocaleUtils {
             isGroupingUsed = false
         }.format(cleaned)
     }
+
+    /**
+     * Parses a user-entered decimal string tolerantly, accepting either a dot or a comma as the
+     * decimal separator. On locales such as Spanish the number keyboard emits a comma (e.g.
+     * "80,5"), which the plain [String.toFloatOrNull] rejects. Returns null if the string is not a
+     * valid number. Mirrors the `replace(',', '.')` pattern already used at the goal-input sites.
+     */
+    @JvmStatic
+    fun parseLocalizedFloat(value: String): Float? =
+        value.trim().replace(',', '.').toFloatOrNull()
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/overview/MeasurementDetailScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/overview/MeasurementDetailScreen.kt
@@ -297,7 +297,7 @@ fun MeasurementDetailScreen(
 
                             when (type.inputType) {
                                 InputFieldType.FLOAT -> {
-                                    floatVal = inputString.toFloatOrNull()
+                                    floatVal = LocaleUtils.parseLocalizedFloat(inputString)
                                     if (floatVal == null) {
                                         Toast.makeText(
                                             context,
@@ -473,7 +473,7 @@ fun MeasurementDetailScreen(
                         } else {
                             var isValid = false
                             if (currentType.inputType == InputFieldType.FLOAT) {
-                                val floatOrNull = trimmedValue.toFloatOrNull()
+                                val floatOrNull = LocaleUtils.parseLocalizedFloat(trimmedValue)
                                 if (floatOrNull != null) {
                                     valuesState[currentType.id] = floatOrNull.toString()
                                     isValid = true
@@ -735,7 +735,7 @@ fun incrementValue(value: String, type: MeasurementType): String {
                 else -> 0.1f
             }
 
-            (value.toFloatOrNull()?.plus(step) ?: 0.1f).toString()
+            (LocaleUtils.parseLocalizedFloat(value)?.plus(step) ?: 0.1f).toString()
         }
         else -> value
     }
@@ -752,7 +752,7 @@ fun decrementValue(value: String, type: MeasurementType): String {
                 else -> 0.1f
             }
 
-            (value.toFloatOrNull()?.minus(step) ?: 0.1f).toString()
+            (LocaleUtils.parseLocalizedFloat(value)?.minus(step) ?: 0.1f).toString()
         }
         else -> value
     }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/UserDetailScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/UserDetailScreen.kt
@@ -322,8 +322,10 @@ fun UserDetailScreen(
         OutlinedTextField(
             value = heightValueString,
             onValueChange = { newValue ->
-                val filteredValue = newValue.filter { it.isDigit() || it == '.' }
-                if (filteredValue.count { it == '.' } <= 1) {
+                // Accept both '.' and ',' as decimal separators so comma-locale keyboards
+                // (e.g. Spanish) can enter decimals; addUser()/updateUser() normalize on save.
+                val filteredValue = newValue.filter { it.isDigit() || it == '.' || it == ',' }
+                if (filteredValue.count { it == '.' || it == ',' } <= 1) {
                     heightValueString = filteredValue
                 }
             },
@@ -337,7 +339,7 @@ fun UserDetailScreen(
                     val nextIndex = (currentIndex + 1) % heightUnitsOptions.size
                     val newUnit = heightUnitsOptions[nextIndex]
 
-                    val currentNumericValue = heightValueString.toFloatOrNull()
+                    val currentNumericValue = heightValueString.replace(',', '.').toFloatOrNull()
                     if (currentNumericValue != null && currentNumericValue > 0f) {
                         val convertedValue = ConverterUtils.convertFloatValueUnit(currentNumericValue, heightInputUnit, newUnit)
                         heightValueString = String.format(Locale.US, "%.1f", convertedValue)

--- a/android_app/app/src/test/java/com/health/openscale/core/utils/LocaleUtilsTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/utils/LocaleUtilsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LocaleUtilsTest {
+
+    private companion object {
+        const val EPS = 1e-4f
+    }
+
+    @Test
+    fun parseLocalizedFloat_acceptsDotSeparator() {
+        assertThat(LocaleUtils.parseLocalizedFloat("80.5")).isWithin(EPS).of(80.5f)
+    }
+
+    @Test
+    fun parseLocalizedFloat_acceptsCommaSeparator() {
+        // Comma decimals are what Spanish (and other) number keyboards emit.
+        assertThat(LocaleUtils.parseLocalizedFloat("80,5")).isWithin(EPS).of(80.5f)
+        assertThat(LocaleUtils.parseLocalizedFloat("1,75")).isWithin(EPS).of(1.75f)
+    }
+
+    @Test
+    fun parseLocalizedFloat_trimsWhitespace() {
+        assertThat(LocaleUtils.parseLocalizedFloat("  72,3  ")).isWithin(EPS).of(72.3f)
+    }
+
+    @Test
+    fun parseLocalizedFloat_returnsNullForInvalidInput() {
+        assertThat(LocaleUtils.parseLocalizedFloat("")).isNull()
+        assertThat(LocaleUtils.parseLocalizedFloat("abc")).isNull()
+    }
+}


### PR DESCRIPTION
Add one shared helper and use it at the three broken FLOAT sites (INT sites need no change)

Per #1410