### PR TITLE
Improvements to the X-LINE

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandler.kt
@@ -18,11 +18,14 @@
 package com.health.openscale.core.bluetooth.scales
 
 import com.health.openscale.R
+import com.health.openscale.core.bluetooth.BluetoothEvent.UserInteractionType
 import com.health.openscale.core.bluetooth.data.ScaleMeasurement
 import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.data.ActivityLevel
 import com.health.openscale.core.service.ScannedDeviceInfo
 import com.health.openscale.core.utils.ConverterUtils
 
+import java.nio.charset.StandardCharsets
 import java.util.Date
 import java.util.UUID
 import kotlin.random.Random
@@ -30,7 +33,7 @@ import kotlin.random.Random
 /**
  * BodyConnectHandler
  * ------------------
- * Modern Kotlin handler for the **1BODY CONNECT** smart scale (Transtek family).
+ * Modern Kotlin handler for the **1BODY CONNECT** and X-LINE smart scales (Transtek family).
  *
  * Protocol highlights (per BTSnoop analysis):
  * - GATT Service:      0x7892
@@ -47,7 +50,7 @@ import kotlin.random.Random
  *
  * Host→device opcodes:
  * - 0x02 = Set Time        (UTC timestamp as seconds since 2010-01-01)
- * - 0x03 = Slot Ack        (echo of a slot status record)
+ * - 0x03 = Add User        (Register a user name into a slot)
  * - 0x20 = Challenge Resp  (challenge XOR password)
  * - 0x21 = Broadcast ID    (sent during pairing)
  * - 0x22 = Enable Disconnect
@@ -59,12 +62,13 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
         val name = device.name
-        if (!name.startsWith("1BODY CONNECT") && !name.startsWith("0BODY CONNECT") && !name.startsWith("0X-LINE") && !name.startsWith("1X-LINE")) return null
+        val prefixes = listOf("1BODY CONNECT", "0BODY CONNECT", "0X-LINE", "1X-LINE")
+        if (!prefixes.any { name.startsWith(it) }) return null
         val displayName = if (name.contains("BODY CONNECT")) "1BODY CONNECT" else "1X-LINE"
         return DeviceSupport(
             displayName = displayName,
             capabilities = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.USER_SYNC, DeviceCapability.HISTORY_READ),
-            implemented = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.HISTORY_READ),
+            implemented = setOf(DeviceCapability.BODY_COMPOSITION, DeviceCapability.TIME_SYNC, DeviceCapability.USER_SYNC, DeviceCapability.HISTORY_READ),
             linkMode = LinkMode.CONNECT_GATT
         )
     }
@@ -86,11 +90,15 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     // --- Download (host → device) opcodes --------------------------------------
 
-    private val CMD_ACK: Byte                = 0x03
+    private val CMD_ADD_USER: Byte           = 0x03
     private val CMD_TIME: Byte               = 0x02
     private val CMD_CHALLENGE_RESPONSE: Byte = 0x20
     private val CMD_BROADCAST: Byte          = 0x21
     private val CMD_ENABLE_DISCONNECT: Byte  = 0x22
+
+    private val OP_WRITE_PROFILE: Byte = 0x51
+    private val OP_BODY: Byte          = 0x7F
+    private val OP_WEIGHT: Byte        = 0x1F
 
     // Non-zero broadcast ID required for pairing to succeed; generated randomly per device instance
     private val BROADCAST_ID = Random.nextInt(Int.MAX_VALUE - 1) + 1
@@ -100,11 +108,28 @@ class BodyConnectHandler : ScaleDeviceHandler() {
     // The X-LINE returns a timestamp in seconds since 2020-01-01 only in the body composition response
     private val ALT_TS_OFFSET = 315619200
 
+    private val KEY_PASSWORD = "bodyconnect/password"
+    private val KEY_SLOT = "bodyconnect/slot"
+
     // --- Pairing state ---------------------------------------------------------
 
     private var pairing = false
     private var password: Int? = null
-    private var statusAcked = false
+    private var slotAcked = false
+
+    // Slots the scale reported as empty, collected across the whole 0x83 stream.
+    private val freeSlots = mutableSetOf<Int>()
+
+    // Slot number to the name stored on the scale, collected across the whole 0x83 stream.
+    private val slotNames = mutableMapOf<Int, String>()
+
+    // Non-null while a slot-choice dialog is open, holding the user the answer applies to.
+    private var pendingUser: ScaleUser? = null
+
+    private val LAST_SLOT = 8
+    private val DEFAULT_SLOT = 1
+    private val NAME_LENGTH = 16
+    private val SPACE: Byte = 0x20
 
     // --- Frame matching --------------------------------------------------------
     // 0x1F and 0x7F frames share a device timestamp; we cache the weight from
@@ -119,49 +144,83 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         setNotifyOn(SVC, CHR_WEIGHT)
         setNotifyOn(SVC, CHR_BODY)
         setNotifyOn(SVC, CHR_UPLD)
+        logD("Connected to device")
 
         // Restore password persisted from a previous pairing session
-        password = settingsGetInt("bodyconnect/password", -1).takeIf { it != -1 }
+        password = settingsGetInt(KEY_PASSWORD, -1).takeIf { it != -1 }
         pairing = false
-        statusAcked = false
+        slotAcked = false
+        lastTS = null
+        lastWeight = null
+        pendingUser = null
+        freeSlots.clear()
+        slotNames.clear()
     }
 
     override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) {
         when (characteristic) {
-            CHR_UPLD             -> onUpload(data)
+            CHR_UPLD     -> onUpload(data)
             CHR_WEIGHT   -> onWeight(data)
             CHR_BODY     -> onBody(data, user)
-            else                 -> logW("Unknown characteristic: $characteristic")
+            else         -> logW("Unknown characteristic: $characteristic")
         }
     }
+
+    override suspend fun onUserInteractionFeedback(
+        interactionType: UserInteractionType,
+        appUserId: Int,
+        feedbackData: Any
+    ) {
+        if (interactionType != UserInteractionType.CHOOSE_USER) return
+        val slot = (feedbackData as? Int)?.takeIf { it in 1..LAST_SLOT } ?: run {
+            logW("Ignoring CHOOSE_USER feedback $feedbackData")
+            return
+        }
+        val user = pendingUser ?: currentAppUser()
+        pendingUser = null
+        logD("User chose slot $slot")
+        registerIntoSlot(slot, user)
+    }
+
 
     // --- Upload (device → host) processing -------------------------------------
 
     private fun onUpload(data: ByteArray) {
         if (data.isEmpty()) return
-        when (data[0]) {
-            CMD_PASSWORD    -> onPassword(data)
-            CMD_CHALLENGE   -> onChallenge(data)
+        logD("onUpload (${data.size} bytes)")
+        val command = data[0]
+        when (command) {
+            CMD_PASSWORD     -> onPassword(data)
+            CMD_CHALLENGE    -> onChallenge(data)
             CMD_PROFILE_ECHO -> onProfileEcho()
-            CMD_SLOT_STATUS -> onSlotStatus(data)
+            CMD_SLOT_STATUS  -> onSlotStatus(data)
         }
     }
 
     private fun onPassword(data: ByteArray) {
-        if (data.size < 5) return
+        if (data.size < 5) {
+            logE("Password data too short (${data.size} bytes)")
+            return
+        }
         val pw = ConverterUtils.fromSignedInt32Le(data, 1)
         password = pw
-        settingsPutInt("bodyconnect/password", pw)
+        settingsPutInt(KEY_PASSWORD, pw)
+        logD("Password received")
 
         userInfo(R.string.bluetooth_scale_trisa_success_pairing)
         pairing = true
         // Broadcast ID must be set before the scale accepts further commands
+        logD("Sending broadcast ID")
         writeCommand(CMD_BROADCAST, BROADCAST_ID)
     }
 
     private fun onChallenge(data: ByteArray) {
-        if (data.size < 5) return
+        if (data.size < 5) {
+            logW("Challenge data too short: ${data.size} bytes")
+            return
+        }
         val pw = password ?: run {
+            logW("No password available for challenge response")
             userWarn(R.string.bluetooth_scale_trisa_message_not_paired_instruction)
             requestDisconnect()
             return
@@ -170,8 +229,8 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         writeCommand(CMD_CHALLENGE_RESPONSE, challenge xor pw)
 
         if (!pairing) {
-            // Already paired: send profile + time directly (scale skips slot negotiation)
-            writeProfile(currentAppUser())
+            logD("Already paired: send profile + time directly (scale skips slot negotiation)")
+            writeProfile(settingsGetInt(KEY_SLOT, DEFAULT_SLOT), currentAppUser())
             writeCommand(CMD_TIME, javaTimeToDevice(System.currentTimeMillis()))
         }
     }
@@ -182,30 +241,52 @@ class BodyConnectHandler : ScaleDeviceHandler() {
     }
 
     private fun onSlotStatus(data: ByteArray) {
-        // Scale lists its 8 user slots (first non‑empty one must be acknowledged)
-        if (data.size < 3 || statusAcked) return
-        val hasName = (2 until data.size).any { i ->
+        // Scale lists its 8 user slots
+        if (data.size < 18) {
+            logW("Slot status data too short: ${data.size} bytes")
+            return
+        }
+        val slot = data[1].toInt() and 0xFF
+
+        val occupied = (2 until data.size).any { i ->
             val b = data[i].toInt() and 0xFF
             b != 0x00 && b != 0x20
         }
-        if (!hasName) return
-        statusAcked = true
+        if (!occupied) freeSlots.add(slot)
+        slotNames[slot] = parseSlotName(data)
+        logD("Slot $slot ${if (occupied) "occupied" else "free"}")
 
-        // Echo the slot record with opcode 0x03 to acknowledge it
-        val ack = data.copyOf().also { it[0] = CMD_ACK }
-        writeTo(SVC, CHR_DNLD, ack, withResponse = true)
-
-        // Now send profile, time, and signal setup complete
+        if (slot != LAST_SLOT || slotAcked) return
+        slotAcked = true
         val user = currentAppUser()
-        writeProfile(user)
-        writeCommand(CMD_TIME, javaTimeToDevice(System.currentTimeMillis()))
-        writeCommand(CMD_ENABLE_DISCONNECT)
+
+        // A slot chosen in an earlier session is reused without asking again.
+        val stored = settingsGetInt(KEY_SLOT, -1)
+        if (stored in 1..LAST_SLOT) {
+            logD("Reusing stored slot $stored")
+            registerIntoSlot(stored, user)
+            return
+        }
+
+        // First pairing: ask which scale user this is. Guessing is wrong too often. A brand new
+        // scale has eight empty slots and nothing to match on, and a second-hand one may be full
+        // of a previous owner's profiles that the user legitimately wants to take over.
+        pendingUser = user
+        logD("Presenting slot choice dialog")
+        presentSlotChoice(user)
     }
 
     // --- Frame parsing ---------------------------------------------------------
 
     private fun onWeight(data: ByteArray) {
-        if (data.size < 20 || data[0] != 0x1F.toByte()) return
+        if (data.size < 20) {
+            logW("Weight data too short: ${data.size} bytes")
+            return
+        }
+        if (data[0] != OP_WEIGHT.toByte()) {
+            logW("Weight frame has wrong opcode")
+            return
+        }
 
         // 0x1F frame layout:
         //   off 0:       opcode 0x1F
@@ -216,7 +297,14 @@ class BodyConnectHandler : ScaleDeviceHandler() {
     }
 
     private fun onBody(data: ByteArray, user: ScaleUser) {
-        if (data.size < 20 || data[0] != 0x7F.toByte()) return
+        if (data.size < 20) {
+            logW("Body data too short: ${data.size} bytes")
+            return
+        }
+        if (data[0] != OP_BODY.toByte()) {
+            logW("Body frame has wrong opcode")
+            return
+        }
 
         // 0x7F frame layout:
         //   off 0:       opcode 0x7F
@@ -232,7 +320,10 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         val muscle = parseBodyComp(data, 14)
         val bone = parseBodyComp(data, 16)
 
-        if (fat == null && water == null && muscle == null && bone == null) return
+        if (fat == null && water == null && muscle == null && bone == null) {
+            logW("No valid body composition data in frame")
+            return
+        }
 
         val ts = ConverterUtils.fromSignedInt32Le(data, 1)
         if (lastTS == null || (lastTS != ts && lastTS != ts + ALT_TS_OFFSET)) {
@@ -241,7 +332,10 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         }
 
         val weight = lastWeight
-        if (weight == null || weight <= 0f) return
+        if (weight == null || weight <= 0f) {
+            logW("No valid weight available for body composition")
+            return
+        }
 
         val m = ScaleMeasurement().apply {
             dateTime = Date(deviceTimeToJava(lastTS!!))
@@ -256,24 +350,37 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     // --- Download (host → device) helpers --------------------------------------
 
-    private fun writeProfile(user: ScaleUser) {
-        val b = ByteArray(15)
-        b[0] = 0x51.toByte()
-        b[1] = 0xDF.toByte()
-        b[2] = 0x01.toByte()
-        b[3] = if (user.gender.isMale()) 0x01.toByte() else 0x00.toByte()
-        b[4] = user.age.toByte()
-        b[5] = user.bodyHeight.toInt().toByte()
-        b[6] = 0xE0.toByte()
-        b[7] = 0x00.toByte()
-        b[8] = 0x00.toByte()
-        b[9] = 0x40.toByte()
-        b[10] = 0x1F.toByte()
-        b[11] = 0x00.toByte()
-        b[12] = 0xFE.toByte()
-        b[13] = 0x00.toByte()
-        b[14] = 0x00.toByte()
-        writeTo(SVC, CHR_DNLD, b, withResponse = true)
+    private fun writeProfile(slot: Int, user: ScaleUser) {
+        logD("Writing user profile in slot $slot")
+        val b = ByteArray(14) { 0x00.toByte() }
+        b[0] = 0xDF.toByte()
+        b[1] = slot.toByte()
+        b[2] = getGenderByte(user)
+        b[3] = user.age.toByte()
+        b[4] = user.bodyHeight.toInt().toByte()
+        b[5] = 0xE0.toByte()
+        b[6] = getActivityByte(user)
+        ConverterUtils.toInt16Le(b, 8, (user.initialWeight * 100).toInt())
+        b[11] = 0xFE.toByte()
+        writeCommand(OP_WRITE_PROFILE, b)
+    }
+
+    private fun getGenderByte(user: ScaleUser): Byte {
+        if (user.gender.isMale()) {
+            return if (user.activityLevel <= ActivityLevel.MODERATE) 0x01 else 0x03
+        } else {
+            return if (user.activityLevel <= ActivityLevel.MODERATE) 0x02 else 0x04
+        }
+    }
+
+    private fun getActivityByte(user: ScaleUser): Byte {
+        return when (user.activityLevel) {
+            ActivityLevel.SEDENTARY -> 0x00
+            ActivityLevel.MILD -> 0x00
+            ActivityLevel.MODERATE -> 0x00
+            ActivityLevel.HEAVY -> 0x01
+            ActivityLevel.EXTREME -> 0x02
+        }
     }
 
     private fun parseBodyComp(data: ByteArray, off: Int): Float? {
@@ -284,8 +391,110 @@ class BodyConnectHandler : ScaleDeviceHandler() {
         return if (hi and 0xF0 == 0xF0) ((hi and 0x0F) shl 8 or lo) / 10f else null
     }
 
+    private fun parseSlotName(frame: ByteArray): String {
+        if (frame.size <= 2) return ""
+        return frame.copyOfRange(2, minOf(frame.size, 2 + NAME_LENGTH))
+            .map { (it.toInt() and 0xFF).toChar() }
+            .filter { it.code in 0x20..0x7E }
+            .joinToString("")
+            .trim()
+    }
+
+    /**
+     * Ask the user which of the scale's eight slots is theirs, listing the names the scale just
+     * streamed so the choice is made against what is actually on the device. A slot whose name
+     * matches the openScale user is flagged as the suggestion.
+     *
+     * If the link drops before the answer arrives the writes fail harmlessly. The choice is still
+     * persisted, so the next connection takes the stored-slot path above.
+     */
+    private fun presentSlotChoice(user: ScaleUser) {
+        val suggested = chooseSlot(-1, user.userName, slotNames, freeSlots)
+        val labels = ArrayList<CharSequence>(LAST_SLOT)
+        val ids = IntArray(LAST_SLOT)
+        for (slot in 1..LAST_SLOT) {
+            val stored = slotNames[slot].orEmpty()
+            val name = stored.ifEmpty { resolveString(R.string.bluetooth_scale_weightgurus_slot_empty) }
+            labels += resolveString(
+                if (slot == suggested && stored.isNotEmpty()) {
+                    R.string.bluetooth_scale_weightgurus_slot_match
+                } else {
+                    R.string.bluetooth_scale_weightgurus_slot
+                },
+                slot, name
+            )
+            ids[slot - 1] = slot
+        }
+        logD("Asking which slot to claim (suggesting $suggested)")
+        requestUserInteraction(UserInteractionType.CHOOSE_USER, Pair(labels.toTypedArray(), ids))
+    }
+
+    /**
+     * Suggest which slot to register into.
+     *
+     * This is only a suggestion. The slot is chosen by the user, who is shown the scale's
+     * actual roster (see `presentSlotChoice`). It is used to flag one entry in that list, and
+     * as the answer on later connections once a choice has been stored.
+     *
+     * Re-pairing should land on the slot it used last time. Taking a fresh slot each time
+     * leaves another copy of the same person on the scale, and measurements get attributed
+     * to whichever duplicate the user happens to step on.
+     *
+     * The stored slot number is the first choice, but it does not survive the app's data
+     * being cleared, so a slot already carrying this user's name is matched next. Only then
+     * does it take the lowest free slot, falling back to the first slot if the scale is full.
+     */
+    private fun chooseSlot(
+        storedSlot: Int,
+        userName: String,
+        slotNames: Map<Int, String>,
+        freeSlots: Set<Int>
+    ): Int {
+        if (storedSlot in 1..LAST_SLOT) return storedSlot
+
+        val wanted = userName.take(NAME_LENGTH).trim()
+        if (wanted.isNotEmpty()) {
+            slotNames.entries
+                .filter { it.value.equals(wanted, ignoreCase = true) }
+                .minByOrNull { it.key }
+                ?.let { return it.key }
+        }
+        return freeSlots.minOrNull() ?: DEFAULT_SLOT
+    }
+
+    /**
+     * Claim [slot] for this openScale user and close out setup. Writing the profile here is what
+     * corrects a slot still holding a stale height/age, which is what the scale computes body
+     * composition from.
+     */
+    private fun registerIntoSlot(slot: Int, user: ScaleUser) {
+        settingsPutInt(KEY_SLOT, slot)
+        logD("Registering user into slot $slot")
+        writeAddUser(slot, user)
+        writeProfile(slot, user)
+        writeCommand(CMD_TIME, javaTimeToDevice(System.currentTimeMillis()))
+        writeCommand(CMD_ENABLE_DISCONNECT)
+        logD("User registration complete for slot $slot")
+    }
+
+    /**
+     * 0x03 registers a user in a scale-side slot: `[opcode][slot][16-byte name][0000]`. The name is
+     * truncated to 16 characters and right-padded with spaces. It mirrors the shape of the
+     * 0x83 frame that prompts it, but this is a registration, not an acknowledgement.
+     */
+    private fun writeAddUser(slot: Int, user: ScaleUser) {
+        val name = ByteArray(NAME_LENGTH) { SPACE }
+        // The slot list is plain ASCII; anything else is replaced.
+        user.userName.take(NAME_LENGTH).replace("[^\\x00-\\x7F]".toRegex(), "-").toByteArray(StandardCharsets.ISO_8859_1).copyInto(name)
+        writeCommand(CMD_ADD_USER, byteArrayOf(slot.toByte()) + name)
+    }
+
     private fun writeCommand(opcode: Byte) {
         writeTo(SVC, CHR_DNLD, byteArrayOf(opcode), withResponse = true)
+    }
+
+    private fun writeCommand(opcode: Byte, payload: ByteArray) {
+        writeTo(SVC, CHR_DNLD, byteArrayOf(opcode) + payload, withResponse = true)
     }
 
     private fun writeCommand(opcode: Byte, arg: Int) {
@@ -298,11 +507,11 @@ class BodyConnectHandler : ScaleDeviceHandler() {
 
     // --- Timestamp conversion --------------------------------------------------
 
-    private fun javaTimeToDevice(ms: Long): Int {
+    internal fun javaTimeToDevice(ms: Long): Int {
         return (((ms + 500) / 1000) - TS_OFFSET).toInt()
     }
 
-    private fun deviceTimeToJava(s: Int): Long {
+    internal fun deviceTimeToJava(s: Int): Long {
         return 1000L * (TS_OFFSET + s.toLong())
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandlerTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/BodyConnectHandlerTest.kt
@@ -1,0 +1,674 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.BluetoothEvent.UserInteractionType
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.data.ActivityLevel
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.data.WeightUnit
+import com.health.openscale.core.service.ScannedDeviceInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Date
+import java.util.UUID
+
+/**
+ * Tests for [BodyConnectHandler].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BodyConnectHandlerTest {
+
+    private val CHR_UPLD = uuid16(0x8A82)
+    private val CHR_WEIGHT = uuid16(0x8A24)
+    private val CHR_BODY = uuid16(0x8A22)
+    private val CMD_PASSWORD: Byte = 0xA0.toByte()
+    private val CMD_CHALLENGE: Byte = 0xA1.toByte()
+    private val CMD_SLOT_STATUS: Byte = 0x83.toByte()
+    private val OP_WEIGHT: Byte = 0x1F
+    private val OP_BODY: Byte = 0x7f
+    private val KEY_PASSWORD = "bodyconnect/password"
+    private val PASSWORD: Int = 0x1234_5678
+    private val CHALLENGE: Long = 0xDEAD_BEEF
+    private val RESOLVED_STRING_SLOT = "res:${R.string.bluetooth_scale_weightgurus_slot}"
+    private val RESOLVED_STRING_SLOT_MATCH = "res:${R.string.bluetooth_scale_weightgurus_slot_match}"
+
+    private val dispatcher = StandardTestDispatcher()
+
+    private typealias SlotSelectionData = Pair<Array<CharSequence>, IntArray>
+
+    private val user = ScaleUser(
+        id = 1,
+        userName = "Test User",
+        birthday = Date(769238400000L),
+        bodyHeight = 175f,
+        gender = GenderType.MALE,
+        initialWeight = 80f,
+        goalWeight = 70f,
+        scaleUnit = WeightUnit.KG,
+        activityLevel = ActivityLevel.MODERATE,
+    )
+
+    private class InMemorySettings : ScaleDeviceHandler.DriverSettings {
+        val strings = mutableMapOf<String, String>()
+        private val ints = mutableMapOf<String, Int>()
+
+        override fun getInt(key: String, default: Int): Int = ints[key] ?: default
+        override fun putInt(key: String, value: Int) {
+            ints[key] = value
+        }
+
+        override fun getString(key: String, default: String?): String? = strings[key] ?: default
+        override fun putString(key: String, value: String) {
+            strings[key] = value
+        }
+
+        override fun remove(key: String) {
+            strings.remove(key)
+            ints.remove(key)
+        }
+    }
+
+    private class FixedDataProvider(
+        private val user: ScaleUser,
+        private val previous: ScaleMeasurement? = null,
+    ) : ScaleDeviceHandler.DataProvider {
+        override fun currentUser(): ScaleUser = user
+        override fun usersForDevice(): List<ScaleUser> = listOf(user)
+        override fun lastMeasurementFor(userId: Int): ScaleMeasurement? =
+            previous?.takeIf { userId == user.id }
+    }
+
+    private fun setupHandler(
+        settings: InMemorySettings = InMemorySettings(),
+    ): Setup {
+        val handler = BodyConnectHandler()
+        val transport = CapturingTransport()
+        val callbacks = CapturingCallbacks()
+        handler.attach(transport, callbacks, settings, FixedDataProvider(user), CoroutineScope(dispatcher))
+        return Setup(handler, transport, callbacks, settings, user)
+    }
+
+    private fun setupHandlerConnected(
+        settings: InMemorySettings = InMemorySettings(),
+    ): Setup {
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+        return setup
+    }
+
+    // --- Device matching --------------------------------------------------------
+
+    @Test
+    fun recognizeBodyConnectDeviceWithPrefix1() {
+        val handler = BodyConnectHandler()
+        val support = handler.supportFor(device("1BODY CONNECT Smart Scale"))
+        assertThat(support).isNotNull()
+        assertThat(support?.displayName).isEqualTo("1BODY CONNECT")
+        assertThat(support?.implemented).containsExactly(
+            DeviceCapability.BODY_COMPOSITION,
+            DeviceCapability.TIME_SYNC,
+            DeviceCapability.USER_SYNC,
+            DeviceCapability.HISTORY_READ,
+        )
+    }
+
+    @Test
+    fun recognizeBodyConnectDeviceWithPrefix0() {
+        val handler = BodyConnectHandler()
+        val support = handler.supportFor(device("0BODY CONNECT Scale"))
+        assertThat(support).isNotNull()
+        assertThat(support?.displayName).isEqualTo("1BODY CONNECT")
+    }
+
+    @Test
+    fun recognizeXLineDeviceWithPrefix0() {
+        val handler = BodyConnectHandler()
+        val support = handler.supportFor(device("0X-LINE Scale"))
+        assertThat(support).isNotNull()
+        assertThat(support?.displayName).isEqualTo("1X-LINE")
+    }
+
+    @Test
+    fun recognizeXLineDeviceWithPrefix1() {
+        val handler = BodyConnectHandler()
+        val support = handler.supportFor(device("1X-LINE Scale"))
+        assertThat(support).isNotNull()
+        assertThat(support?.displayName).isEqualTo("1X-LINE")
+    }
+
+    @Test
+    fun rejectsOtherDevices() {
+        val handler = BodyConnectHandler()
+        assertThat(handler.supportFor(device("SomeOther Scale"))).isNull()
+    }
+
+    // --- Authentication ---------------------------------------------------------
+
+    @Test
+    fun handlesPasswordResponseAndSendsBroadcastID() {
+        val settings = InMemorySettings()
+        val setup = setupHandlerConnected(settings)
+
+        setup.handler.handleNotification(CHR_UPLD, buildPasswordFrame())
+
+        assertThat(settings.getInt(KEY_PASSWORD).toLong() and 0xFFFFFFFF).isEqualTo(PASSWORD)
+        assertThat(setup.transport.writes).hasSize(1)
+        assertThat(setup.transport.writes[0].payload[0]).isEqualTo(0x21.toByte())
+    }
+
+    @Test
+    fun passwordFrameTooShortIsIgnored() {
+        val settings = InMemorySettings()
+        val setup = setupHandlerConnected(settings)
+
+        val shortPassword = byteArrayOf(CMD_PASSWORD, 0x01.toByte(), 0x02.toByte())
+
+        setup.handler.handleNotification(CHR_UPLD, shortPassword)
+
+        assertThat(settings.getInt(KEY_PASSWORD)).isEqualTo(-1)
+    }
+
+    @Test
+    fun handlesChallengeResponseWhenNoPassword() {
+        val settings = InMemorySettings()
+        val setup = setupHandlerConnected(settings)
+
+        setup.handler.handleNotification(CHR_UPLD, buildChallengeFrame())
+
+        assertThat(setup.transport.writes).isEmpty()
+    }
+
+    @Test
+    fun handlesChallengeResponseWhenPaired() {
+        val settings = InMemorySettings().apply {
+            putInt(KEY_PASSWORD, PASSWORD)
+        }
+        val setup = setupHandlerConnected(settings)
+
+        setup.handler.handleNotification(CHR_UPLD, buildChallengeFrame())
+
+        // Handler sends 3 writes: challenge response, profile, and time
+        assertThat(setup.transport.writes).hasSize(3)
+        assertThat(setup.transport.writes[0].payload[0]).isEqualTo(0x20.toByte()) // CMD_CHALLENGE_RESPONSE
+        assertThat(setup.transport.writes[1].payload[0]).isEqualTo(0x51.toByte()) // Profile
+        assertThat(setup.transport.writes[2].payload[0]).isEqualTo(0x02.toByte()) // CMD_TIME
+
+        val expectedResponse = CHALLENGE xor PASSWORD.toLong()
+        assertThat(setup.transport.writes[0].payload[1].toInt() and 0xFF).isEqualTo(expectedResponse and 0xFF)
+        assertThat(setup.transport.writes[0].payload[2].toInt() and 0xFF).isEqualTo(expectedResponse shr 8 and 0xFF)
+        assertThat(setup.transport.writes[0].payload[3].toInt() and 0xFF).isEqualTo(expectedResponse shr 16 and 0xFF)
+        assertThat(setup.transport.writes[0].payload[4].toInt() and 0xFF).isEqualTo(expectedResponse shr 24 and 0xFF)
+    }
+
+    @Test
+    fun handlesProfileEchoAndSendsEnableDisconnect() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        setup.handler.handleNotification(CHR_UPLD, byteArrayOf(0xC0.toByte()))
+
+        assertThat(setup.transport.writes).hasSize(1)
+        assertThat(setup.transport.writes[0].payload[0]).isEqualTo(0x22.toByte())
+    }
+
+    // --- Slot selection ---------------------------------------------------------
+
+    @Test
+    fun handlesSlotStatusAndRequestsSlotFromUser() {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(1, "John"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(2, "Eve"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(3, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(4, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(5, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(6, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(7, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(8, ""))
+
+        assertThat(setup.transport.writes).isEmpty()
+        assertThat(setup.callbacks.requestedUserInteractions).hasSize(1)
+        assertThat(setup.callbacks.requestedUserInteractions[0].first).isEqualTo(UserInteractionType.CHOOSE_USER)
+        val requestedUserInteractionData = setup.callbacks.requestedUserInteractions[0].second as SlotSelectionData
+        assertThat(requestedUserInteractionData.first).isEqualTo(Array<CharSequence>(8) { RESOLVED_STRING_SLOT })   // no suggestion
+        assertThat(requestedUserInteractionData.second).isEqualTo(intArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+    }
+
+    @Test
+    fun handlesSlotStatusAndRequestsSlotFromUserWithMatch() {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(1, "John"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(2, "Eve"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(3, "Test User"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(4, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(5, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(6, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(7, ""))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(8, ""))
+
+        assertThat(setup.transport.writes).isEmpty()
+        assertThat(setup.callbacks.requestedUserInteractions).hasSize(1)
+        assertThat(setup.callbacks.requestedUserInteractions[0].first).isEqualTo(UserInteractionType.CHOOSE_USER)
+        val requestedUserInteractionData = setup.callbacks.requestedUserInteractions[0].second as SlotSelectionData
+        assertThat(requestedUserInteractionData.first).isEqualTo(Array<CharSequence>(8) { RESOLVED_STRING_SLOT }.also { it[2] = RESOLVED_STRING_SLOT_MATCH })   // slot 3 suggested
+        assertThat(requestedUserInteractionData.second).isEqualTo(intArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+    }
+
+    @Test
+    fun handlesSlotStatusAndRequestsSlotFromUserNoEmptySlotSuggestsFirst() {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(1, "John"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(2, "Eve"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(3, "Max"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(4, "Mike"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(5, "Angela"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(6, "Sylvia"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(7, "Alex"))
+        setup.handler.handleNotification(CHR_UPLD, buildSlotFrame(8, "John 2"))
+
+        assertThat(setup.transport.writes).isEmpty()
+        assertThat(setup.callbacks.requestedUserInteractions).hasSize(1)
+        assertThat(setup.callbacks.requestedUserInteractions[0].first).isEqualTo(UserInteractionType.CHOOSE_USER)
+        val requestedUserInteractionData = setup.callbacks.requestedUserInteractions[0].second as SlotSelectionData
+        assertThat(requestedUserInteractionData.first).isEqualTo(Array<CharSequence>(8) { RESOLVED_STRING_SLOT }.also { it[0] = RESOLVED_STRING_SLOT_MATCH })   // slot 1 suggested
+        assertThat(requestedUserInteractionData.second).isEqualTo(intArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+    }
+
+    @Test
+    fun handlesSlotChoiceAndSendsProfileTimeAck() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[0].payload[0]).isEqualTo(0x03.toByte())
+        assertThat(setup.transport.writes[1].payload[0]).isEqualTo(0x51.toByte())
+        assertThat(setup.transport.writes[2].payload[0]).isEqualTo(0x02.toByte())
+        assertThat(setup.transport.writes[3].payload[0]).isEqualTo(0x22.toByte())
+
+        // Add user
+        assertThat(setup.transport.writes[0].payload[1].toInt()).isEqualTo(3)
+        assertThat(setup.transport.writes[0].payload.copyOfRange(2, 18)).isEqualTo("Test User       ".toByteArray())
+
+        // Profile
+        assertThat(setup.transport.writes[1].payload[2].toInt()).isEqualTo(3)   // slot
+        assertThat(setup.transport.writes[1].payload[3]).isEqualTo(0x01.toByte())   // male
+        assertThat(setup.transport.writes[1].payload[4].toInt() and 0xFF).isEqualTo(32)   // age
+        assertThat(setup.transport.writes[1].payload[5].toInt() and 0xFF).isEqualTo(175)   // height
+        assertThat(setup.transport.writes[1].payload[7]).isEqualTo(0x00)   // activity
+        assertThat((setup.transport.writes[1].payload[9].toInt() and 0xFF) or (setup.transport.writes[1].payload[10].toInt() and 0xFF shl 8)).isEqualTo(8000)   // initial weight
+    }
+
+    @Test
+    fun handlesSlotChoiceInvalidResult() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 17)
+
+        assertThat(setup.transport.writes).isEmpty()
+    }
+
+    @Test
+    fun handlesTruncatedUserName() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        user.userName = "This is a very long user name that exceeds the maximum allowed length for a slot name"
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[0].payload.copyOfRange(2, 18)).isEqualTo("This is a very l".toByteArray())
+    }
+
+    @Test
+    fun handlesUserNameWithSpecialCharacters() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        user.userName = "User ûýþØ"
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[0].payload.copyOfRange(2, 18)).isEqualTo("User ----       ".toByteArray())
+    }
+
+    @Test
+    fun handlesSlotChoiceFemaleUser() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        user.gender = GenderType.FEMALE
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[1].payload[3]).isEqualTo(0x02.toByte())
+    }
+
+    @Test
+    fun handlesSlotChoiceHeavyActivity() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        user.gender = GenderType.MALE
+        user.activityLevel = ActivityLevel.HEAVY
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[1].payload[3]).isEqualTo(0x03.toByte())   // active male
+        assertThat(setup.transport.writes[1].payload[7]).isEqualTo(0x01)    // heavey activity
+    }
+
+    @Test
+    fun handlesSlotChoiceFemaleUserExtremeActivity() = runTest {
+        val settings = InMemorySettings()
+        val setup = setupHandler(settings)
+        user.gender = GenderType.FEMALE
+        user.activityLevel = ActivityLevel.EXTREME
+        setup.handler.handleConnected(user)
+
+        setup.handler.onUserInteractionFeedback(UserInteractionType.CHOOSE_USER, 0, 3)
+
+        assertThat(setup.transport.writes).hasSize(4)
+        assertThat(setup.transport.writes[1].payload[3]).isEqualTo(0x04.toByte())   // active female
+        assertThat(setup.transport.writes[1].payload[7]).isEqualTo(0x02)    // extreme activity
+    }
+
+    // --- Weight and body composition frame parsing -----------------------------------------
+
+    @Test
+    fun rejectsBodyFrameWithoutMatchingWeight() {
+        val settings = InMemorySettings().apply {
+            putInt(KEY_PASSWORD, PASSWORD)
+        }
+        val setup = setupHandlerConnected(settings)
+
+        val bodyFrame = buildBodyFrame(524159516L, 176, 616, 427, 360)
+
+        setup.handler.handleNotification(CHR_BODY, bodyFrame)
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    @Test
+    fun parsesValidBodyCompositionFrameWithMatchingWeight() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        val weightFrame = buildWeightFrame(524159516L, 8020)
+        val bodyFrame = buildBodyFrame(524159516L, 176, 616, 427, 36)
+
+        setup.handler.handleNotification(CHR_WEIGHT, weightFrame)
+        setup.handler.handleNotification(CHR_BODY, bodyFrame)
+
+        assertThat(setup.callbacks.published).hasSize(1)
+        val measurement = setup.callbacks.published.single()
+        assertThat(measurement.weight).isWithin(1e-5f).of(80.2f)
+        assertThat(measurement.fat).isWithin(1e-5f).of(17.6f)
+        assertThat(measurement.water).isWithin(1e-5f).of(61.6f)
+        assertThat(measurement.muscle).isWithin(1e-5f).of(42.7f)
+        assertThat(measurement.bone).isWithin(1e-5f).of(3.6f)
+    }
+
+    @Test
+    fun parsesValidBodyCompositionFrameWithAlternativeTimestampReference() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        val weightFrame = buildWeightFrame(524159516L, 8020)
+        val bodyFrame = buildBodyFrame(208540316L, 176, 616, 427, 36)
+
+        setup.handler.handleNotification(CHR_WEIGHT, weightFrame)
+        setup.handler.handleNotification(CHR_BODY, bodyFrame)
+
+        assertThat(setup.callbacks.published).hasSize(1)
+    }
+
+    @Test
+    fun rejectsBodyCompositionFrameWithDifferentTimestamp() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        val weightFrame = buildWeightFrame(524159516L, 8020)
+        val bodyFrame = buildBodyFrame(123456L, 176, 616, 427, 360)
+
+        setup.handler.handleNotification(CHR_WEIGHT, weightFrame)
+        setup.handler.handleNotification(CHR_BODY, bodyFrame)
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    @Test
+    fun rejectsBodyFrameWithZeroWeight() {
+        val settings = InMemorySettings().apply {
+            putInt(KEY_PASSWORD, PASSWORD)
+        }
+        val setup = setupHandlerConnected(settings)
+
+        val weightFrame = buildWeightFrame(524159516L, 0)
+        val bodyFrame = buildBodyFrame(524159516L, 176, 616, 427, 360)
+
+        setup.handler.handleNotification(CHR_WEIGHT, weightFrame)
+        setup.handler.handleNotification(CHR_BODY, bodyFrame)
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    @Test
+    fun rejectsTruncatedBodyFrame() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        val truncated = byteArrayOf(OP_BODY, 0x00.toByte(), 0x00.toByte(), 0x00.toByte())
+
+        setup.handler.handleNotification(CHR_BODY, truncated)
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    // --- Timestamp conversion ---------------------------------------------------
+
+    @Test
+    fun convertsJavaTimeToDeviceTimeAndBackCorrectly() {
+        val handler = BodyConnectHandler()
+        val javaMs = System.currentTimeMillis()
+        val deviceTime = handler.javaTimeToDevice(javaMs)
+        val convertedBack = handler.deviceTimeToJava(deviceTime)
+
+        assertThat(convertedBack).isWithin(1000L).of(javaMs)
+    }
+
+    // --- Edge cases -------------------------------------------------------------
+
+    @Test
+    fun handlesEmptyUploadData() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        setup.handler.handleNotification(CHR_UPLD, ByteArray(0))
+
+        assertThat(setup.transport.writes).isEmpty()
+    }
+
+    @Test
+    fun handlesEmptyWeightData() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        setup.handler.handleNotification(CHR_WEIGHT, ByteArray(0))
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    @Test
+    fun handlesEmptyBodyData() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        setup.handler.handleNotification(CHR_BODY, ByteArray(0))
+
+        assertThat(setup.callbacks.published).isEmpty()
+    }
+
+    @Test
+    fun handlesUnknownCharacteristic() {
+        val setup = setupHandlerConnected(InMemorySettings())
+
+        val unknownUuid = uuid16(0x9999)
+        setup.handler.handleNotification(unknownUuid, byteArrayOf(0x00.toByte()))
+    }
+
+    // --- Helper classes ---------------------------------------------------------
+
+    private data class Setup(
+        val handler: BodyConnectHandler,
+        val transport: CapturingTransport,
+        val callbacks: CapturingCallbacks,
+        val settings: InMemorySettings,
+        val user: ScaleUser,
+    )
+
+    private class CapturingTransport : ScaleDeviceHandler.Transport {
+        val writes = mutableListOf<Write>()
+
+        override fun setNotifyOn(service: UUID, characteristic: UUID) = Unit
+        override fun write(service: UUID, characteristic: UUID, payload: ByteArray, withResponse: Boolean) {
+            writes += Write(service, characteristic, payload.copyOf(), withResponse)
+        }
+        override fun read(service: UUID, characteristic: UUID) = Unit
+        override fun disconnect() = Unit
+        override fun getPeripheral() = null
+        override fun hasCharacteristic(service: UUID, characteristic: UUID) = true
+    }
+
+    private data class Write(
+        val service: UUID,
+        val characteristic: UUID,
+        val payload: ByteArray,
+        val withResponse: Boolean,
+    )
+
+    private class CapturingCallbacks : ScaleDeviceHandler.Callbacks {
+        val published = mutableListOf<ScaleMeasurement>()
+        val requestedUserInteractions = mutableListOf<Pair<UserInteractionType, SlotSelectionData?>>()
+
+        override fun onPublish(measurement: ScaleMeasurement) {
+            published += measurement.copy()
+        }
+        override fun onUserInteractionRequired(interactionType: UserInteractionType, data: Any?) {
+            @Suppress("UNCHECKED_CAST")
+            requestedUserInteractions += Pair(interactionType, data as? SlotSelectionData)
+        }
+        override fun resolveString(resId: Int, vararg args: Any) = "res:$resId"
+    }
+
+    private fun device(name: String, vararg services: Int) = ScannedDeviceInfo(
+        name = name,
+        address = "00:11:22:33:44:55",
+        rssi = -50,
+        serviceUuids = services.map { uuid16(it) },
+        manufacturerData = null,
+    )
+
+    private fun uuid16(short: Int): UUID =
+        UUID.fromString(String.format("0000%04x-0000-1000-8000-00805f9b34fb", short))
+
+    private fun buildSlotFrame(slot: Int, name: String): ByteArray {
+        val nameArray = ByteArray(16) { 0x20.toByte() }
+        name.toByteArray().copyInto(nameArray)
+        return byteArrayOf(CMD_SLOT_STATUS, slot.toByte()) + nameArray
+    }
+
+    private fun buildPasswordFrame(): ByteArray {
+        return byteArrayOf(
+            CMD_PASSWORD,
+            PASSWORD.toByte(), // byte 0 (LSB)
+            (PASSWORD ushr 8 and 0xFF).toByte(), // byte 1
+            (PASSWORD ushr 16 and 0xFF).toByte(), // byte 2
+            (PASSWORD ushr 24 and 0xFF).toByte(), // byte 3 (MSB)
+        )
+    }
+
+    private fun buildChallengeFrame(): ByteArray {
+        // Challenge in little-endian format (as sent by device)
+        return byteArrayOf(
+            CMD_CHALLENGE, // CMD_CHALLENGE
+            CHALLENGE.toByte(), // byte 0 (LSB)
+            (CHALLENGE ushr 8 and 0xFF).toByte(), // byte 1
+            (CHALLENGE ushr 16 and 0xFF).toByte(), // byte 2
+            (CHALLENGE ushr 24 and 0xFF).toByte(), // byte 3 (MSB)
+        )
+    }
+
+    private fun buildWeightFrame(timestamp: Long, weight: Int): ByteArray {
+        return byteArrayOf(
+            OP_WEIGHT,
+            (weight and 0xFF).toByte(),
+            (weight and 0xFF00 shr 8).toByte(),
+            0x00.toByte(), 0xFE.toByte(),
+            (timestamp and 0xFF).toByte(),
+            (timestamp and 0xFF00 shr 8).toByte(),
+            (timestamp and 0xFF0000 shr 16).toByte(),
+            (timestamp and 0xFF000000 shr 24).toByte(),
+            0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte(),
+            0xFF.toByte(), 0xB2.toByte(), 0x13.toByte(), 0x00.toByte(),
+            0xFF.toByte(), 0x01.toByte(), 0x19.toByte(), 0x00.toByte(),
+        )
+    }
+
+    private fun buildBodyFrame(timestamp: Long, fat: Int, water: Int, muscle: Int, bone: Int): ByteArray {
+        return byteArrayOf(
+            OP_BODY,
+            (timestamp and 0xFF).toByte(),
+            (timestamp and 0xFF00 shr 8).toByte(),
+            (timestamp and 0xFF0000 shr 16).toByte(),
+            (timestamp and 0xFF000000 shr 24).toByte(),
+            0x01.toByte(), 0x00.toByte(), 0x00.toByte(),
+            (fat and 0xFF).toByte(),
+            (fat and 0xFF00 shr 8 or 0xF0).toByte(),
+            (water and 0xFF).toByte(),
+            (water and 0xFF00 shr 8 or 0xF0).toByte(),
+            0x00.toByte(), 0xF0.toByte(),
+            (muscle and 0xFF).toByte(),
+            (muscle and 0xFF00 shr 8 or 0xF0).toByte(),
+            (bone and 0xFF).toByte(),
+            (bone and 0xFF00 shr 8 or 0xF0).toByte(),
+            0x00.toByte(), 0x00.toByte(),
+        )
+    }
+}


### PR DESCRIPTION
The current implementation of the Body Connect / X-LINE has a basic user slot choice algorithm, where we essentially always pick the first non-empty slot. This has the downside of not supporting either a first-time setup, or multiple users.

What the manufacturer's app does in this case is the following:
* Receive all slot statuses from the device (8 in total) with the corresponding name
* Open a dialog for the user to pick a slot
* Send an ACK to the device with the slot number and the new name

It turns out this exact flow was recently implemented by @psuedo-tty in https://github.com/oliexdev/openScale/pull/1467 for another scale, the Weight Gurus 0376.
This PR borrows from it with an adaptation to incorporate this flow into the BodyScaleHandler class.

The only adaptation I had to make from WeightGurusA3Handler is that the maximum size of names is 16 instead of 18.

## Changes
* Change the `onSlotStatus` implementation to allow the user to pick a slot
* Copy the related flow from WeightGurusA3Handler, changing the max name size to 16
* Slight improvements on the profile writing, adding activity level and initial weight
* Add more logging
* Add a comprehensive set of unit tests

## Tests
On top of the unit tests I added, I tested the pairing flow with my X-LINE scale:
* The dialog appears with the slot and the associated names
* One of the choices matches the current user
* When choosing a slot, the device correctly registers the slot number and name
* The name is truncated when longer than 16 characters (note that the manufacturer's app fails at this point)

## Open questions
* This flow is likely to also work on the Body Connect but we can't be sure about it, since I cannot test with it. Maybe @LucasDumont could give it a try of he has time
* Should the slot choice flow be extracted to a common helper class?