### PR TITLE
feat: Add support for the ProfiCare PC-PW 3008 BT

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/HoffenBbs8107Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/HoffenBbs8107Handler.kt
@@ -30,12 +30,17 @@ import java.util.UUID
 import kotlin.math.max
 
 /**
- * Handler for the Hoffen BBS-8107 scale.
+ * Handler for the Hoffen BBS-8107 and its rebrands.
  *
  * Protocol (single custom characteristic):
  *  - Service 0xFFB0, Characteristic 0xFFB2 (notify + write with response)
  *  - Packets start with 0xFA, then `cmdOrResp`, `len`, `payload`, `checksum`
  *  - Checksum = XOR of bytes 1..(n-2); some final measurement frames deliver checksum in a follow-up notify.
+ *
+ * This is the Chipsea "WeChat scale" protocol: the same firmware is sold under several brands,
+ * all advertising the WeChat service 0xFEE7 alongside the 0xFFB0 service they actually talk on.
+ * Verified against the stock "Dr.Curve+" app (`com.yilai.DrCurvePlus`), whose `onWeixinFatScale`
+ * routine decodes exactly the offsets [parseFinalMeasurement] uses.
  */
 class HoffenBbs8107Handler : ScaleDeviceHandler() {
 
@@ -46,9 +51,20 @@ class HoffenBbs8107Handler : ScaleDeviceHandler() {
 
     // --- DeviceSupport --------------------------------------------------------
 
+    /**
+     * Advertised name (lowercased) → name to show in the UI.
+     *
+     * Matched by exact name on purpose. These scales also advertise service 0xFEE7, but that is
+     * the generic WeChat BLE service used by all kinds of unrelated devices, so claiming it
+     * outright would produce false positives in the scan list.
+     */
+    private val KNOWN_DEVICES = mapOf(
+        "hoffen bs-8107" to "Hoffen BBS-8107",
+        "pc-pw 3008 bt" to "ProfiCare PC-PW 3008 BT",
+    )
+
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
-        val name = device.name.lowercase(Locale.US)
-        if (name != "hoffen bs-8107") return null
+        val displayName = KNOWN_DEVICES[device.name.trim().lowercase(Locale.US)] ?: return null
 
         val caps = setOf(
             DeviceCapability.BODY_COMPOSITION,
@@ -57,7 +73,7 @@ class HoffenBbs8107Handler : ScaleDeviceHandler() {
         )
         // We implement everything we claim above.
         return DeviceSupport(
-            displayName = "Hoffen BBS-8107",
+            displayName = displayName,
             capabilities = caps,
             implemented = caps,
             linkMode = LinkMode.CONNECT_GATT

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
@@ -210,6 +210,7 @@ object ScaleCatalog {
         device("Hagrid-B29") claimedBy HuaweiHagridWspHandler::class.java,
         device("HUAWEI Scale 3") claimedBy HuaweiHagridWspHandler::class.java,
         device("Hoffen BS-8107") claimedBy HoffenBbs8107Handler::class.java,
+        device("PC-PW 3008 BT") claimedBy HoffenBbs8107Handler::class.java,
         device("yunchen") claimedBy HesleyHandler::class.java,
         device("vscale") claimedBy ExingtechY1Handler::class.java,
         device("Body Fat-B2") claimedBy EbelterBodyFatB2Handler::class.java,

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/HoffenBbs8107HandlerTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/HoffenBbs8107HandlerTest.kt
@@ -1,0 +1,95 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.core.service.ScannedDeviceInfo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+/**
+ * Matching tests for [HoffenBbs8107Handler], which drives a Chipsea "WeChat scale" firmware sold
+ * under more than one brand.
+ *
+ * Fixtures are synthetic advertisements built from the names these scales are documented to
+ * advertise, not personal captures.
+ *
+ * Robolectric is required for android.util.SparseArray in ScannedDeviceInfo.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HoffenBbs8107HandlerTest {
+
+    /** The generic WeChat service these scales advertise alongside the 0xFFB0 they talk on. */
+    private val SERVICE_FEE7 = uuid16(0xFEE7)
+
+    private fun uuid16(short: Int): UUID =
+        UUID.fromString(String.format("0000%04x-0000-1000-8000-00805f9b34fb", short))
+
+    private fun device(name: String, vararg services: UUID) = ScannedDeviceInfo(
+        name = name,
+        address = "C0:FF:EE:12:34:56",
+        rssi = -50,
+        serviceUuids = services.toList(),
+        manufacturerData = null,
+    )
+
+    @Test
+    fun `claims the Hoffen BBS-8107`() {
+        val support = HoffenBbs8107Handler().supportFor(device("Hoffen BS-8107", SERVICE_FEE7))
+        assertThat(support).isNotNull()
+        assertThat(support!!.displayName).isEqualTo("Hoffen BBS-8107")
+    }
+
+    @Test
+    fun `claims the ProfiCare PC-PW 3008 BT rebrand under its own name`() {
+        val support = HoffenBbs8107Handler().supportFor(device("PC-PW 3008 BT", SERVICE_FEE7))
+        assertThat(support).isNotNull()
+        assertThat(support!!.displayName).isEqualTo("ProfiCare PC-PW 3008 BT")
+        assertThat(support.linkMode).isEqualTo(LinkMode.CONNECT_GATT)
+    }
+
+    @Test
+    fun `matches regardless of case and surrounding whitespace`() {
+        assertThat(HoffenBbs8107Handler().supportFor(device("pc-pw 3008 bt"))).isNotNull()
+        assertThat(HoffenBbs8107Handler().supportFor(device(" PC-PW 3008 BT "))).isNotNull()
+    }
+
+    @Test
+    fun `implements everything it claims`() {
+        val support = HoffenBbs8107Handler().supportFor(device("PC-PW 3008 BT"))!!
+        assertThat(support.implemented).isEqualTo(support.capabilities)
+        assertThat(support.capabilities).contains(DeviceCapability.BODY_COMPOSITION)
+    }
+
+    @Test
+    fun `does not claim other devices advertising the generic WeChat service`() {
+        // 0xFEE7 is used by all sorts of unrelated hardware; the name is what decides.
+        assertThat(HoffenBbs8107Handler().supportFor(device("MI Band 5", SERVICE_FEE7))).isNull()
+        assertThat(HoffenBbs8107Handler().supportFor(device("", SERVICE_FEE7))).isNull()
+    }
+
+    @Test
+    fun `does not claim a similarly named but different model`() {
+        assertThat(HoffenBbs8107Handler().supportFor(device("PC-PW 3007 BT"))).isNull()
+        assertThat(HoffenBbs8107Handler().supportFor(device("PC-PW 3008"))).isNull()
+    }
+}

--- a/android_app/app/src/test/resources/scale_catalog_remarks.txt
+++ b/android_app/app/src/test/resources/scale_catalog_remarks.txt
@@ -16,3 +16,4 @@ ES-CS20M / ES-32MD = Uses the Trisa Body Analyze body measurement library until 
 Custom openScale = See [here](Custom-Bluetooth-Scale) for a tutorial
 Trisa Body Analyze 4.0 = See [Trisa Body Analyze](Trisa-Body-Analyze) for the protocol
 Debug = Not a scale: assign it to a device to record its GATT services for reverse engineering
+ProfiCare PC-PW 3008 BT = Same Chipsea "WeChat scale" firmware as the Hoffen BBS-8107, so it is driven by the same handler


### PR DESCRIPTION
## Scale

**ProfiCare PC-PW 3008 BT** — body-analysis scale sold mainly in the German market. Vendor app: "Dr.Curve+" (`com.yilai.DrCurvePlus`).

## What this changes

The PC-PW 3008 BT runs the same Chipsea "WeChat scale" firmware as the Hoffen BBS-8107, so `HoffenBbs8107Handler` already decoded it correctly — the only thing missing was recognition. The handler's exact-name check becomes a small advertised-name → display-name map, so the scale is reported under its own product name instead of the Hoffen's.

**No protocol/parsing code changed.**

## Feature status

Verified on real hardware (Samsung Galaxy A55), matching the vendor app's readings:

- Weight
- Body composition: fat, water, muscle, bone, visceral fat

Capability flags are unchanged from the existing handler (`BODY_COMPOSITION`, `USER_SYNC`, `UNIT_CONFIG`).

## Evidence

The scale advertises:

```
02 01 06                    Flags
03 02 E7 FE                 16-bit service UUID 0xFEE7   (WeChat service)
0E 09 "PC-PW 3008 BT"       Complete Local Name
09 FF 31 01 6A2B0000A6BC    Manufacturer data, company 0x0131
```

I don't have a `btsnoop_hci.log` for this scale. Instead the protocol was confirmed by decompiling the vendor app: its `onWeixinFatScale` routine decodes exactly the offsets `parseFinalMeasurement` already uses — weight LE16 @3, fat @6, water @8, muscle @10, bone @14, visceral fat @17 — and its command set (`0xFA 0x85` user, `0xFA 0x83` unit, `0xFA 0x82` done; responses `0x01`/`0x02`/`0x03`) matches what the handler sends. The hardware test above then confirmed it end to end.

Happy to capture an HCI log if you'd like it for the record.

## Why matched by name

Matched on the advertised name rather than on service `0xFEE7`. That service is the generic WeChat BLE service used by plenty of unrelated hardware, so claiming it outright would list non-scales as supported devices. `HoffenBbs8107HandlerTest` covers that case explicitly.

## Tests

- `ScaleCatalog.kt` — one fixture line, so the registry regression test and the generated wiki row both follow automatically
- `scale_catalog_remarks.txt` — remark noting the shared firmware, since the table now has two rows served by one handler
- `HoffenBbs8107HandlerTest` — new; 6 tests covering both brands, case/whitespace tolerance, and negative matches (other 0xFEE7 devices, near-miss model names)

`./gradlew testDebugUnitTest compileDebugAndroidTestKotlin assembleDebug` passes, with two exceptions unrelated to this change: `BackupRestoreUseCasesTest.restoreDatabase_withValidBackupZip_restoresPreviousSnapshot` and `restoreDatabase_withLegacySingleFile_restoresAndMigrates` fail identically on unmodified `master` (61cb196) in my environment (Windows, JDK 21), so they look environmental rather than caused by this PR.
