### PR TITLE
Add support for Dr. Trust Smart 505 Scale (India)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
@@ -145,7 +145,22 @@ class MGBHandler : ScaleDeviceHandler() {
         if (characteristic != CHAR_CTRL) return
         when (data.size) {
             20 -> onCompositeFrame(data)
-            8 -> onStreamingFrame(data, user)
+            8 -> {
+                if (streamingPublished) return
+
+                parseFinalWeightRaw(data)?.let { raw ->
+                    streamingWeightRaw = raw
+                    logD("streaming final weight raw=$raw")
+                    tryPublishStreaming(user)
+                    return
+                }
+
+                parseImpedanceOhm(data)?.let { ohm ->
+                    streamingImpedanceOhm = ohm
+                    logD("streaming impedance=$ohm Ω")
+                    tryPublishStreaming(user)
+                }
+            }
             else -> return
         }
     }
@@ -176,23 +191,6 @@ class MGBHandler : ScaleDeviceHandler() {
     }
 
     // -- Streaming (8-byte) variant, e.g. Dr Trust Smart 505 --
-
-    private fun onStreamingFrame(data: ByteArray, user: ScaleUser) {
-        if (streamingPublished) return
-
-        parseFinalWeightRaw(data)?.let { raw ->
-            streamingWeightRaw = raw
-            logD("streaming final weight raw=$raw")
-            tryPublishStreaming(user)
-            return
-        }
-
-        parseImpedanceOhm(data)?.let { ohm ->
-            streamingImpedanceOhm = ohm
-            logD("streaming impedance=$ohm Ω")
-            tryPublishStreaming(user)
-        }
-    }
 
     private fun tryPublishStreaming(user: ScaleUser) {
         if (streamingPublished) return

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
@@ -20,6 +20,7 @@ package com.health.openscale.core.bluetooth.scales
 import com.health.openscale.R
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
 import com.health.openscale.core.service.ScannedDeviceInfo
 import com.health.openscale.core.utils.LogManager
 import java.util.Date
@@ -45,10 +46,21 @@ import java.util.UUID
  *    - 0xFE 06 <unit> 00
  * 3) Ask user to step on the scale.
  *
- * Data frames (NOTIFY on 0xFFB2, 20 bytes):
+ * Two wire variants share this service/characteristic pair, distinguished by frame size:
+ *
+ * Composite frames (NOTIFY on 0xFFB2, 20 bytes):
  *  - First part:  header AC 02|03 FF … → contains weight, fat (and other fields we ignore)
  *  - Second part: header 01 00 …       → contains muscle, bone, water (+ misc)
  * We collect both parts to publish one complete ScaleMeasurement.
