### PR TITLE
Cult Smart Scale Pro: muscle is stored in kg but the field is a percentage

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/CultSmartScaleProHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/CultSmartScaleProHandler.kt
@@ -272,7 +272,7 @@ class CultSmartScaleProHandler : ScaleDeviceHandler() {
 
             m.fat        = lib.totalFatPercentage.toFloat().coerceIn(0f, 75f)
             m.water      = lib.totalBodyWaterPercentage.toFloat().coerceIn(0f, 80f)
-            m.muscle     = lib.skeletalMuscleMassKg.toFloat().coerceIn(0f, 100f)
+            m.muscle     = lib.skeletalMusclePercentage.toFloat().coerceIn(0f, 100f)
             m.bone       = lib.boneMassKg.toFloat().coerceIn(0f, 10f)
             m.lbm        = lib.fatFreeMassKg.toFloat().coerceIn(0f, 150f)
             m.bmr        = lib.basalMetabolicRate.toFloat().coerceIn(0f, 5000f)
@@ -280,12 +280,12 @@ class CultSmartScaleProHandler : ScaleDeviceHandler() {
 
             logI(
                 "body comp (StandardImpedanceLib, impedance=${pendingImpedance}Ω): " +
-                "fat=${m.fat}% water=${m.water}% muscle=${m.muscle}kg " +
+                "fat=${m.fat}% water=${m.water}% muscle=${m.muscle}% " +
                 "bone=${m.bone}kg lbm=${m.lbm}kg bmr=${m.bmr}kcal"
             )
         }
 
-        logI("publishing → weight=${m.weight}kg fat=${m.fat}% water=${m.water}% muscle=${m.muscle}kg bmr=${m.bmr}kcal impedance=${m.impedance}Ω")
+        logI("publishing → weight=${m.weight}kg fat=${m.fat}% water=${m.water}% muscle=${m.muscle}% bmr=${m.bmr}kcal impedance=${m.impedance}Ω")
         publish(m)
     }
 


### PR DESCRIPTION
`ScaleMeasurement.muscle` is declared with an explicit unit:

```kotlin
// core/bluetooth/data/ScaleMeasurement.kt:32
var muscle: Float = 0.0f, // must be in percentage
```

`CultSmartScaleProHandler.kt:275` assigns kilograms to it:

```kotlin
m.fat    = lib.totalFatPercentage.toFloat().coerceIn(0f, 75f)          // percentage ✓
m.water  = lib.totalBodyWaterPercentage.toFloat().coerceIn(0f, 80f)    // percentage ✓
m.muscle = lib.skeletalMuscleMassKg.toFloat().coerceIn(0f, 100f)       // kilograms ✗
```

`StandardImpedanceLib` exposes both `skeletalMuscleMassKg` (`:121`) and `skeletalMusclePercentage` (`:125`); this is the only handler that picks the former.

### Why I'm confident without owning the device

This is a unit-contract mismatch inside the app, not a claim about what the scale transmits — so it can be settled from the code alone:

1. The field documents its unit at the declaration.
2. The two sibling assignments **in the same block** use the `…Percentage` accessors.
3. Every other handler using `StandardImpedanceLib` writes the percentage: `MGBHandler.kt:221`, `VitafitVT701Handler.kt:146`, `EtekcityESF551Handler.kt:135`, and `DrTrustSSW532Handler.kt:297`.
4. The handler's own log lines said `muscle=${m.muscle}kg` — the unit was known at the call site; it was written into the percentage field anyway.

I do **not** own a Cult Smart Scale Pro, and I'm stating that plainly rather than implying I tested against hardware. Nothing here changes how the device is parsed or what is read off the wire — only which accessor of an already-computed result is stored. `gradlew :app:compileDebugKotlin` passes.

The two log lines are corrected to `%` in the same commit, since leaving them saying `kg` would preserve the confusion that caused this.

### One thing I did not change

The impedance sanity guard here is `pendingImpedance > 0.0` (`:264`) with no upper bound, while the sibling handlers use `in 1 until 1500` (`MGBHandler.kt:210`, `VitafitVT701Handler.kt:137`) or `> 0 && < 1500` (`EtekcityESF551Handler.kt:125`). That looked like the same family of inconsistency, but tightening it is a behaviour change on hardware I can't test, so I left it alone — flagging it here in case you want it.
