### PR TITLE
Support Terraillon X-LINE scale

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
@@ -59,8 +59,8 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name
-        if (!name.startsWith("1BODY CONNECT") && !name.startsWith("0BODY CONNECT") && !name.startsWith("0X-LINE")) return null
-        val displayName = if (name.contains("BODY CONNECT")) "1BODY CONNECT" else "X-LINE"
+        if (!name.startsWith("1BODY CONNECT") && !name.startsWith("0BODY CONNECT") && !name.startsWith("0X-LINE") && !name.startsWith("1X-LINE")) return null
+        val displayName = if (name.contains("BODY CONNECT")) "1BODY CONNECT" else "1X-LINE"
         return DeviceSupport(
             displayName = displayName,
             capabilities = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.USER_SYNC, DeviceCapability.HISTORY_READ),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
@@ -59,9 +59,10 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name
-        if (!name.startsWith("1BODY CONNECT") && !name.startsWith("0BODY CONNECT")) return null
+        if (!name.startsWith("1BODY CONNECT") && !name.startsWith("0BODY CONNECT") && !name.startsWith("0X-LINE")) return null
+        val displayName = if (name.contains("BODY CONNECT")) "1BODY CONNECT" else "X-LINE"
         return DeviceSupport(
-            displayName = "1BODY CONNECT",
+            displayName = displayName,
             capabilities = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.USER_SYNC, DeviceCapability.HISTORY_READ),
             implemented = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.HISTORY_READ),
             linkMode = LinkMode.CONNECT_GATT
@@ -96,6 +97,8 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     // Timestamp base: 2010-01-01 00:00:00 UTC; device stores seconds since this epoch
     private val TS_OFFSET = 1262304000L
+    // The X-LINE returns a timestamp in seconds since 2020-01-01 only in the body composition response
+    private val ALT_TS_OFFSET = 315619200
 
     // --- Pairing state ---------------------------------------------------------
 
@@ -232,11 +235,16 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         if (fat == null && water == null && muscle == null && bone == null) return
 
         val ts = ConverterUtils.fromSignedInt32Le(data, 1)
-        val weight = if (lastTS == ts) lastWeight else null
+        if (lastTS == null || (lastTS != ts && lastTS != ts + ALT_TS_OFFSET)) {
+            logW("Timestamps don't match: $ts; $lastTS")
+            return
+        }
+
+        val weight = lastWeight
         if (weight == null || weight <= 0f) return
 
         val m = ScaleMeasurement().apply {
-            dateTime = Date(deviceTimeToJava(ts))
+            dateTime = Date(deviceTimeToJava(lastTS!!))
             this.weight = weight
         }
         fat?.let { m.fat = it }


### PR DESCRIPTION
Adding support for my scale, a Terraillon X-LINE. This model, from the Transtek family, is very similar to the Body Connect, which is already supported in the `BodyConnectHandler.kt`. A timestamp adaptation is needed though, as the scale returns a timestamp based on 2020-01-01, only when providing the body composition info.

I cannot test with the Body Connect scale, but the code should behave the same.

## Changes
* Add `0X-LINE*` to the supported devices for the `BodyConnectHandler.kt`
* Adapt the display name
* Make an adaptation on timestamps in `onBody`

## Tests
I tested the following:
* On the app, created a new user, matching the one that is already stored in the scale
* Paired the app with the scale
* Initiated a measurement with weight, water, fat, muscle and bone
* Made sure the history is retrieved
* Made sure the timstamps are correct

## btsnoop HCI log file
This was taken with the Manufacturer's app:
[btsnoop_hci.log](https://github.com/user-attachments/files/30969452/btsnoop_hci.log)

This one is more extensive, as it contains the pairing, etc:
[btsnoop_hci_pairing.log](https://github.com/user-attachments/files/30980172/btsnoop_hci_pairing.log)