+ *
+ * Streaming frames (NOTIFY on 0xFFB2, 8 bytes, e.g. Dr Trust Smart 505):
+ *  `AC 02 [b2] [b3] [b4] [b5] [b6] [chk]`, checksum = (b2+b3+b4+b5+b6) & 0xFF. Byte 6 is a
+ *  type/state flag: 0xCE = live weight (settling, ignored), 0xCA = final weight (same payload as
+ *  the preceding 0xCE, flag flipped), 0xCB = impedance, 0xCC = config echo/status (ignored).
+ *  Weight is a big-endian u16 in b2:b3 (0.01 kg) with b4==0 && b5==0. Impedance is a big-endian
+ *  u16 in b4:b5, only valid when b2==0xFD && b3==0x01 (0xFD 0x00 opens the block, 0xFD 0xFF marks
+ *  impedance-unavailable; both are ignored). We latch weight and impedance as they stream in and
+ *  publish once both are present.
  */
 class MGBHandler : ScaleDeviceHandler() {
 
@@ -57,8 +69,13 @@ class MGBHandler : ScaleDeviceHandler() {
     private val CHAR_CFG: UUID = uuid16(0xFFB1)   // write
     private val CHAR_CTRL: UUID = uuid16(0xFFB2)  // notify
 
-    // Pending measurement until 2nd frame arrives
+    // Pending measurement until 2nd composite frame arrives
     private var pending: ScaleMeasurement? = null
+
+    // Streaming-variant session state, latched until both are present
+    private var streamingWeightRaw: Int? = null
+    private var streamingImpedanceOhm: Int? = null
+    private var streamingPublished = false
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name.lowercase(Locale.ROOT)
@@ -126,8 +143,22 @@ class MGBHandler : ScaleDeviceHandler() {
     // -- Notifications --
     override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) {
         if (characteristic != CHAR_CTRL) return
-        if (data.size != 20) return
+        when (data.size) {
+            20 -> onCompositeFrame(data)
+            8 -> onStreamingFrame(data, user)
+            else -> return
+        }
+    }
 
+    override fun onDisconnected() {
+        streamingWeightRaw = null
+        streamingImpedanceOhm = null
+        streamingPublished = false
+    }
+
+    // -- Composite (20-byte) variant --
+
+    private fun onCompositeFrame(data: ByteArray) {
         val b0 = data[0].toUByte().toInt()
         val b1 = data[1].toUByte().toInt()
         val b2 = data[2].toUByte().toInt()
@@ -142,6 +173,60 @@ class MGBHandler : ScaleDeviceHandler() {
         if (b0 == 0x01 && b1 == 0x00) {
             parseSecondFrameAndPublish(data)
         }
+    }
+
+    // -- Streaming (8-byte) variant, e.g. Dr Trust Smart 505 --
+
+    private fun onStreamingFrame(data: ByteArray, user: ScaleUser) {
+        if (streamingPublished) return
+
+        parseFinalWeightRaw(data)?.let { raw ->
+            streamingWeightRaw = raw
+            logD("streaming final weight raw=$raw")
+            tryPublishStreaming(user)
+            return
+        }
+
+        parseImpedanceOhm(data)?.let { ohm ->
+            streamingImpedanceOhm = ohm
+            logD("streaming impedance=$ohm Ω")
+            tryPublishStreaming(user)
+        }
+    }
+
+    private fun tryPublishStreaming(user: ScaleUser) {
+        if (streamingPublished) return
+        val weightRaw = streamingWeightRaw ?: return
+        val impedanceOhm = streamingImpedanceOhm ?: return
+        streamingPublished = true
+
+        val weightKg = weightRaw / 100.0f
+        val m = ScaleMeasurement().apply {
+            userId = user.id
+            dateTime = Date()
+            weight = weightKg
+        }
+
+        // The scale reports only weight + raw impedance; derive body composition the same way
+        // VitafitVT701Handler does for its weight+impedance scales.
+        if (impedanceOhm in 1 until 1500) {
+            m.impedance = impedanceOhm.toDouble()
+            val lib = StandardImpedanceLib(
+                gender = user.gender,
+                age = user.age,
+                weightKg = weightKg.toDouble(),
+                heightM = user.bodyHeight / 100.0,
+                impedance = impedanceOhm.toDouble(),
+            )
+            m.fat = lib.totalFatPercentage.toFloat()
+            m.water = lib.totalBodyWaterPercentage.toFloat()
+            m.muscle = lib.skeletalMusclePercentage.toFloat()
+            m.bone = lib.boneMassKg.toFloat()
+            m.bmr = lib.basalMetabolicRate.toFloat()
+        }
+
+        publish(m)
+        logI("streaming publish weight=$weightKg kg impedance=$impedanceOhm Ω")
     }
 
     // -- Helpers: config writer, parsers, LE readers --
@@ -241,5 +326,51 @@ class MGBHandler : ScaleDeviceHandler() {
         val lo = d[off + 1].toUByte().toInt()
         val v = (hi shl 8) or lo
         return v / 10.0f
+    }
+
+    companion object {
+        private const val FLAG_LIVE_WEIGHT = 0xCE
+        private const val FLAG_FINAL_WEIGHT = 0xCA
+        private const val FLAG_IMPEDANCE = 0xCB
+
+        /**
+         * True if [frame] is a well-formed 8-byte streaming frame with a matching checksum.
+         *
+         * Layout: `AC 02 [b2] [b3] [b4] [b5] [b6] [chk]`, checksum = (b2+b3+b4+b5+b6) & 0xFF.
+         */
+        fun isValidStreamingFrame(frame: ByteArray): Boolean {
+            if (frame.size != 8) return false
+            if ((frame[0].toInt() and 0xFF) != 0xAC) return false
+            if ((frame[1].toInt() and 0xFF) != 0x02) return false
+            val sum = (2..6).sumOf { frame[it].toInt() and 0xFF } and 0xFF
+            return sum == (frame[7].toInt() and 0xFF)
+        }
+
+        private fun weightRaw(frame: ByteArray, flag: Int): Int? {
+            if (!isValidStreamingFrame(frame)) return null
+            if ((frame[6].toInt() and 0xFF) != flag) return null
+            if ((frame[4].toInt() and 0xFF) != 0 || (frame[5].toInt() and 0xFF) != 0) return null
+            return ((frame[2].toInt() and 0xFF) shl 8) or (frame[3].toInt() and 0xFF)
+        }
+
+        /** Raw weight in 0.01 kg units from a *final* (0xCA) streaming frame, or `null`. */
+        fun parseFinalWeightRaw(frame: ByteArray): Int? = weightRaw(frame, FLAG_FINAL_WEIGHT)
+
+        /** Raw weight in 0.01 kg units from a *live/settling* (0xCE) streaming frame, or `null`. */
+        fun parseLiveWeightRaw(frame: ByteArray): Int? = weightRaw(frame, FLAG_LIVE_WEIGHT)
+
+        /**
+         * Whole-body impedance in ohms from a `FD 01 [hi] [lo] CB [chk]` streaming frame, or
+         * `null`. `FD 00 …` (block open) and `FD FF …` (impedance-unavailable) are not values;
+         * config writes also use 0xFD in b2 (e.g. the date write), so the flag byte (0xCB, not
+         * 0xCC) is what distinguishes an impedance frame from a config echo.
+         */
+        fun parseImpedanceOhm(frame: ByteArray): Int? {
+            if (!isValidStreamingFrame(frame)) return null
+            if ((frame[6].toInt() and 0xFF) != FLAG_IMPEDANCE) return null
+            if ((frame[2].toInt() and 0xFF) != 0xFD) return null
+            if ((frame[3].toInt() and 0xFF) != 0x01) return null
+            return ((frame[4].toInt() and 0xFF) shl 8) or (frame[5].toInt() and 0xFF)
+        }
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/MGBHandlerStreamingTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/MGBHandlerStreamingTest.kt
@@ -1,0 +1,93 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [MGBHandler]'s 8-byte streaming frame parsers (e.g. Dr Trust Smart 505).
+ *
+ * Vectors are taken from the decoded protocol notes; checksums were hand-verified against
+ * `chk = (b2 + b3 + b4 + b5 + b6) & 0xFF`.
+ */
+class MGBHandlerStreamingTest {
+
+    private fun hex(s: String): ByteArray =
+        s.filterNot { it.isWhitespace() }.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    fun `extracts 99_10 kg from the final weight frame`() {
+        val raw = MGBHandler.parseFinalWeightRaw(hex("AC 02 26 B6 00 00 CA A6"))
+        assertThat(raw).isEqualTo(9910)
+        assertThat(raw!! / 100.0f).isWithin(1e-3f).of(99.10f)
+    }
+
+    @Test
+    fun `live frames are not read as final weight`() {
+        // Same payload as the final-weight frame, flag still 0xCE (settling).
+        assertThat(MGBHandler.parseFinalWeightRaw(hex("AC 02 26 B6 00 00 CE AA")))
+            .isNull()
+    }
+
+    @Test
+    fun `live frames are readable via parseLiveWeightRaw`() {
+        val raw = MGBHandler.parseLiveWeightRaw(hex("AC 02 26 B6 00 00 CE AA"))
+        assertThat(raw).isEqualTo(9910)
+    }
+
+    @Test
+    fun `extracts 600 ohm from the impedance frame`() {
+        assertThat(MGBHandler.parseImpedanceOhm(hex("AC 02 FD 01 02 58 CB 23")))
+            .isEqualTo(600)
+    }
+
+    @Test
+    fun `FD 00 block-open frame is not an impedance value`() {
+        assertThat(MGBHandler.parseImpedanceOhm(hex("AC 02 FD 00 00 00 CB C8")))
+            .isNull()
+    }
+
+    @Test
+    fun `FD FF impedance-unavailable frame is not an impedance value`() {
+        assertThat(MGBHandler.parseImpedanceOhm(hex("AC 02 FD FF 00 00 CB C7")))
+            .isNull()
+    }
+
+    @Test
+    fun `date-write config echo is not confused with impedance`() {
+        // Same FD-in-b2 shape as impedance frames, but flag is 0xCC (config), not 0xCB.
+        assertThat(MGBHandler.parseImpedanceOhm(hex("AC 02 FD 1A 07 18 CC 02")))
+            .isNull()
+    }
+
+    @Test
+    fun `rejects a frame with a bad checksum`() {
+        assertThat(MGBHandler.isValidStreamingFrame(hex("AC 02 26 B6 00 00 CA FF")))
+            .isFalse()
+        assertThat(MGBHandler.parseFinalWeightRaw(hex("AC 02 26 B6 00 00 CA FF")))
+            .isNull()
+    }
+
+    @Test
+    fun `does not accept a 20-byte composite frame as a streaming frame`() {
+        assertThat(MGBHandler.isValidStreamingFrame(ByteArray(20))).isFalse()
+        assertThat(MGBHandler.parseFinalWeightRaw(ByteArray(20))).isNull()
+        assertThat(MGBHandler.parseImpedanceOhm(ByteArray(20))).isNull()
+    }
+}


### PR DESCRIPTION
Add 8-byte streaming protocol support to MGBHandler (Dr Trust Smart 505)

MGBHandler matches by name (swan/icomon/yg) or service 0xFFB0. The Dr Trust Smart 505 matches but sends 8-byte frames, while the handler only accepted 20-byte composite frames (if (data.size != 20) return) — so it connected, ran its init writes, and silently saved nothing.

This makes onNotification() dispatch on frame size and adds a path for the 8-byte variant. The 20-byte path is unchanged (extracted verbatim into a private method).

Protocol (8-byte variant)
Frame: AC 02 [b2] [b3] [b4] [b5] [flag] [chk], chk = (b2+b3+b4+b5+flag) & 0xFF. Flag byte: CE live weight, CA settled weight (u16 in b2:b3, 0.01 kg), CB impedance (FD 01 [hi] [lo], ohms), CC status. Completion is the CE→CA flag change, not a separate frame.

Implementation

Pure companion-object parsers (isValidStreamingFrame, parseFinalWeightRaw, parseLiveWeightRaw, parseImpedanceOhm), following VitafitVT701Handler's pattern.
Latches weight + impedance, publishes once both arrive, resets in a new onDisconnected().
Composition via StandardImpedanceLib — same library and sanity guard VitafitVT701Handler uses; raw impedance also stored. No new formulas.

Tests
New MGBHandlerStreamingTest.kt covering weight/impedance parsing, the flag distinctions, the FD-config-vs-impedance collision, and checksum/size rejection. Passes; existing VitafitVT701HandlerTest still passes.

Tested on a physical Dr Trust Smart 505: weigh-in saves correctly, and weight/BMI/bone match the vendor app. Composition is derived from raw impedance via StandardImpedanceLib, so it differs from the vendor's proprietary values (as with other impedance scales here) — happy to swap the estimator if preferred. I don't own the 20-byte variant, so only the 8-byte path is hardware-verified.