### PR TITLE
Fix MiScale +2h/+1h timestamp offset regression (revert to local timezone)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MiScaleHandler.kt
@@ -202,7 +202,7 @@ class MiScaleHandler : ScaleDeviceHandler() {
 
     /** Prefer writing Current Time to the primary service; fallback to alternate if needed. */
     private fun writeCurrentTimePreferPrimary(primarySvc: UUID, alternateSvc: UUID) {
-        val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        val c = Calendar.getInstance()
         val year = c.get(Calendar.YEAR)
         val payload = byteArrayOf(
             (year and 0xFF).toByte(), ((year shr 8) and 0xFF).toByte(),
@@ -455,7 +455,7 @@ class MiScaleHandler : ScaleDeviceHandler() {
     private fun parseMinuteDate(y: Int, m: Int, d: Int, h: Int, min: Int): Date? =
         runCatching {
             val sdf = SimpleDateFormat("yyyy/MM/dd/HH/mm", Locale.US)
-            sdf.timeZone = TimeZone.getTimeZone("UTC")
+            sdf.timeZone = TimeZone.getDefault()
             sdf.parse("$y/$m/$d/$h/$min")
         }.getOrNull()
 


### PR DESCRIPTION
## Summary

Xiaomi Mi Scale / Mi Body Composition Scale (`MIBFS`/`MIBCS`) measurements have been recorded with a timestamp offset by exactly the device's local UTC delta (e.g. +2h during CEST, +1h during CET) since commit cd4d5e16 ("Fix: Use UTC for MiScale time synchronization").

That commit changed `MiScaleHandler.writeCurrentTimePreferPrimary` and `MiScaleHandler.parseMinuteDate` from using the device's default (local) timezone to hardcoded UTC, for both writing the BLE Current Time characteristic and parsing the time echoed back by the scale.

The scale itself has no timezone concept - it only stores/echoes plain wall-clock digits (year/month/day/hour/minute/second) and expects those to represent local time. Writing UTC digits while still parsing the reply as UTC produces a timestamp that is off by the local UTC offset, because the round trip no longer matches the convention the firmware assumes.

## Evidence

I cross-referenced years of measurements from a MIBFS scale recorded by openScale against an independent BLE reader of the same physical device (a different companion app that also supports this scale and logs its own timestamps). Every measurement recorded before cd4d5e16 (2021 through Sept 2025) matches the independent reader exactly (0.0h delta, hundreds of samples). Every measurement recorded since cd4d5e16 (Apr 2026 onward, once the scale was used again) is off by exactly the local UTC offset at the time of measurement (+2.00h, matching CEST).

I could not find a linked issue or repro for cd4d5e16's stated rationale ("previously the device's local timezone was used, which could lead to incorrect timestamps") - it appears to have been a direct commit without an associated bug report. The data above contradicts that rationale for this device.

## Change

Reverts the two timezone lines in `MiScaleHandler.kt` to their pre-cd4d5e16 behavior (`Calendar.getInstance()` / `TimeZone.getDefault()`), while keeping the unrelated day-of-week/adjust-reason trailing payload byte fix from the same commit, which is a separate and still-valid protocol correction untouched by the timezone regression.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` builds successfully with this change
- [x] Verified against real-world measurement history from an affected device (see Evidence above); no unit test exists for `MiScaleHandler`'s time parsing (only `MiScaleLibTest.kt`, unrelated body-composition math) so this relies on the historical data comparison rather than an automated regression test
- [ ] Would appreciate a maintainer/other MIBFS-MIBCS user confirming on their own device, since I can't verify behavior across all Mi Scale v1/v2 firmware variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)