### PR TITLE
Fix: aggregation drops INT-typed measurements (heart rate vanishes from chart and statistics)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementAggregationUseCase.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementAggregationUseCase.kt
@@ -32,6 +32,7 @@ import java.time.temporal.WeekFields
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.roundToInt
 
 /**
  * Use case that aggregates a list of [EnrichedMeasurement] into a smaller list of
@@ -160,7 +161,14 @@ class MeasurementAggregationUseCase @Inject constructor() {
                 id            = -1,
                 measurementId = -1,
                 floatValue    = avg,
-                intValue      = null,
+                // The synthetic value keeps the original type, so consumers still switch on
+                // InputFieldType.INT and read intValue. Leaving it null made INT-typed
+                // measurements read as absent everywhere downstream.
+                intValue      = if (vwt.type.inputType == InputFieldType.INT) {
+                    avg.roundToInt()
+                } else {
+                    null
+                },
             )
             vwt.copy(value = syntheticVal)
         }

--- a/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementAggregationUseCaseTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementAggregationUseCaseTest.kt
@@ -19,6 +19,7 @@ package com.health.openscale.core.usecase
 
 import com.google.common.truth.Truth.assertThat
 import com.health.openscale.core.data.AggregationLevel
+import com.health.openscale.core.data.InputFieldType
 import com.health.openscale.core.data.MeasurementTypeKey
 import com.health.openscale.core.model.EnrichedMeasurement
 import com.health.openscale.testutil.Fixtures
@@ -79,5 +80,71 @@ class MeasurementAggregationUseCaseTest {
         val out = useCase.aggregate(input, AggregationLevel.DAY)
         assertThat(out).hasSize(2)
         assertThat(out.map { it.aggregatedFromCount }).containsExactly(1, 1)
+    }
+
+    // --- INT-typed measurements ------------------------------------------------
+    // The aggregated value keeps the original type, so every consumer switches on
+    // InputFieldType.INT and reads intValue. If only floatValue is populated, an
+    // INT-typed measurement reads as absent in the chart, the statistics screen and
+    // smoothing alike.
+
+    private val heartRate = Fixtures.type(
+        id = 2,
+        key = MeasurementTypeKey.HEART_RATE,
+        inputType = InputFieldType.INT,
+    )
+
+    private fun emInt(measurementId: Int, timestamp: Long, value: Int): EnrichedMeasurement =
+        Fixtures.enriched(
+            Fixtures.mwv(
+                measurementId = measurementId,
+                timestamp = timestamp,
+                values = listOf(Fixtures.intValueWithType(heartRate, value, measurementId)),
+            )
+        )
+
+    @Test
+    fun aggregate_day_populatesIntValueForIntTypedMeasurements() {
+        val input = listOf(
+            emInt(1, Fixtures.ts(2025, 4, 7, 8), 60),
+            emInt(2, Fixtures.ts(2025, 4, 7, 20), 70),
+        )
+        val out = useCase.aggregate(input, AggregationLevel.DAY)
+
+        assertThat(out).hasSize(1)
+        val aggregated = out[0].enriched.measurementWithValues.values
+            .first { it.type.id == heartRate.id }.value
+
+        assertThat(aggregated.intValue).isEqualTo(65)
+        // floatValue stays populated too, so consumers reading either field agree.
+        assertThat(aggregated.floatValue).isNotNull()
+        assertThat(aggregated.floatValue!!).isWithin(1e-3f).of(65f)
+    }
+
+    @Test
+    fun aggregate_day_roundsIntValueRatherThanTruncating() {
+        // 60 and 65 average to 62.5 — truncation would report 62.
+        val input = listOf(
+            emInt(1, Fixtures.ts(2025, 4, 7, 8), 60),
+            emInt(2, Fixtures.ts(2025, 4, 7, 20), 65),
+        )
+        val out = useCase.aggregate(input, AggregationLevel.DAY)
+
+        val aggregated = out[0].enriched.measurementWithValues.values
+            .first { it.type.id == heartRate.id }.value
+        assertThat(aggregated.intValue).isEqualTo(63)
+    }
+
+    @Test
+    fun aggregate_leavesIntValueNullForFloatTypedMeasurements() {
+        val input = listOf(
+            em(1, Fixtures.ts(2025, 4, 7, 8), 80f),
+            em(2, Fixtures.ts(2025, 4, 7, 20), 82f),
+        )
+        val out = useCase.aggregate(input, AggregationLevel.DAY)
+
+        val aggregated = out[0].enriched.measurementWithValues.values
+            .first { it.type.id == weight.id }.value
+        assertThat(aggregated.intValue).isNull()
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/testutil/Fixtures.kt
+++ b/android_app/app/src/test/java/com/health/openscale/testutil/Fixtures.kt
@@ -62,6 +62,13 @@ object Fixtures {
             type = type,
         )
 
+    /** As [valueWithType], but for a type whose [MeasurementType.inputType] is INT. */
+    fun intValueWithType(type: MeasurementType, value: Int, measurementId: Int = 0): MeasurementValueWithType =
+        MeasurementValueWithType(
+            value = MeasurementValue(measurementId = measurementId, typeId = type.id, intValue = value),
+            type = type,
+        )
+
     fun mwv(
         measurementId: Int,
         timestamp: Long,


### PR DESCRIPTION
Aggregation averages the values correctly but writes `intValue = null`, while copying the measurement type unchanged — so the synthetic entry still reports `InputFieldType.INT`. Every consumer switches on `inputType` and reads `intValue`, so an INT-typed measurement reads as **absent** as soon as any aggregation level other than `NONE` is selected.

`MeasurementAggregationUseCase.kt:157-166` (before):

```kotlin
val syntheticVal = vwt.value.copy(
    id            = -1,
    measurementId = -1,
    floatValue    = avg,
    intValue      = null,   // type is still INT, so this is what consumers read
)
```

Downstream:

| consumer | effect |
|---|---|
| `MeasurementChart.kt:634-638, :673-677` | `yValue` resolves to null → the series disappears from the chart |
| `StatisticsScreen.kt:204-208` | min / max / avg / first / last / difference all become null |
| `MeasurementSmoothingUseCases.kt:119-123` | the type is dropped from smoothing entirely |

**User-visible symptom:** `HEART_RATE` is `InputFieldType.INT` (`Enums.kt:396`), as are INT custom types. Switching the Statistics screen to weekly aggregation renders the heart-rate card as `Min: -  Max: -  Avg: -` with an empty chart, while the same data at aggregation `NONE` renders correctly.

### The change

Populate `intValue` for INT-typed values, rounding rather than truncating:

```kotlin
intValue = if (vwt.type.inputType == InputFieldType.INT) avg.roundToInt() else null,
```

`floatValue` stays populated exactly as before, so consumers reading either field agree with each other. FLOAT-typed values are unaffected — there's a test asserting `intValue` stays null for them.

### Verification

Three tests added to `MeasurementAggregationUseCaseTest.kt`, which previously had no INT coverage at all:

- `aggregate_day_populatesIntValueForIntTypedMeasurements` — 60 and 70 aggregate to `intValue = 65`
- `aggregate_day_roundsIntValueRatherThanTruncating` — 60 and 65 give 63, not 62
- `aggregate_leavesIntValueNullForFloatTypedMeasurements` — guards the other direction

**Red/green confirmed, not assumed:** with the production change reverted and the tests kept, `gradlew :app:testDebugUnitTest --tests *AggregationUseCaseTest*` reports **7 tests, 2 failures**. With the change applied: **7 tests, 0 failures**.

`Fixtures.kt` gains an `intValueWithType` helper — the existing `valueWithType` only ever sets `floatValue`, so an INT fixture wasn't expressible. It's additive; nothing else changes.

No hardware needed for any of this.
