### PR TITLE
Added support for Etekcity Fit 8S Scale.

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -39,6 +39,7 @@ import com.health.openscale.core.bluetooth.scales.EufyC20Handler
 import com.health.openscale.core.bluetooth.scales.EufyP2Handler
 import com.health.openscale.core.bluetooth.scales.EbelterBodyFatB2Handler
 import com.health.openscale.core.bluetooth.scales.EtekcityESF551Handler
+import com.health.openscale.core.bluetooth.scales.EtekcityFit8SHandler
 import com.health.openscale.core.bluetooth.scales.GattScaleAdapter
 import com.health.openscale.core.bluetooth.scales.HesleyHandler
 import com.health.openscale.core.bluetooth.scales.HoffenBbs8107Handler
@@ -175,6 +176,7 @@ class ScaleFactory @Inject constructor(
             EbelterBodyFatB2Handler(),
             ExcelvanCF36xHandler(),
             EtekcityESF551Handler(),
+            EtekcityFit8SHandler(),
             EufyC20Handler(),
             EufyP2Handler(),
             ESCS20MHandler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
@@ -34,6 +34,7 @@ import java.util.UUID
  * advertisement with key `0x06D0` for "Etekcity Corporation". It also adds `SCALE_SERIVCE` 
  * uuid defined below.
  *
+ * Measurement data is always 20 bytes. Device does not advertise any other data format.
  * Data structure (from ronnnnnnnnnnnnn code):
  * - `[0]`    : header byte (`0x01`) (ignored)
  * - `[1:7]`   : device MAC address, little-endian (ignored)
@@ -94,7 +95,7 @@ class EtekcityFit8SHandler : ScaleDeviceHandler() {
         // record in the same advertisement is a different vendor's data and must not be parsed.
         val payload = msd.get(MANUFACTURER_ID) ?: return BroadcastAction.IGNORED
 
-        if (payload.size < PAYLOAD_SIZE) {
+        if (payload.size != PAYLOAD_SIZE) {
             logD("Manufacturer record too short (${payload.size} bytes), ignoring")
             return BroadcastAction.IGNORED
         }

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
@@ -1,0 +1,153 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.le.ScanResult
+import android.util.SparseArray
+import androidx.core.util.isEmpty
+import androidx.core.util.size
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
+import com.health.openscale.core.service.ScannedDeviceInfo
+import java.util.Date
+import java.util.UUID
+
+// Based on https://github.com/ronnnnnnnnnnnnn/etekcity_esf551_ble
+
+/**
+ * Etekcity Fit 8S scale handler
+ *
+ * The device supports Broadcasts only. It puts data in ManufacturerSpecific data
+ * advertisement with key `0x06D0` for "Etekcity Corporation". It also adds `SCALE_SERIVCE` 
+ * uuid defined below.
+ *
+ * Data structure (from ronnnnnnnnnnnnn code):
+ * - `[0]`    : header byte (`0x01`) (ignored)
+ * - `[1:7]`   : device MAC address, little-endian (ignored)
+ * - `[7:10]`  : unknown (ignored)
+ * - `[10:13]` : weight in grams, 3-byte little-endian int
+ * - `[13:15]` : bioelectrical impedance in ohms, 2-byte little-endian int (0 = not measured)
+ * - `[15]`   : stability flag (`0x01` = stable reading)
+ * - `[16]`   : display unit (`0x00`=kg, `0x01`=lb, `0x02`=st) 
+ *                  (ignored since incoming data always in grams 
+ *                   and no way to change device settings remotely)
+ * - `[17:20]` : unknown/constant (ignored)
+ * 
+ */
+class EtekcityFit8SHandler : ScaleDeviceHandler() {
+    companion object {
+        private const val MANUFACTURER_ID = 0x06D0
+        private val SCALE_SERVICE = UUID.fromString("0000ffd0-0000-1000-8000-00805f9b34fb")
+    }
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        // device return data in manufacturer data with MANUFACTURER_ID key
+        if (device.manufacturerData == null || !device.manufacturerData.contains(MANUFACTURER_ID)) {
+            logD("No manufacturer data or manufacturer id is incorrect, ignoring device")
+            return null
+        }
+
+        // all messages from device have service UUID 16: 0xffd0
+        if (!device.serviceUuids.contains(SCALE_SERVICE)) {
+            logD("Does not contain correct service uuid, ignoring device")
+            return null
+        }
+
+        return DeviceSupport(
+            displayName = "Etekcity Fit 8S",
+            capabilities = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+            ),
+            implemented = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+            ),
+            linkMode = LinkMode.BROADCAST_ONLY,
+        )
+    }
+    
+    
+    /**
+     * Handle a single advertisement; return a BroadcastAction to steer the adapter.
+     */
+    override fun onAdvertisement(result: ScanResult, user: ScaleUser): BroadcastAction {
+        val msgRaw = result.scanRecord?.manufacturerSpecificData ?: return BroadcastAction.IGNORED
+
+        val msg = msgRaw as? SparseArray<*> ?: return BroadcastAction.IGNORED
+        
+        if (msg.isEmpty()) return BroadcastAction.IGNORED
+        
+        val values = (0 until msg.size).mapNotNull { msg.valueAt(it) as? ByteArray }
+
+        val payload = values.firstOrNull { it.size >= 20} ?: return BroadcastAction.IGNORED
+
+        if ((payload[15].toInt() and 0xFF) != 1) {
+            logD("Measurement not stable yet. Continuing...")
+
+            return BroadcastAction.CONSUMED_KEEP_SCANNING
+        }
+
+        logD("Measurement stabilized.")
+
+        val weightGrams: Int = (payload[10].toInt() and 0xFF) or
+                    ((payload[11].toInt() and 0xFF) shl 8) or
+                    ((payload[12].toInt() and 0xFF) shl 16)
+
+        if (weightGrams <= 0) {
+            // invalid weight
+            return BroadcastAction.CONSUMED_KEEP_SCANNING
+        }
+
+        val weightKg = weightGrams.toFloat() / 1000.0f
+
+        val m = ScaleMeasurement().apply {
+            userId = user.id
+            dateTime = Date()
+            weight = weightKg
+        }
+
+        val impedance = (payload[13].toInt() and 0xFF) or
+                ((payload[14].toInt() and 0xFF) shl 8)
+
+        if (impedance != 0) {
+            m.impedance = impedance.toDouble()
+
+            val lib = StandardImpedanceLib(
+                gender = user.gender,
+                age = user.age,
+                weightKg = m.weight.toDouble(),
+                heightM = user.bodyHeight / 100.0,
+                impedance = m.impedance
+            )
+
+            m.fat = lib.totalFatPercentage.toFloat()
+            m.water = lib.totalBodyWaterPercentage.toFloat()
+            m.muscle = lib.skeletalMusclePercentage.toFloat()
+            m.bone = lib.boneMassKg.toFloat()
+            m.bmr = lib.basalMetabolicRate.toFloat()
+            m.lbm = lib.fatFreeMassKg.toFloat()
+        } else {
+            logD("Impedance is missing or zero. Publishing weight only")
+        }
+
+        publish(m)
+        return BroadcastAction.CONSUMED_STOP
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/EtekcityFit8SHandler.kt
@@ -18,9 +18,6 @@
 package com.health.openscale.core.bluetooth.scales
 
 import android.bluetooth.le.ScanResult
-import android.util.SparseArray
-import androidx.core.util.isEmpty
-import androidx.core.util.size
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
 import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
@@ -54,6 +51,9 @@ class EtekcityFit8SHandler : ScaleDeviceHandler() {
     companion object {
         private const val MANUFACTURER_ID = 0x06D0
         private val SCALE_SERVICE = UUID.fromString("0000ffd0-0000-1000-8000-00805f9b34fb")
+
+        /** Bytes the layout documented above needs; shorter records are not a measurement. */
+        private const val PAYLOAD_SIZE = 20
     }
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
@@ -88,15 +88,16 @@ class EtekcityFit8SHandler : ScaleDeviceHandler() {
      * Handle a single advertisement; return a BroadcastAction to steer the adapter.
      */
     override fun onAdvertisement(result: ScanResult, user: ScaleUser): BroadcastAction {
-        val msgRaw = result.scanRecord?.manufacturerSpecificData ?: return BroadcastAction.IGNORED
+        val msd = result.scanRecord?.manufacturerSpecificData ?: return BroadcastAction.IGNORED
 
-        val msg = msgRaw as? SparseArray<*> ?: return BroadcastAction.IGNORED
-        
-        if (msg.isEmpty()) return BroadcastAction.IGNORED
-        
-        val values = (0 until msg.size).mapNotNull { msg.valueAt(it) as? ByteArray }
+        // Only the record under our own company id carries the layout documented above; any other
+        // record in the same advertisement is a different vendor's data and must not be parsed.
+        val payload = msd.get(MANUFACTURER_ID) ?: return BroadcastAction.IGNORED
 
-        val payload = values.firstOrNull { it.size >= 20} ?: return BroadcastAction.IGNORED
+        if (payload.size < PAYLOAD_SIZE) {
+            logD("Manufacturer record too short (${payload.size} bytes), ignoring")
+            return BroadcastAction.IGNORED
+        }
 
         if ((payload[15].toInt() and 0xFF) != 1) {
             logD("Measurement not stable yet. Continuing...")

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleFactoryTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleFactoryTest.kt
@@ -17,10 +17,19 @@
  */
 package com.health.openscale.core.bluetooth
 
+import android.util.SparseArray
 import com.google.common.truth.Truth.assertThat
 import com.health.openscale.core.bluetooth.scales.DrTrustSSW532Handler
+import com.health.openscale.core.bluetooth.scales.EtekcityESF551Handler
+import com.health.openscale.core.bluetooth.scales.EtekcityFit8SHandler
+import com.health.openscale.core.bluetooth.scales.EufyC20Handler
 import com.health.openscale.core.bluetooth.scales.FitTrackDaraHandler
 import com.health.openscale.core.bluetooth.scales.MGBHandler
+import com.health.openscale.core.bluetooth.scales.OkOkHandler
+import com.health.openscale.core.bluetooth.scales.QNHandlerBroadcast
+import com.health.openscale.core.bluetooth.scales.ScaleupHandler
+import com.health.openscale.core.bluetooth.scales.SinocareHandler
+import com.health.openscale.core.bluetooth.scales.YunmaiXHandler
 import com.health.openscale.core.bluetooth.scales.RelaxmedicHandler
 import com.health.openscale.core.bluetooth.scales.RobiS9Handler
 import com.health.openscale.core.bluetooth.scales.SanitasSbf72Handler
@@ -74,6 +83,25 @@ class ScaleFactoryTest {
         rssi = -50,
         serviceUuids = services.toList(),
         manufacturerData = null,
+    )
+
+    /**
+     * A broadcast advertisement: name (often empty on broadcast-only scales), advertised services
+     * and the manufacturer-specific records, keyed by company id exactly like `ScanRecord` hands
+     * them to the scanner.
+     */
+    private fun advertisement(
+        name: String = "",
+        services: List<UUID> = emptyList(),
+        manufacturerData: List<Pair<Int, ByteArray>> = emptyList(),
+    ) = ScannedDeviceInfo(
+        name = name,
+        address = "C0:FF:EE:12:34:56",
+        rssi = -50,
+        serviceUuids = services,
+        manufacturerData = SparseArray<ByteArray>().apply {
+            manufacturerData.forEach { (id, data) -> put(id, data) }
+        },
     )
 
     private fun uuid16(short: Int): UUID =
@@ -247,6 +275,139 @@ class ScaleFactoryTest {
 
         val order = ScaleFactory.createHandlers().map { it.javaClass.simpleName }
         assertThat(order.indexOf("SanitasSbf72Handler")).isLessThan(order.indexOf("BeurerSanitasHandler"))
+    }
+
+    // --- Broadcast fingerprints -------------------------------------------------------------
+
+    /** Etekcity's company id — together with service 0xFFD0 the only fingerprint of the Fit 8S. */
+    private val ETEKCITY_COMPANY_ID = 0x06D0
+
+    /** Service 0xFFD0 — advertised by the Fit 8S alongside its manufacturer record. */
+    private val SERVICE_FFD0 = uuid16(0xFFD0)
+
+    /** A stable 75.500 kg / 500 Ω reading in the Fit 8S advertisement layout. */
+    private fun fit8sPayload(): ByteArray = ByteArray(20).apply {
+        this[0] = 0x01                              // header
+        this[10] = 0xEC.toByte()                    // weight 75500 g, 3-byte little-endian
+        this[11] = 0x26
+        this[12] = 0x01
+        this[13] = 0xF4.toByte()                    // impedance 500 Ω, 2-byte little-endian
+        this[14] = 0x01
+        this[15] = 0x01                             // stable
+    }
+
+    private fun fit8sAdvertisement() = advertisement(
+        name = "",                                  // the scale advertises no name at all
+        services = listOf(SERVICE_FFD0),
+        manufacturerData = listOf(ETEKCITY_COMPANY_ID to fit8sPayload()),
+    )
+
+    /**
+     * The Fit 8S is nameless, so it can only be recognised by company id plus service UUID. Both
+     * halves must be required: matching on either one alone would make the handler claim
+     * advertisements it cannot parse.
+     */
+    @Test
+    fun `the nameless Etekcity Fit 8S is claimed by its own handler`() {
+        assertClaimedBy(fit8sAdvertisement(), EtekcityFit8SHandler::class.java)
+
+        val fit8s = EtekcityFit8SHandler()
+        // Company id without the service…
+        assertThat(
+            fit8s.supportFor(
+                advertisement(manufacturerData = listOf(ETEKCITY_COMPANY_ID to fit8sPayload()))
+            )
+        ).isNull()
+        // …and the service without the company id.
+        assertThat(
+            fit8s.supportFor(
+                advertisement(
+                    services = listOf(SERVICE_FFD0),
+                    manufacturerData = listOf(0xFF64 to fit8sPayload()),
+                )
+            )
+        ).isNull()
+        // A scan result that carried no manufacturer data at all.
+        assertThat(fit8s.supportFor(device("", SERVICE_FFD0))).isNull()
+    }
+
+    /**
+     * ScaleupHandler claims *any* manufacturer record whose company-id low byte is 0xD0 or 0xE0 —
+     * and Etekcity's company id 0x06D0 ends in 0xD0, so both handlers answer for a Fit 8S. Only the
+     * list position keeps the device on the driver that can decode it.
+     */
+    @Test
+    fun `Etekcity Fit 8S is matched ahead of the low-byte Scaleup match`() {
+        val claimants = claimants(fit8sAdvertisement()).map { it.javaClass.simpleName }
+        assertThat(claimants).containsExactly("EtekcityFit8SHandler", "ScaleupHandler").inOrder()
+
+        val order = ScaleFactory.createHandlers().map { it.javaClass.simpleName }
+        assertThat(order.indexOf("EtekcityFit8SHandler")).isLessThan(order.indexOf("ScaleupHandler"))
+    }
+
+    /**
+     * The other direction of the same overlap: a Scaleup advertisement carries no 0xFFD0 service
+     * and a different company id, so the Fit 8S handler must keep its hands off it.
+     */
+    @Test
+    fun `Scaleup broadcasts are not swallowed by the Etekcity Fit 8S handler`() {
+        // key = (weight MSB shl 8) or flag → 75.50 kg (0x1D7E) while measuring (0xD0)
+        val scaleup = advertisement(manufacturerData = listOf(0x1DD0 to ByteArray(9)))
+
+        assertClaimedBy(scaleup, ScaleupHandler::class.java)
+        assertThat(EtekcityFit8SHandler().supportFor(scaleup)).isNull()
+    }
+
+    /**
+     * The connectable Etekcity ESF551 is the Fit 8S's closest neighbour — same vendor, so possibly
+     * the same company id. It identifies itself by name and must keep winning: the Fit 8S handler
+     * would otherwise downgrade it to broadcast-only.
+     */
+    @Test
+    fun `the named Etekcity ESF551 wins over the broadcast Fit 8S handler`() {
+        val esf551 = advertisement(
+            name = "Etekcity Smart Fitness Scale",
+            services = listOf(SERVICE_FFD0),
+            manufacturerData = listOf(ETEKCITY_COMPANY_ID to fit8sPayload()),
+        )
+
+        assertClaimedBy(esf551, EtekcityESF551Handler::class.java)
+
+        val order = ScaleFactory.createHandlers().map { it.javaClass.simpleName }
+        assertThat(order.indexOf("EtekcityESF551Handler"))
+            .isLessThan(order.indexOf("EtekcityFit8SHandler"))
+    }
+
+    /**
+     * The registry holds several handlers that identify a scale from its manufacturer record alone.
+     * Each must keep its own advertisement, and none of them may be answered by the Fit 8S handler.
+     */
+    @Test
+    fun `manufacturer-data broadcasts stay with their own handler`() {
+        val expectations: List<Pair<ScannedDeviceInfo, Class<out ScaleDeviceHandler>>> = listOf(
+            // Sinocare — company id 0xFF64
+            advertisement(manufacturerData = listOf(0xFF64 to ByteArray(12)))
+                    to SinocareHandler::class.java,
+            // QN broadcast variant — company id 0xFFFF with the AABB magic header
+            advertisement(
+                manufacturerData = listOf(
+                    0xFFFF to byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0x00, 0x00, 0x00, 0x00)
+                )
+            ) to QNHandlerBroadcast::class.java,
+            // Eufy C20 — company id 0xBC64
+            advertisement(manufacturerData = listOf(48228 to ByteArray(14)))
+                    to EufyC20Handler::class.java,
+            // OKOK V20 — company id 0x20CA behind one of the known names
+            advertisement(name = "ADV", manufacturerData = listOf(0x20CA to ByteArray(16)))
+                    to OkOkHandler::class.java,
+            // Yunmai X — recognised by its advertised 16-bit service 0x1320
+            advertisement(services = listOf(uuid16(0x1320))) to YunmaiXHandler::class.java,
+        )
+
+        for ((device, expected) in expectations) {
+            assertClaimedBy(device, expected)
+            assertThat(EtekcityFit8SHandler().supportFor(device)).isNull()
+        }
     }
 
     // --- Non-scales -------------------------------------------------------------------------


### PR DESCRIPTION
Model name: Etekcity Fit 8S.
Features working:
- Live Weight
- Body Composition (impedance)

Notes about the implementation:
- The reverse engineering was already done by ronnnnnnnnnnnnn in  [his python project](https://github.com/ronnnnnnnnnnnnn/etekcity_esf551_ble). This implementation takes information from the work in that project.
- The device operates in Broadcast mode only. No GATT connection.
- I used the built-in `StandardImpedanceLib` for derived information only when impedance is available.
- The device does not publish its name in advertisement. The only way to filter it is by Manufacturer ID in advertisement and Scale service UUID. As such:
    - The handler for `Etekcity Fit 8S` may interfere with advertisements from the same manufacturer. I made sure to put the handler below other `Etekcity` handlers in `modernKotlinHandlers`.
    - The device shows with `Unknown` name in Settings-Bluetooth screen. I'm not sure how to fix that. _(screenshot below)_
- Documentation and tests have not been updated. _(Let me know if they are required)_
- The device has a button to switch display units. It reports its current display unit in advertisement data. However, it always reports the actual weight in grams. There is no way to switch the on-device display units remotely. The code currently ignores the display unit flag.

Instead of the `btsnoop_hci.log`, I've attached a filtered WireShark capture of a couple of measurements. [scale-capture-72..zip](https://github.com/user-attachments/files/31092117/scale-capture-72.zip)  I filtered by BD_ADDR. Let me know if this is sufficient.

<img width="1080" height="796" alt="openScale-unknown-name" src="https://github.com/user-attachments/assets/843e9abf-64f4-4a35-96da-b18743ef0047" />