### PR TITLE
Add DIVERSE gender option and disable sex-specific metrics (#1415)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/data/Enums.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/data/Enums.kt
@@ -155,10 +155,22 @@ enum class SupportedLanguage(val code: String, val nativeDisplayName: String) {
 
 enum class GenderType(@param:StringRes val displayNameResId: Int) {
     MALE(R.string.gender_male),
-    FEMALE(R.string.gender_female);
+    FEMALE(R.string.gender_female),
+    DIVERSE(R.string.gender_diverse);
 
     fun isMale(): Boolean {
         return this == MALE}
+
+    /**
+     * Whether this gender maps to a sex-specific reference table / body-composition
+     * formula. Body-composition metrics (body fat, water, muscle, LBM, BMR, ...) rely
+     * on male/female specific formulas and reference ranges. [DIVERSE] has no such
+     * medically defined reference, so those metrics are disabled for it (issue #1415):
+     * their values are neither estimated nor evaluated (no in/out-of-range coloring).
+     */
+    fun hasSexSpecificReference(): Boolean {
+        return this != DIVERSE
+    }
 
     fun getDisplayName(context: Context): String {
         return context.getString(displayNameResId)

--- a/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/model/EvaluationReferenceTables.kt
@@ -222,14 +222,25 @@ object EvaluationReferenceTables {
 
     // ----- Dynamic strategies -----
 
+    /**
+     * Strategy that never yields a range, used when no sex-specific reference exists
+     * for the user (e.g. [GenderType.DIVERSE], see issue #1415).
+     */
+    val undefinedStrategy: EvaluationStrategy = object : EvaluationStrategy {
+        override fun evaluate(value: Float, age: Int): MeasurementEvaluationResult =
+            MeasurementEvaluationResult(value, -1f, -1f, EvaluationState.UNDEFINED)
+    }
+
     /** Waist circumference (cm) thresholds by gender. */
     fun waistStrategyCm(gender: GenderType): EvaluationStrategy = when (gender) {
-        GenderType.MALE   -> AgeBandStrategy(listOf(AgeBand(18, 90, 0f, 94f)))
-        GenderType.FEMALE -> AgeBandStrategy(listOf(AgeBand(18, 90, 0f, 80f)))
+        GenderType.MALE    -> AgeBandStrategy(listOf(AgeBand(18, 90, 0f, 94f)))
+        GenderType.FEMALE  -> AgeBandStrategy(listOf(AgeBand(18, 90, 0f, 80f)))
+        GenderType.DIVERSE -> undefinedStrategy
     }
 
     /** Target weight bounds computed from height (cm) and BMI ranges by gender. */
     fun targetWeightStrategy(heightCm: Int, gender: GenderType): EvaluationStrategy {
+        if (!gender.hasSexSpecificReference()) return undefinedStrategy
         val h2 = (heightCm / 100f) * (heightCm / 100f)
         val (bmiLo, bmiHi) = if (gender == GenderType.MALE) 20f to 25f else 19f to 24f
         return FormulaStrategy(

--- a/android_app/app/src/main/java/com/health/openscale/core/service/DerivedValuesCalculator.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/service/DerivedValuesCalculator.kt
@@ -301,6 +301,8 @@ class DerivedValuesCalculator @Inject constructor(
         return when (gender) {
             GenderType.MALE   -> (10.0f * weightKg) + (6.25f * heightCm) - (5.0f * ageYears) + 5.0f
             GenderType.FEMALE -> (10.0f * weightKg) + (6.25f * heightCm) - (5.0f * ageYears) - 161.0f
+            // No sex-specific BMR offset defined for DIVERSE -> metric disabled (issue #1415).
+            GenderType.DIVERSE -> null
         }
     }
 
@@ -346,6 +348,12 @@ class DerivedValuesCalculator @Inject constructor(
             return null
         }
 
+        // Skinfold body-density constants are only defined for male/female. For DIVERSE
+        // the caliper-based body-fat metric is disabled (issue #1415).
+        if (!gender.hasSexSpecificReference()) {
+            return null
+        }
+
         // Sum of skinfolds in millimeters
         val sumSkinfoldsMm = (caliper1Cm + caliper2Cm + caliper3Cm) * 10.0f
         // LogManager.v(CALC_PROCESS_TAG, "Sum of skinfolds (S): $sumSkinfoldsMm mm")
@@ -369,6 +377,8 @@ class DerivedValuesCalculator @Inject constructor(
                 k2 = 0.0000023f
                 ka = 0.0001392f
             }
+            // Unreachable: DIVERSE returns null above. Kept for exhaustiveness/definite assignment.
+            GenderType.DIVERSE -> return null
         }
 
         val bodyDensity =

--- a/android_app/app/src/main/java/com/health/openscale/core/service/MeasurementEvaluator.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/service/MeasurementEvaluator.kt
@@ -17,6 +17,7 @@
  */
 package com.health.openscale.core.service
 
+import com.health.openscale.core.data.EvaluationState
 import com.health.openscale.core.data.GenderType
 import com.health.openscale.core.model.EvaluationReferenceTables
 import com.health.openscale.core.usecase.MeasurementEvaluationResult
@@ -27,38 +28,51 @@ import com.health.openscale.core.usecase.MeasurementEvaluationResult
  */
 object MeasurementEvaluator {
 
+    /**
+     * Result used when a metric cannot be evaluated for the given user, e.g. a
+     * sex-specific reference does not exist for [GenderType.DIVERSE] (issue #1415).
+     * Reported as [EvaluationState.UNDEFINED] so the UI shows no in/out-of-range coloring.
+     */
+    private fun undefined(value: Float): MeasurementEvaluationResult =
+        MeasurementEvaluationResult(value, -1f, -1f, EvaluationState.UNDEFINED)
+
     // --- Body composition ---
 
     fun evalBodyFat(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.fatMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.fatFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.fatMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.fatFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     fun evalWater(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.waterMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.waterFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.waterMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.waterFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     fun evalMuscle(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.muscleMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.muscleFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.muscleMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.muscleFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     fun evalLBM(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.lbmMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.lbmFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.lbmMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.lbmFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     // --- Indices ---
 
     fun evalBmi(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.bmiMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.bmiFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.bmiMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.bmiFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     fun evalWHtR(value: Float, age: Int): MeasurementEvaluationResult =
@@ -66,8 +80,9 @@ object MeasurementEvaluator {
 
     fun evalWHR(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
         when (gender) {
-            GenderType.MALE   -> EvaluationReferenceTables.whrMale.evaluate(value, age)
-            GenderType.FEMALE -> EvaluationReferenceTables.whrFemale.evaluate(value, age)
+            GenderType.MALE    -> EvaluationReferenceTables.whrMale.evaluate(value, age)
+            GenderType.FEMALE  -> EvaluationReferenceTables.whrFemale.evaluate(value, age)
+            GenderType.DIVERSE -> undefined(value)
         }
 
     fun evalVisceralFat(value: Float, age: Int): MeasurementEvaluationResult =
@@ -76,7 +91,8 @@ object MeasurementEvaluator {
     // --- Circumference / targets ---
 
     fun evalWaistCm(value: Float, age: Int, gender: GenderType): MeasurementEvaluationResult =
-        EvaluationReferenceTables.waistStrategyCm(gender).evaluate(value, age)
+        if (!gender.hasSexSpecificReference()) undefined(value)
+        else EvaluationReferenceTables.waistStrategyCm(gender).evaluate(value, age)
 
     /** Evaluates current weight against BMI-derived target range for given height/gender. */
     fun evalWeightAgainstTargetRange(
@@ -85,7 +101,8 @@ object MeasurementEvaluator {
         heightCm: Int,
         gender: GenderType
     ): MeasurementEvaluationResult =
-        EvaluationReferenceTables
+        if (!gender.hasSexSpecificReference()) undefined(weightKg)
+        else EvaluationReferenceTables
             .targetWeightStrategy(heightCm, gender)
             .evaluate(weightKg, age)
 }

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementTransformationUseCase.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementTransformationUseCase.kt
@@ -165,6 +165,12 @@ class MeasurementTransformationUseCase @Inject constructor(
         ) return values
 
         val user  = userUseCases.observeUserById(measurement.userId).first() ?: return values
+
+        // The body-fat / body-water / LBM estimation formulas below are sex-specific.
+        // For DIVERSE there is no defined sex reference, so we skip estimation entirely
+        // and leave any device-provided values untouched (issue #1415).
+        if (!user.gender.hasSexSpecificReference()) return values
+
         val types = query.getAllMeasurementTypes().first()
         val byKey = types.associateBy { it.key }
 

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/settings/DataManagementSettingsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.Face3
 import androidx.compose.material.icons.filled.Face6
 import androidx.compose.material.icons.filled.FileDownload
@@ -693,6 +694,8 @@ fun UserSelectionDialog(
                             Icons.Default.Face6 to MaterialTheme.colorScheme.primary
                         GenderType.FEMALE ->
                             Icons.Default.Face3 to MaterialTheme.colorScheme.secondary
+                        GenderType.DIVERSE ->
+                            Icons.Default.Face to MaterialTheme.colorScheme.tertiary
                     }
 
                     val textColor =

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="user_detail_label_gender">Gender</string>
     <string name="gender_male">Male</string>
     <string name="gender_female">Female</string>
+    <string name="gender_diverse">Diverse</string>
     <string name="amputation_correction_label">Amputation correction</string>
     <string name="amputation_none">None</string>
     <string name="amputation_hand">Hand</string>

--- a/android_app/app/src/test/java/com/health/openscale/core/service/DerivedValuesCalculatorFormulasTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/service/DerivedValuesCalculatorFormulasTest.kt
@@ -161,4 +161,17 @@ class DerivedValuesCalculatorFormulasTest {
         assertThat(DerivedValuesCalculator.processFatCaliperCalculation(0f, 1f, 1f, 25, GenderType.MALE)).isNull()
         assertThat(DerivedValuesCalculator.processFatCaliperCalculation(1f, 1f, null, 25, GenderType.MALE)).isNull()
     }
+
+    // ---- DIVERSE gender: sex-specific derived metrics are disabled (issue #1415) ---------------
+
+    @Test
+    fun bmr_returnsNull_forDiverseGender() {
+        // Same body inputs that yield a value for male/female must return null for DIVERSE.
+        assertThat(DerivedValuesCalculator.processBmrCalculation(80f, 175f, 30, GenderType.DIVERSE)).isNull()
+    }
+
+    @Test
+    fun fatCaliper_returnsNull_forDiverseGender() {
+        assertThat(DerivedValuesCalculator.processFatCaliperCalculation(1f, 1f, 1f, 25, GenderType.DIVERSE)).isNull()
+    }
 }

--- a/android_app/app/src/test/java/com/health/openscale/core/service/MeasurementEvaluatorTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/service/MeasurementEvaluatorTest.kt
@@ -108,4 +108,36 @@ class MeasurementEvaluatorTest {
         assertThat(MeasurementEvaluator.evalWeightAgainstTargetRange(85f, 30, 180, GenderType.MALE).state)
             .isEqualTo(EvaluationState.HIGH)
     }
+
+    // ---- DIVERSE gender: sex-specific metrics are disabled (issue #1415) ------------------------
+
+    @Test
+    fun diverse_sexSpecificMetrics_areUndefined() {
+        // Values that would be NORMAL for male/female must be UNDEFINED for DIVERSE.
+        assertThat(MeasurementEvaluator.evalBodyFat(17f, 25, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalWater(55f, 30, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalMuscle(40f, 25, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalLBM(60f, 30, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalBmi(22f, 30, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalWHR(0.85f, 40, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalWaistCm(90f, 40, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+        assertThat(MeasurementEvaluator.evalWeightAgainstTargetRange(70f, 30, 180, GenderType.DIVERSE).state)
+            .isEqualTo(EvaluationState.UNDEFINED)
+    }
+
+    @Test
+    fun diverse_nonGenderedMetrics_stillEvaluate() {
+        // WHtR and visceral fat are not sex-specific and stay available for DIVERSE users.
+        assertThat(MeasurementEvaluator.evalWHtR(0.45f, 30).state)
+            .isEqualTo(EvaluationState.NORMAL)
+        assertThat(MeasurementEvaluator.evalVisceralFat(5f, 30).state)
+            .isEqualTo(EvaluationState.NORMAL)
+    }
 }


### PR DESCRIPTION
Implements #1415 — adds a third gender option for users who don't identify as male or female.

## What
- New `GenderType.DIVERSE` option (shown in the user gender dropdown).
- Metrics that rely on male/female-specific formulas are disabled for DIVERSE users, as requested in the issue:
  - Evaluation (in/out-of-range coloring) returns `UNDEFINED` for body fat, body water, muscle, LBM, BMI, WHR, waist circumference and the BMI-derived target-weight range.
  - Derived-value calculation returns `null` (metric not stored) for BMR and the skinfold/caliper body-fat estimate.
  - Body-fat / body-water / LBM estimation formulas are skipped, leaving any device-provided values untouched.
- Non-sex-specific metrics (weight, BMI value, WHtR, visceral fat, circumferences) are unaffected.

## Notes
- A new `GenderType.hasSexSpecificReference()` helper centralizes the rule.
- Gender is stored as enum-name text, so **no database migration** is required.
- BLE scales that compute body composition on-device still use their internal binary reference; wiring DIVERSE through those handlers is left as a follow-up.

## Tests
- Added DIVERSE coverage to `MeasurementEvaluatorTest` and `DerivedValuesCalculatorFormulasTest`.
- `./gradlew testDebugUnitTest` passes (JDK 21, matching CI).

Open to feedback on the behaviour — e.g. using a neutral reference instead of disabling for DIVERSE.