### PR TITLE
fix(bluetooth): stop MGBHandler claiming shared 0xFFB0 by service alone (#1470)

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -118,9 +118,9 @@ class ScaleFactory @Inject constructor(
          * Builds the list of modern Kotlin-based device handlers.
          *
          * Order matters: [createCommunicator] returns the FIRST handler whose [ScaleDeviceHandler.supportFor]
-         * is non-null. TaylorBIAHandler, FitTrackDaraHandler, RelaxmedicHandler, RobiS9Handler and
-         * DrTrustSSW532Handler must stay ahead of MGBHandler — all live on service 0xFFB0, which
-         * MGBHandler matches on its own, so a later position would let MGB wrongly claim them.
+         * is non-null. Keep name-specific 0xFFB0 siblings (TaylorBIA, FitTrack Dara, Relaxmedic,
+         * Robi S9, DrTrust SSW532, …) ahead of broader catch-alls. MGBHandler is name-gated
+         * (swan/icomon/yg) and must not claim shared 0xFFB0 by service alone (#1470).
          *
          * Exposed so the registry (order, device claims, duplicates) can be asserted in unit tests
          * without building the Hilt graph — see `ScaleFactoryTest`.

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/MGBHandler.kt
@@ -79,11 +79,11 @@ class MGBHandler : ScaleDeviceHandler() {
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name.lowercase(Locale.ROOT)
+        // Name-only: service 0xFFB0 is shared by many unrelated OEM forks (Dr. Trust SSW532,
+        // FitTrack Dara, Taylor BIA, …). Matching on service alone let this catch-all steal
+        // those devices when it sat ahead of their handlers (see #1470).
         val nameMatch = name.startsWith("swan") || (name == "icomon") || (name == "yg")
-
-        val serviceMatch = device.serviceUuids.any { it == SERVICE }
-
-        if (!nameMatch && !serviceMatch) return null
+        if (!nameMatch) return null
 
         val caps = setOf(
             DeviceCapability.LIVE_WEIGHT_STREAM, // we get final (and sometimes intermediate) frames

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleFactoryTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleFactoryTest.kt
@@ -191,9 +191,8 @@ class ScaleFactoryTest {
     // --- Ordering ---------------------------------------------------------------------------
 
     /**
-     * MGBHandler claims *any* device advertising service 0xFFB0, so every sibling on that service
-     * only wins by standing earlier in the list. This pins the documented order; moving MGBHandler
-     * up (or a sibling down) breaks these devices silently at runtime.
+     * Several unrelated handlers share service 0xFFB0. They must still claim their own names,
+     * and MGBHandler (swan/icomon/yg only) must not steal them via a service-only match.
      */
     @Test
     fun `0xFFB0 siblings are matched ahead of the generic MGB handler`() {
@@ -203,36 +202,28 @@ class ScaleFactoryTest {
         assertClaimedBy(device("robi", SERVICE_FFB0), RobiS9Handler::class.java)
         assertClaimedBy(device("SSW532", SERVICE_FFB0), DrTrustSSW532Handler::class.java)
 
-        // The generic member of the family keeps the devices nobody else claims.
         assertClaimedBy(device("swan", SERVICE_FFB0), MGBHandler::class.java)
 
-        val order = ScaleFactory.createHandlers().map { it.javaClass.simpleName }
-        val mgb = order.indexOf("MGBHandler")
-        val siblings = listOf(
-            "TaylorBIAHandler",
-            "FitTrackDaraHandler",
-            "RelaxmedicHandler",
-            "RobiS9Handler",
-            "DrTrustSSW532Handler",
-        )
-        for (sibling in siblings) {
-            assertThat(order.indexOf(sibling)).isLessThan(mgb)
-        }
+        // Unknown 0xFFB0 name: MGB must not claim it (service alone is not enough).
+        assertThat(MGBHandler().supportFor(device("SomeOtherFFB0Scale", SERVICE_FFB0))).isNull()
+        assertThat(claimants(device("SomeOtherFFB0Scale", SERVICE_FFB0)).map { it.javaClass.simpleName })
+            .doesNotContain("MGBHandler")
     }
 
     /**
-     * The Dr. Trust driver only claims a device when the name *and* the 0xFFB0 service match, so it
-     * can never take a device away from MGBHandler — but it sat behind MGB in the registry, which
-     * meant MGB (service-only match) swallowed every SSW-532. Pins both halves of that fix.
+     * Regression for #1470: MGB must not claim Dr. Trust SSW532 (shared 0xFFB0) by service alone.
+     * MGB is name-gated (swan/icomon/yg); DrTrust still needs name + service.
      */
     @Test
     fun `Dr Trust SSW532 is not swallowed by the service-only MGB match`() {
         assertClaimedBy(device("SSW532", SERVICE_FFB0), DrTrustSSW532Handler::class.java)
         assertClaimedBy(device("SSW-532 FG2211", SERVICE_FFB0), DrTrustSSW532Handler::class.java)
 
+        assertThat(MGBHandler().supportFor(device("SSW532", SERVICE_FFB0))).isNull()
+
         // Without the service the Dr. Trust handler must stay out of the way…
         assertThat(claimants(device("SSW532")).map { it.javaClass.simpleName }).isEmpty()
-        // …and without the name it must not touch MGB's own devices.
+        // …and MGB still owns its own names.
         assertClaimedBy(device("icomon", SERVICE_FFB0), MGBHandler::class.java)
         assertClaimedBy(device("yg", SERVICE_FFB0), MGBHandler::class.java)
     }


### PR DESCRIPTION
## Summary
- `MGBHandler.supportFor` now requires a known MGB BLE name (`swan` / `icomon` / `yg`) instead of matching **any** device that only advertises shared service `0xFFB0`.
- Updates `ScaleFactory` docs + `ScaleFactoryTest` for that rule.

Fixes https://github.com/oliexdev/openScale/issues/1470

## Why (generic, not scale-specific)
`0xFFB0` is shared by several unrelated handlers. A service-only MGB catch-all steals whoever is later in the registry (reproduced on **3.1.2** with Dr. Trust `SSW532` → SWAN/Icomon MGB, FFB2-only, no FFB3 body-comp).

Name-gating MGB fixes every sibling on that service, not only SSW532. Registry order remains defense in depth.

## Test plan
- [ ] `ScaleFactoryTest` (FFB0 siblings + Dr Trust / MGB cases)
- [ ] Manual: `SSW532` binds as **Dr. Trust SSW532**, not SWAN/MGB; weigh-in saves
- [ ] Manual: a real `swan`/`icomon`/`yg` device still uses MGBHandler