### PR TITLE
Picooc: add a driver for the connection-oriented scale line

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -131,9 +131,6 @@ class ScaleFactory @Inject constructor(
         @VisibleForTesting
         internal fun createHandlers(): List<ScaleDeviceHandler> = listOf(
             // Exact-name match must precede generic LeFu/0xFFF0 handlers (first match wins).
-            // PicoocHandler matches only "PICOOC-*"/"Latin-*" names, but has to stay ahead of
-            // ScaleupHandler, which claims any device whose manufacturer data carries a
-            // 0xD0/0xE0 key regardless of name.
             PicoocHandler(),
             ActiveEraBF06Handler(),
             KeepS3Handler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -58,6 +58,7 @@ import com.health.openscale.core.bluetooth.scales.XiaomiS800Handler
 import com.health.openscale.core.bluetooth.scales.BodyConnectHandler
 import com.health.openscale.core.bluetooth.scales.OkOkHandler
 import com.health.openscale.core.bluetooth.scales.OmronWlcHandler
+import com.health.openscale.core.bluetooth.scales.PicoocHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneNewHandler
 import com.health.openscale.core.bluetooth.scales.QNHandler
@@ -130,6 +131,10 @@ class ScaleFactory @Inject constructor(
         @VisibleForTesting
         internal fun createHandlers(): List<ScaleDeviceHandler> = listOf(
             // Exact-name match must precede generic LeFu/0xFFF0 handlers (first match wins).
+            // PicoocHandler matches only "PICOOC-*"/"Latin-*" names, but has to stay ahead of
+            // ScaleupHandler, which claims any device whose manufacturer data carries a
+            // 0xD0/0xE0 key regardless of name.
+            PicoocHandler(),
             ActiveEraBF06Handler(),
             KeepS3Handler(),
             OmronWlcHandler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/PicoocHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/PicoocHandler.kt
@@ -1,0 +1,653 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
+import com.health.openscale.core.data.WeightUnit
+import com.health.openscale.core.service.ScannedDeviceInfo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+import kotlin.math.roundToInt
+
+/**
+ * Picooc (有品) body fat scales that speak the connection-oriented BLE protocol:
+ * Latin-S, PICOOC-C1…CQ, PICOOC-14…25, PICOOC-IS and the S3 Lite V2.0.
+ *
+ * Protocol from a public analysis of a decompiled Picooc app v4.13.4
+ * (https://garden.1900.live/22-knowledge/开发/picooc体脂秤ble协议分析):
+ *  - Service 0xFFF0, notify characteristic 0xFFF1, write characteristic 0xFFF2.
+ *  - Scale→app frames are `[opcode][length][payload…]`, big-endian throughout.
+ *  - App→scale frames are prefixed with 0xF1 (Latin family) or 0xA1 (newer models, the ones
+ *    that use opcodes 0x51/0x52 in place of 0x3A/0x39); `length` counts the prefix as well.
+ *  - Handshake: scale sends 0x3A (or 0x51) asking for the time, the app answers with a
+ *    10-byte time frame; the scale then asks for the user profile with 0x30, which the app
+ *    acks and follows ~100 ms later with a 6-byte sex/height/age frame. Only then does the
+ *    scale run its BIA engine and stream 0x39 (or 0x52) frames. It hangs up on its own once
+ *    the measurement is done.
+ *
+ * The Picooc app computes body composition on the phone (FatModelCaculate) rather than reading
+ * it off the scale, so 0x32 is not guaranteed to arrive. When it does we trust its values and
+ * only fill the gaps from [StandardImpedanceLib]; when it does not, the whole composition is
+ * derived from the streamed impedance.
+ *
+ * Several documented opcodes have no published byte layout (0x36/0x37 history, 0x3E
+ * multi-frequency BIA, 0x3F balance test). Those are acked where an ack is expected and dumped
+ * to the log verbatim so a real capture can be used to decode them later. Every frame in both
+ * directions is logged in full hex under the "Picooc RX"/"Picooc TX" prefixes, so
+ * `adb logcat | grep -i picooc` yields a complete session dump.
+ */
+class PicoocHandler : ScaleDeviceHandler() {
+
+    private val service = uuid16(0xFFF0)
+    private val notifyCharacteristic = uuid16(0xFFF1)
+    private val writeCharacteristic = uuid16(0xFFF2)
+
+    /** 0xF1 for the Latin family; latched to 0xA1 as soon as the scale uses a 0x5x opcode. */
+    private var ackPrefix = PREFIX_LATIN
+
+    private var pendingWeightKg = 0f
+    private var pendingImpedance = 0.0
+    private var pendingHeartRate = 0
+    private var pendingComposition: Composition? = null
+    private var published = false
+    private var profilePushed = false
+    private var settleJob: Job? = null
+
+    /** Latched in [onConnected] so [onDisconnected] can still publish after the link is gone. */
+    private var sessionUser: ScaleUser? = null
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        val name = device.name.lowercase(Locale.ROOT)
+
+        // PICOOC-L (Mini and the other new models) is broadcast-only: it carries its payload in
+        // the advertisement and never accepts a GATT connection. Leave the name unclaimed so a
+        // future broadcast handler can take it, rather than failing to connect here.
+        if (name.startsWith("picooc-l")) return null
+
+        // The connection-oriented line advertises either "PICOOC-<model>" (C1…CQ, 14…25, IS,
+        // and the S3 Lite V2.0 which shows up as PICOOC-CQ) or, for the Latin series, a bare
+        // "Latin-…" with no vendor prefix at all. No other handler in this package claims
+        // either prefix.
+        val isPicooc = name.startsWith("picooc")
+        val isLatin = name.startsWith("latin-")
+        if (!isPicooc && !isLatin) return null
+
+        return DeviceSupport(
+            // Show the advertised model: the line spans a lot of hardware and the name is the
+            // only thing that tells two of them apart in the device list.
+            displayName = if (isPicooc) device.name else "Picooc ${device.name}",
+            capabilities = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+                DeviceCapability.TIME_SYNC,
+                DeviceCapability.USER_SYNC,
+                DeviceCapability.UNIT_CONFIG,
+                DeviceCapability.HISTORY_READ,
+                DeviceCapability.BATTERY_LEVEL
+            ),
+            // History frames are logged but not decoded yet, and the scale only reports that the
+            // battery is low, never a level.
+            implemented = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+                DeviceCapability.TIME_SYNC,
+                DeviceCapability.USER_SYNC,
+                DeviceCapability.UNIT_CONFIG
+            ),
+            tuningProfile = TuningProfile.Conservative,
+            linkMode = LinkMode.CONNECT_GATT
+        )
+    }
+
+    override fun onConnected(user: ScaleUser) {
+        resetSession()
+        sessionUser = user
+        logI("Picooc: connected, subscribing to 0xFFF1")
+        setNotifyOn(service, notifyCharacteristic)
+        userInfo(R.string.bt_info_step_on_scale)
+    }
+
+    override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) {
+        if (characteristic != notifyCharacteristic || data.isEmpty()) return
+
+        val opcode = data[0].toInt() and 0xFF
+        logI("Picooc RX 0x%02X len=%d | %s".format(opcode, data.size, hex(data)))
+
+        when (opcode) {
+            OP_TIME_REQUEST_ALT -> {
+                // Only the newer models use 0x5x opcodes, and those expect the 0xA1 prefix.
+                ackPrefix = PREFIX_MODERN
+                handleTimeRequest(user, OP_HANDSHAKE)
+                pushUserProfileOnce(user)
+            }
+
+            OP_HANDSHAKE -> {
+                parseBomInfo(data)?.let { logI("Picooc BOM info: $it") }
+                handleTimeRequest(user, OP_HANDSHAKE)
+                pushUserProfileOnce(user)
+            }
+
+            OP_TIME_SYNC -> handleTimeRequest(user, OP_TIME_SYNC)
+
+            OP_USER_REQUEST -> {
+                send(buildAck(ackPrefix, OP_USER_REQUEST), "ack 0x30")
+                sendUserProfile(user)
+            }
+
+            OP_LIVE_WEIGHT_ALT -> {
+                ackPrefix = PREFIX_MODERN
+                handleLiveFrame(data, opcode, user)
+            }
+
+            OP_LIVE_WEIGHT -> handleLiveFrame(data, opcode, user)
+
+            OP_BODY_COMPOSITION -> {
+                send(buildAck(ackPrefix, OP_BODY_COMPOSITION), "ack 0x32")
+                val composition = parseComposition(data)
+                if (composition == null) {
+                    logW("Picooc 0x32 too short to decode (len=${data.size})")
+                    return
+                }
+                logI("Picooc composition: $composition")
+                pendingComposition = composition
+                if (composition.weightKg in MIN_WEIGHT_KG..MAX_WEIGHT_KG) {
+                    pendingWeightKg = composition.weightKg
+                }
+                if (composition.impedance > 0.0) pendingImpedance = composition.impedance
+                armSettle(user, "0x32 body composition")
+            }
+
+            OP_HEART_RATE -> {
+                // Acked like the weight frames are. A PICOOC-CQ capture without this ack shows
+                // the scale resending a byte-identical `3C 05 00 00 01` ten times at exactly
+                // 1 Hz and then hanging up, while the acked 0x39 arrives exactly once — the
+                // signature of an unacknowledged retransmit. The scale's own display had a
+                // heart rate the whole time, so the result frame is one the scale would only
+                // move on to once the previous one is confirmed.
+                send(buildAck(ackPrefix, OP_HEART_RATE), "ack 0x3C")
+                // Only the PICOOC-CQ layout is confirmed; dump the alternatives so a capture
+                // from another model shows at a glance where its reading sits.
+                logD(
+                    "Picooc 0x3C candidates: " +
+                        heartRateCandidates(data).joinToString { "${it.first}=${it.second}" }
+                )
+                val bpm = parseHeartRate(data)
+                if (bpm != null) {
+                    logI("Picooc heart rate: $bpm bpm (status=${heartRateStatus(data)})")
+                    pendingHeartRate = bpm
+                } else {
+                    logD("Picooc heart rate still measuring | ${hex(data)}")
+                }
+                // Re-arm either way: the reading is still running, and publishing now would
+                // close the record before a result can arrive.
+                armSettle(user, "0x3C heart rate")
+            }
+
+            OP_LOW_BATTERY -> {
+                logW("Picooc reports a low battery | ${hex(data)}")
+                userWarn(R.string.bt_warn_low_battery_unknown)
+            }
+
+            OP_HISTORY, OP_HISTORY_DONE -> {
+                // Acked so the scale keeps going; the payload layout is undocumented.
+                send(buildAck(ackPrefix, opcode), "ack 0x%02X".format(opcode))
+                logI("Picooc history frame 0x%02X (layout unknown) | %s".format(opcode, hex(data)))
+            }
+
+            OP_MULTI_FREQ_BIA -> {
+                send(buildAck(ackPrefix, OP_MULTI_FREQ_BIA), "ack 0x3E")
+                logI("Picooc multi-frequency BIA 0x3E (layout unknown) | ${hex(data)}")
+            }
+
+            OP_BALANCE_TEST -> {
+                send(buildAck(ackPrefix, OP_BALANCE_TEST), "ack 0x3F")
+                logI("Picooc balance test 0x3F (layout unknown, no openScale field) | ${hex(data)}")
+            }
+
+            else -> logI("Picooc RX unhandled 0x%02X | %s".format(opcode, hex(data)))
+        }
+    }
+
+    override fun onDisconnected() {
+        // The scale hangs up as soon as it is done. If the completion flag was never seen — or
+        // read wrongly — this is the last chance to keep the reading.
+        val user = sessionUser
+        if (!published && pendingWeightKg > 0f && user != null) {
+            publishSession(user, "disconnect fallback")
+        }
+        resetSession()
+    }
+
+    // --- protocol steps --------------------------------------------------------------------
+
+    /**
+     * Push the profile without waiting for a 0x30 request. PICOOC-CQ never asks for it — it goes
+     * straight from the handshake to the measurement — so waiting would leave its BIA engine
+     * without sex/height/age. Sending it unprompted is the documented frame, just earlier.
+     */
+    private fun pushUserProfileOnce(user: ScaleUser) {
+        if (profilePushed) return
+        profilePushed = true
+        sendUserProfile(user)
+    }
+
+    private fun sendUserProfile(user: ScaleUser) {
+        // The scale needs a moment before the profile; the adapter's Conservative inter-write
+        // gap is only 50 ms, so pace it explicitly.
+        val profile = buildUserProfile(user)
+        scope.launch {
+            delay(PROFILE_DELAY_MS)
+            logI(
+                "Picooc user profile: sex=${if (user.gender.isMale()) "M" else "F"} " +
+                    "height=${user.bodyHeight}cm age=${user.age}"
+            )
+            send(profile, "user profile")
+        }
+    }
+
+    private fun handleTimeRequest(user: ScaleUser, replyOpcode: Int) {
+        val unit = unitCode(user.scaleUnit)
+        val epochSeconds = System.currentTimeMillis() / 1000L
+        send(
+            buildTimeReply(ackPrefix, replyOpcode, epochSeconds, unit),
+            "time sync (epoch=$epochSeconds unit=$unit)"
+        )
+    }
+
+    private fun handleLiveFrame(data: ByteArray, opcode: Int, user: ScaleUser) {
+        send(buildAck(ackPrefix, opcode), "ack 0x%02X".format(opcode))
+
+        val frame = parseLiveFrame(data)
+        if (frame == null) {
+            logW("Picooc live frame 0x%02X too short to decode (len=%d)".format(opcode, data.size))
+            return
+        }
+        logI("Picooc live: $frame")
+
+        if (frame.weightKg in MIN_WEIGHT_KG..MAX_WEIGHT_KG) {
+            pendingWeightKg = frame.weightKg
+            userInfo(R.string.bluetooth_scale_info_measuring_weight, frame.weightKg)
+        }
+        if (frame.impedance > 0.0) pendingImpedance = frame.impedance
+
+        if (frame.complete) armSettle(user, "live frame completion flag")
+    }
+
+    /**
+     * (Re)start the settle window. The order in which the scale sends 0x32 and 0x3C after the
+     * live stream completes is not documented, so instead of publishing on the first of them we
+     * wait a moment for the rest and publish whatever arrived.
+     */
+    private fun armSettle(user: ScaleUser, reason: String) {
+        if (published || pendingWeightKg <= 0f) return
+        settleJob?.cancel()
+        settleJob = scope.launch {
+            delay(SETTLE_WAIT_MS)
+            publishSession(user, reason)
+        }
+    }
+
+    /** Emits exactly one measurement per session. */
+    private fun publishSession(user: ScaleUser, reason: String) {
+        if (published || pendingWeightKg <= 0f) return
+        published = true
+        settleJob?.cancel()
+        settleJob = null
+
+        val composition = pendingComposition
+        val measurement = ScaleMeasurement().apply {
+            userId = user.id
+            dateTime = Date()
+            weight = pendingWeightKg
+            if (pendingImpedance > 0.0) impedance = pendingImpedance
+            if (pendingHeartRate > 0) heartRate = pendingHeartRate
+        }
+
+        val usableImpedance = pendingImpedance in MIN_IMPEDANCE..MAX_IMPEDANCE
+        val lib = if (usableImpedance && user.bodyHeight > 0f) {
+            StandardImpedanceLib(
+                gender = user.gender,
+                age = user.age,
+                weightKg = pendingWeightKg.toDouble(),
+                heightM = user.bodyHeight / 100.0,
+                impedance = pendingImpedance,
+            )
+        } else {
+            null
+        }
+
+        if (composition != null && composition.fatPercent in MIN_FAT_PERCENT..MAX_FAT_PERCENT) {
+            // The scale did the maths for us — prefer its numbers over our estimate.
+            measurement.fat = composition.fatPercent
+            measurement.water = composition.waterPercent.coerceIn(0f, 80f)
+            measurement.bone = composition.boneMassKg.coerceIn(0f, 10f)
+            measurement.visceralFat = composition.visceralFat.toFloat()
+            measurement.lbm = pendingWeightKg * (1f - composition.fatPercent / 100f)
+            // 0x32 carries neither of these, so fall back to the estimator for them.
+            lib?.let {
+                measurement.muscle = it.skeletalMusclePercentage.toFloat().coerceIn(0f, 100f)
+                measurement.bmr = it.basalMetabolicRate.toFloat().coerceIn(0f, 5000f)
+            }
+            logI("Picooc body composition source: 0x32 packet")
+        } else if (lib != null) {
+            measurement.fat = lib.totalFatPercentage.toFloat().coerceIn(0f, 75f)
+            measurement.water = lib.totalBodyWaterPercentage.toFloat().coerceIn(0f, 80f)
+            measurement.muscle = lib.skeletalMusclePercentage.toFloat().coerceIn(0f, 100f)
+            measurement.bone = lib.boneMassKg.toFloat().coerceIn(0f, 10f)
+            measurement.lbm = lib.fatFreeMassKg.toFloat().coerceIn(0f, 150f)
+            measurement.bmr = lib.basalMetabolicRate.toFloat().coerceIn(0f, 5000f)
+            logI("Picooc body composition source: StandardImpedanceLib (${pendingImpedance}Ω)")
+        } else {
+            logI("Picooc body composition unavailable: impedance=$pendingImpedance height=${user.bodyHeight}")
+        }
+
+        // openScale has no measurement type for the metabolic body age the 0x32 packet reports,
+        // nor for the phase angle in the live frames. Re-enabling either needs a
+        // MeasurementTypeKey, a ScaleMeasurement field, a DB migration and BleConnector wiring.
+        composition?.bodyAge?.takeIf { it > 0 }?.let { logI("Picooc metabolic body age: $it (not stored)") }
+
+        logI(
+            "Picooc publishing ($reason) → weight=${measurement.weight}kg fat=${measurement.fat}% " +
+                "water=${measurement.water}% muscle=${measurement.muscle}% bone=${measurement.bone}kg " +
+                "visceral=${measurement.visceralFat} lbm=${measurement.lbm}kg bmr=${measurement.bmr}kcal " +
+                "hr=${measurement.heartRate}bpm impedance=${measurement.impedance}Ω"
+        )
+        publish(measurement)
+        // No requestDisconnect(): the scale terminates the link itself once it is done.
+    }
+
+    private fun send(payload: ByteArray, what: String) {
+        logI("Picooc TX ${hex(payload)} ($what)")
+        writeTo(service, writeCharacteristic, payload, withResponse = false)
+    }
+
+    private fun resetSession() {
+        ackPrefix = PREFIX_LATIN
+        pendingWeightKg = 0f
+        pendingImpedance = 0.0
+        pendingHeartRate = 0
+        pendingComposition = null
+        published = false
+        profilePushed = false
+        sessionUser = null
+        settleJob?.cancel()
+        settleJob = null
+    }
+
+    /** Decoded 0x39 / 0x52 live streaming frame. */
+    data class LiveFrame(
+        val timestamp: Long,
+        val weightKg: Float,
+        val impedance: Double,
+        val weightLb: Float,
+        val unit: Int,
+        val phaseAngle: Float,
+        val complete: Boolean,
+        /** Top bit of byte 10, which is not part of the pound value. Meaning unknown. */
+        val poundFlag: Boolean,
+    )
+
+    /** Decoded 0x32 body composition frame. */
+    data class Composition(
+        val weightKg: Float,
+        val fatPercent: Float,
+        val waterPercent: Float,
+        val boneMassKg: Float,
+        val visceralFat: Int,
+        val bodyAge: Int,
+        val impedance: Double,
+        /** Bytes 8..9 — purpose not documented; logged so a real capture can identify them. */
+        val unknown8: Int,
+        /** Bytes 12..13 — purpose not documented. */
+        val unknown12: Int,
+    )
+
+    /** Firmware / bill-of-materials block carried in the 0x3A handshake. */
+    data class BomInfo(
+        val version: Int,
+        val bomVersion: Int,
+        val year: Int,
+        val month: Int,
+        val modelId: Int,
+        val shortBom: Int,
+        val shortFactoryId: Int,
+    )
+
+    companion object {
+        // App→scale frame prefixes.
+        const val PREFIX_LATIN = 0xF1
+        const val PREFIX_MODERN = 0xA1
+
+        // Scale→app opcodes.
+        const val OP_USER_REQUEST = 0x30
+        const val OP_USER_PROFILE = 0x31
+        const val OP_BODY_COMPOSITION = 0x32
+        const val OP_TIME_SYNC = 0x35
+        const val OP_HISTORY = 0x36
+        const val OP_HISTORY_DONE = 0x37
+        const val OP_LIVE_WEIGHT = 0x39
+        const val OP_HANDSHAKE = 0x3A
+        const val OP_LOW_BATTERY = 0x3B
+        const val OP_HEART_RATE = 0x3C
+        const val OP_MULTI_FREQ_BIA = 0x3E
+        const val OP_BALANCE_TEST = 0x3F
+        const val OP_TIME_REQUEST_ALT = 0x51
+        const val OP_LIVE_WEIGHT_ALT = 0x52
+
+        /** Gap the Picooc app leaves between acking 0x30 and sending the profile. */
+        const val PROFILE_DELAY_MS = 100L
+
+        /**
+         * Quiet period before publishing, re-armed by every measurement frame.
+         *
+         * This is the fallback, not the normal path: PICOOC-CQ terminates the link itself once
+         * it is done and [onDisconnected] publishes then. The timer only has to survive until
+         * that happens, which means outlasting the two gaps a capture of that scale shows —
+         * 3.9 s from the weight frame to the first 0x3C, then roughly 1 s between 0x3C frames
+         * for another 8-12 s. Anything shorter closes the record before the heart rate can
+         * arrive, which is exactly what a 1.5 s window did.
+         */
+        const val SETTLE_WAIT_MS = 8000L
+
+        private const val MIN_WEIGHT_KG = 2.0f
+        private const val MAX_WEIGHT_KG = 250.0f
+        private const val MIN_IMPEDANCE = 100.0
+        private const val MAX_IMPEDANCE = 1500.0
+        private const val MIN_FAT_PERCENT = 3.0f
+        private const val MAX_FAT_PERCENT = 75.0f
+
+        private const val SEX_MALE = 0x01
+        private const val SEX_FEMALE = 0x02
+
+        /** Youngest age the scale's BIA engine accepts. */
+        private const val MIN_AGE = 18
+
+        fun hex(data: ByteArray): String = data.joinToString(" ") { "%02X".format(it) }
+
+        private fun u8(data: ByteArray, index: Int): Int = data[index].toInt() and 0xFF
+
+        private fun u16be(data: ByteArray, index: Int): Int =
+            (u8(data, index) shl 8) or u8(data, index + 1)
+
+        /** `[prefix] 03 [opcode]` — the generic three-byte acknowledgement. */
+        fun buildAck(prefix: Int, opcode: Int): ByteArray =
+            byteArrayOf(prefix.toByte(), 0x03, opcode.toByte())
+
+        /**
+         * `[prefix] 0A [opcode] [epoch BE] [flag] [unit] [extra]` — exactly ten bytes, which is
+         * what the length field advertises.
+         */
+        fun buildTimeReply(prefix: Int, opcode: Int, epochSeconds: Long, unit: Int): ByteArray {
+            val seconds = epochSeconds.toInt()
+            return byteArrayOf(
+                prefix.toByte(),
+                0x0A,
+                opcode.toByte(),
+                ((seconds shr 24) and 0xFF).toByte(),
+                ((seconds shr 16) and 0xFF).toByte(),
+                ((seconds shr 8) and 0xFF).toByte(),
+                (seconds and 0xFF).toByte(),
+                0x00, // flag
+                unit.toByte(),
+                0x00, // extra
+            )
+        }
+
+        /** Scale unit code: 0 = kg, 1 = jin, 2 = lb. Stone falls back to pounds. */
+        fun unitCode(unit: WeightUnit): Int = if (unit == WeightUnit.KG) 0 else 2
+
+        /**
+         * Height is transmitted as `(cm * 10 - 1000) / 5`, i.e. 100…227.5 cm map onto 0…255.
+         * A missing or non-finite height encodes as 0 rather than throwing, so a broken profile
+         * cannot abort the handshake.
+         */
+        fun encodeHeight(heightCm: Float): Int {
+            if (!heightCm.isFinite()) return 0
+            return ((heightCm * 10f - 1000f) / 5f).roundToInt().coerceIn(0, 255)
+        }
+
+        /** `31 06 01 [sex] [height] [age]` — exactly six bytes, matching the length field. */
+        fun buildUserProfile(user: ScaleUser): ByteArray = byteArrayOf(
+            OP_USER_PROFILE.toByte(),
+            0x06,
+            0x01,
+            (if (user.gender.isMale()) SEX_MALE else SEX_FEMALE).toByte(),
+            encodeHeight(user.bodyHeight).toByte(),
+            user.age.coerceIn(MIN_AGE, 255).toByte(),
+        )
+
+        /**
+         * Decode a 0x39 / 0x52 streaming frame, or `null` if it is too short.
+         *
+         * Layout: `[op][len][ts BE 4B][weight/20][impedance/10][lb/10][unit][phase/100][flag]`,
+         * where `flag == 0` marks the reading as settled and reportable.
+         *
+         * The pound field is only 15 bits wide: a PICOOC-CQ capture of 71.7 kg reports
+         * `86 2C`, and 0x862C/10 = 3434.8 is nonsense while (0x862C & 0x7FFF)/10 = 158.0 lb
+         * matches 71.7 kg exactly. The top bit is therefore a separate flag, not part of the
+         * value. It is decoded into [LiveFrame.poundFlag] and logged pending an explanation.
+         */
+        fun parseLiveFrame(data: ByteArray): LiveFrame? {
+            if (data.size < 16) return null
+            return LiveFrame(
+                timestamp = ((u8(data, 2).toLong() shl 24) or (u8(data, 3).toLong() shl 16) or
+                    (u8(data, 4).toLong() shl 8) or u8(data, 5).toLong()),
+                weightKg = u16be(data, 6) / 20.0f,
+                impedance = u16be(data, 8) / 10.0,
+                weightLb = (u16be(data, 10) and 0x7FFF) / 10.0f,
+                unit = u8(data, 12),
+                phaseAngle = u16be(data, 13) / 100.0f,
+                complete = u8(data, 15) == 0,
+                poundFlag = (u8(data, 10) and 0x80) != 0,
+            )
+        }
+
+        /**
+         * Decode a 0x32 body composition frame, or `null` if it is too short.
+         *
+         * Layout: `[op][len][weight/20][fat%/10][water%/10][?][bone kg/20][?][visceral][bodyAge]
+         * [..][impedance]`.
+         */
+        fun parseComposition(data: ByteArray): Composition? {
+            if (data.size < 20) return null
+            return Composition(
+                weightKg = u16be(data, 2) / 20.0f,
+                fatPercent = u16be(data, 4) / 10.0f,
+                waterPercent = u16be(data, 6) / 10.0f,
+                boneMassKg = u16be(data, 10) / 20.0f,
+                visceralFat = u8(data, 14),
+                bodyAge = u8(data, 15),
+                impedance = u16be(data, 18).toDouble(),
+                unknown8 = u16be(data, 8),
+                unknown12 = u16be(data, 12),
+            )
+        }
+
+        /** 0x3C trailing byte: the measurement is still running. */
+        const val HEART_RATE_MEASURING = 0x01
+
+        /** 0x3C trailing byte: the reading in bytes 2..3 is final. */
+        const val HEART_RATE_FINAL = 0x02
+
+        /**
+         * Every byte position in a 0x3C frame that could hold the heart rate, as `label to
+         * value`. The layout is settled now (see [parseHeartRate]); this is kept purely as a
+         * diagnostic dump for other Picooc models, whose frames may well be laid out
+         * differently.
+         */
+        fun heartRateCandidates(data: ByteArray): List<Pair<String, Int>> = buildList {
+            if (data.size >= 4) add("u16be[2..3]" to u16be(data, 2))
+            if (data.size >= 3) add("u8[2]" to u8(data, 2))
+            if (data.size >= 4) add("u8[3]" to u8(data, 3))
+            if (data.size >= 5) add("u16be[3..4]" to u16be(data, 3))
+            if (data.size >= 5) add("u8[4]" to u8(data, 4))
+        }
+
+        /**
+         * Heart rate in bpm from a 0x3C frame, or `null` while the scale is still measuring.
+         *
+         * Layout confirmed against a PICOOC-CQ capture: `3C 05 [bpm BE 2B] [status]`, with
+         * status 1 while measuring and 2 once the value is final. The measuring frame reads
+         * `3C 05 00 00 01` and the result frame `3C 05 00 44 02` — 0x44 = 68 bpm, matching the
+         * scale's own display.
+         *
+         * Shorter frames from other models fall back to a single byte at offset 2; that path is
+         * unverified, hence the [heartRateCandidates] dump alongside it in the log.
+         */
+        fun parseHeartRate(data: ByteArray): Int? {
+            val bpm = when {
+                data.size >= 5 -> u16be(data, 2)
+                data.size >= 3 -> u8(data, 2)
+                else -> return null
+            }
+            return if (bpm in 30..250) bpm else null
+        }
+
+        /**
+         * Trailing status byte of a 0x3C frame — [HEART_RATE_MEASURING] or [HEART_RATE_FINAL] —
+         * or `null` if the frame is too short.
+         */
+        fun heartRateStatus(data: ByteArray): Int? =
+            if (data.size >= 5) u8(data, 4) else null
+
+        /**
+         * Firmware/BOM block appended to the 0x3A handshake. Present only when the high nibble
+         * of byte 11 is 1; returns `null` otherwise.
+         */
+        fun parseBomInfo(data: ByteArray): BomInfo? {
+            if (data.size < 17) return null
+            if ((u8(data, 11) and 0xF0) shr 4 != 1) return null
+            return BomInfo(
+                version = (u8(data, 11) and 0xF0) shr 4,
+                bomVersion = u8(data, 11) and 0x0F,
+                year = (u8(data, 12) and 0xF0) shr 4,
+                month = u8(data, 12) and 0x0F,
+                modelId = (u8(data, 13) shl 4) + ((u8(data, 14) and 0xF0) shr 4),
+                shortBom = ((u8(data, 14) and 0x0F) shl 10) + (u8(data, 15) shl 2) + (u8(data, 16) shr 6),
+                shortFactoryId = u8(data, 16) and 0x3F,
+            )
+        }
+    }
+}

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -899,6 +899,8 @@
 
     <!-- Warnings -->
     <string name="bt_warn_low_battery">Scale battery is low (%1$d%%).</string>
+    <!-- Used by scales that only signal that the battery is low, without reporting a level. -->
+    <string name="bt_warn_low_battery_unknown">Scale battery is low.</string>
     <string name="bt_warn_register_failed_with_code">Creating the user on the scale failed (code %1$d).</string>
     <string name="bt_warn_slots_full">The scale has no free user slots. Delete a user on the device and try again.</string>
     <string name="bt_warn_notify_failed">Failed to enable notifications for %1$s.</string>

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
@@ -53,6 +53,7 @@ import com.health.openscale.core.bluetooth.scales.MiScaleHandler
 import com.health.openscale.core.bluetooth.scales.MiScaleS400Handler
 import com.health.openscale.core.bluetooth.scales.OkOkHandler
 import com.health.openscale.core.bluetooth.scales.OmronWlcHandler
+import com.health.openscale.core.bluetooth.scales.PicoocHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneHandler
 import com.health.openscale.core.bluetooth.scales.OneByoneNewHandler
 import com.health.openscale.core.bluetooth.scales.QNHandler
@@ -159,6 +160,9 @@ object ScaleCatalog {
         // --- Matched by advertised name ---
         device("AE BS-06") claimedBy ActiveEraBF06Handler::class.java,
         device("Keep_S3") claimedBy KeepS3Handler::class.java,
+        // The S3 Lite V2.0 advertises as PICOOC-CQ; the Latin series carries no vendor prefix.
+        device("PICOOC-CQ") claimedBy PicoocHandler::class.java,
+        device("Latin-S") claimedBy PicoocHandler::class.java,
         device("Beurer BF450") claimedBy BeurerBF450Handler::class.java,
         device("BIA SCALE", SERVICE_FFB0) claimedBy TaylorBIAHandler::class.java,
         device("RYFIT") claimedBy RyFitHandler::class.java,

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/PicoocHandlerTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/PicoocHandlerTest.kt
@@ -1,0 +1,678 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.service.ScannedDeviceInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Calendar
+import java.util.UUID
+import kotlin.coroutines.EmptyCoroutineContext
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PicoocHandlerTest {
+    private val notifyCharacteristic = uuid16(0xFFF1)
+
+    // --- device matching -------------------------------------------------------------------
+
+    @Test
+    fun `claims connection-oriented picooc scales`() {
+        val support = PicoocHandler().supportFor(device("PICOOC-CQ"))!!
+
+        assertThat(support.linkMode).isEqualTo(LinkMode.CONNECT_GATT)
+        assertThat(support.implemented).contains(DeviceCapability.BODY_COMPOSITION)
+        assertThat(support.displayName).isEqualTo("PICOOC-CQ")
+    }
+
+    /** The whole connection-oriented line, per the protocol write-up and the CQ capture. */
+    @Test
+    fun `claims every connection-oriented model in the line`() {
+        val names = listOf(
+            "PICOOC-CQ",   // S3 Lite V2.0
+            "PICOOC-C1",
+            "PICOOC-14",
+            "PICOOC-25",
+            "PICOOC-IS",
+            "Picooc S3 Lite V2.0",
+        )
+
+        for (name in names) {
+            assertThat(PicoocHandler().supportFor(device(name))).isNotNull()
+        }
+    }
+
+    /** The Latin series advertises with no vendor prefix at all, so a "picooc" test misses it. */
+    @Test
+    fun `claims the Latin series despite its missing vendor prefix`() {
+        val support = PicoocHandler().supportFor(device("Latin-S"))!!
+
+        assertThat(support.linkMode).isEqualTo(LinkMode.CONNECT_GATT)
+        assertThat(support.displayName).isEqualTo("Picooc Latin-S")
+    }
+
+    @Test
+    fun `leaves the broadcast-only PICOOC-L family unclaimed`() {
+        assertThat(PicoocHandler().supportFor(device("PICOOC-L"))).isNull()
+        assertThat(PicoocHandler().supportFor(device("PICOOC-L1"))).isNull()
+    }
+
+    @Test
+    fun `ignores unrelated devices`() {
+        assertThat(PicoocHandler().supportFor(device("Vitafit VT701"))).isNull()
+        assertThat(PicoocHandler().supportFor(device("QN-Scale"))).isNull()
+        assertThat(PicoocHandler().supportFor(device(""))).isNull()
+    }
+
+    // --- frame builders --------------------------------------------------------------------
+
+    @Test
+    fun `builds three byte acknowledgements`() {
+        assertThat(PicoocHandler.buildAck(PicoocHandler.PREFIX_LATIN, 0x39))
+            .isEqualTo(bytes("F1 03 39"))
+        assertThat(PicoocHandler.buildAck(PicoocHandler.PREFIX_MODERN, 0x52))
+            .isEqualTo(bytes("A1 03 52"))
+    }
+
+    @Test
+    fun `time reply matches its own length field`() {
+        val reply = PicoocHandler.buildTimeReply(
+            PicoocHandler.PREFIX_LATIN,
+            PicoocHandler.OP_HANDSHAKE,
+            0x1234_5678L,
+            unit = 0,
+        )
+
+        assertThat(reply).isEqualTo(bytes("F1 0A 3A 12 34 56 78 00 00 00"))
+        assertThat(reply.size).isEqualTo(reply[1].toInt())
+    }
+
+    @Test
+    fun `encodes height as five millimetre steps above one metre`() {
+        assertThat(PicoocHandler.encodeHeight(180f)).isEqualTo(160)
+        assertThat(PicoocHandler.encodeHeight(150f)).isEqualTo(100)
+        assertThat(PicoocHandler.encodeHeight(100f)).isEqualTo(0)
+        // Clamped at both ends: below 1 m underflows, above 227.5 cm overflows a byte.
+        assertThat(PicoocHandler.encodeHeight(80f)).isEqualTo(0)
+        assertThat(PicoocHandler.encodeHeight(250f)).isEqualTo(255)
+        // A user with no height must not abort the handshake.
+        assertThat(PicoocHandler.encodeHeight(Float.NaN)).isEqualTo(0)
+        assertThat(PicoocHandler.encodeHeight(-1f)).isEqualTo(0)
+    }
+
+    @Test
+    fun `an unusable height still produces a well-formed profile`() {
+        val user = user(GenderType.MALE, 180f, 24).apply { bodyHeight = Float.NaN }
+
+        assertThat(PicoocHandler.buildUserProfile(user)).isEqualTo(bytes("31 06 01 01 00 18"))
+    }
+
+    @Test
+    fun `user profile matches its own length field and carries the real user`() {
+        val profile = PicoocHandler.buildUserProfile(user(GenderType.MALE, 180f, 24))
+
+        assertThat(profile).isEqualTo(bytes("31 06 01 01 A0 18"))
+        assertThat(profile.size).isEqualTo(profile[1].toInt())
+    }
+
+    @Test
+    fun `user profile encodes women as sex two`() {
+        val profile = PicoocHandler.buildUserProfile(user(GenderType.FEMALE, 165f, 31))
+
+        assertThat(profile).isEqualTo(bytes("31 06 01 02 82 1F"))
+    }
+
+    @Test
+    fun `user profile raises ages below the BIA engine minimum`() {
+        val profile = PicoocHandler.buildUserProfile(user(GenderType.MALE, 140f, 9))
+
+        assertThat(profile[5].toInt()).isEqualTo(18)
+    }
+
+    // --- frame parsers ---------------------------------------------------------------------
+
+    @Test
+    fun `parses a completed live frame`() {
+        val frame = PicoocHandler.parseLiveFrame(liveFrame(complete = true))!!
+
+        assertThat(frame.timestamp).isEqualTo(0x1234_5678L)
+        assertThat(frame.weightKg).isWithin(0.0001f).of(70.0f)
+        assertThat(frame.impedance).isWithin(0.0001).of(500.0)
+        assertThat(frame.weightLb).isWithin(0.0001f).of(154.3f)
+        assertThat(frame.unit).isEqualTo(0)
+        assertThat(frame.phaseAngle).isWithin(0.0001f).of(5.25f)
+        assertThat(frame.complete).isTrue()
+        assertThat(frame.poundFlag).isFalse()
+    }
+
+    /** Captured from a PICOOC-CQ weighing 71.7 kg, which the scale's own display confirmed. */
+    @Test
+    fun `parses the captured PICOOC-CQ weight frame`() {
+        val frame = PicoocHandler.parseLiveFrame(
+            bytes("39 10 6A 7B 9A E1 05 9A 13 A6 86 2C 00 02 B7 00"),
+        )!!
+
+        assertThat(frame.weightKg).isWithin(0.0001f).of(71.7f)
+        assertThat(frame.impedance).isWithin(0.0001).of(503.0)
+        assertThat(frame.phaseAngle).isWithin(0.0001f).of(6.95f)
+        assertThat(frame.complete).isTrue()
+        // 0x862C/10 would be 3434.8; only the low 15 bits are the pound value, and 158.0 lb is
+        // exactly 71.7 kg. The top bit is a separate, still unexplained flag.
+        assertThat(frame.weightLb).isWithin(0.0001f).of(158.0f)
+        assertThat(frame.poundFlag).isTrue()
+    }
+
+    @Test
+    fun `treats a non-zero trailing flag as still settling`() {
+        assertThat(PicoocHandler.parseLiveFrame(liveFrame(complete = false))!!.complete).isFalse()
+    }
+
+    @Test
+    fun `rejects a truncated live frame`() {
+        assertThat(PicoocHandler.parseLiveFrame(liveFrame(complete = true).copyOf(15))).isNull()
+    }
+
+    @Test
+    fun `parses a body composition frame`() {
+        val composition = PicoocHandler.parseComposition(compositionFrame())!!
+
+        assertThat(composition.weightKg).isWithin(0.0001f).of(70.0f)
+        assertThat(composition.fatPercent).isWithin(0.0001f).of(18.5f)
+        assertThat(composition.waterPercent).isWithin(0.0001f).of(55.2f)
+        assertThat(composition.boneMassKg).isWithin(0.0001f).of(3.0f)
+        assertThat(composition.visceralFat).isEqualTo(8)
+        assertThat(composition.bodyAge).isEqualTo(27)
+        assertThat(composition.impedance).isWithin(0.0001).of(500.0)
+        assertThat(composition.unknown8).isEqualTo(0x1122)
+        assertThat(composition.unknown12).isEqualTo(0x3344)
+    }
+
+    /**
+     * Both 0x3C payloads a PICOOC-CQ produces, captured back to back: the in-progress frame
+     * first, then the result. 0x44 = 68 bpm matched the scale's own display.
+     */
+    @Test
+    fun `parses the captured heart rate exchange`() {
+        val measuring = bytes("3C 05 00 00 01")
+        assertThat(PicoocHandler.parseHeartRate(measuring)).isNull()
+        assertThat(PicoocHandler.heartRateStatus(measuring))
+            .isEqualTo(PicoocHandler.HEART_RATE_MEASURING)
+
+        val result = bytes("3C 05 00 44 02")
+        assertThat(PicoocHandler.parseHeartRate(result)).isEqualTo(68)
+        assertThat(PicoocHandler.heartRateStatus(result))
+            .isEqualTo(PicoocHandler.HEART_RATE_FINAL)
+    }
+
+    @Test
+    fun `falls back to a single byte on shorter heart rate frames`() {
+        assertThat(PicoocHandler.parseHeartRate(bytes("3C 03 48"))).isEqualTo(72)
+        assertThat(PicoocHandler.parseHeartRate(bytes("3C 03 00"))).isNull()
+        assertThat(PicoocHandler.parseHeartRate(bytes("3C 03"))).isNull()
+    }
+
+    @Test
+    fun `dumps every heart rate candidate for diagnosing other models`() {
+        val candidates = PicoocHandler.heartRateCandidates(bytes("3C 05 00 44 02")).toMap()
+
+        assertThat(candidates).containsExactly(
+            "u16be[2..3]", 68,
+            "u8[2]", 0,
+            "u8[3]", 68,
+            "u16be[3..4]", 17410,
+            "u8[4]", 2,
+        )
+    }
+
+    // --- handshake -------------------------------------------------------------------------
+
+    @Test
+    fun `answers the handshake with a ten byte time frame`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, capturedHandshake)
+
+        val reply = setup.transport.writes.single().payload
+        assertThat(reply.size).isEqualTo(10)
+        assertThat(reply.copyOf(3)).isEqualTo(bytes("F1 0A 3A"))
+    }
+
+    /**
+     * PICOOC-CQ never sends 0x30 — the capture goes straight from the handshake to the weight
+     * frame — so the profile has to be pushed unprompted or the scale's BIA engine never gets
+     * sex, height and age.
+     */
+    @Test
+    fun `pushes the profile after the handshake even without a 0x30 request`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, capturedHandshake)
+        advanceTimeBy(PicoocHandler.PROFILE_DELAY_MS)
+        runCurrent()
+
+        assertThat(setup.transport.writes).hasSize(2)
+        assertThat(setup.transport.writes[1].payload).isEqualTo(bytes("31 06 01 01 A0 18"))
+    }
+
+    @Test
+    fun `does not push the profile twice for repeated handshakes`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, capturedHandshake)
+        setup.handler.handleNotification(notifyCharacteristic, capturedHandshake)
+        advanceTimeBy(PicoocHandler.PROFILE_DELAY_MS)
+        runCurrent()
+
+        assertThat(setup.transport.writes.count { it.payload.contentEquals(bytes("31 06 01 01 A0 18")) })
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `decodes the captured PICOOC-CQ handshake`() {
+        val bom = PicoocHandler.parseBomInfo(capturedHandshake)!!
+
+        assertThat(bom.version).isEqualTo(1)
+        assertThat(bom.bomVersion).isEqualTo(0)
+        assertThat(bom.modelId).isEqualTo(0x3A)
+    }
+
+    @Test
+    fun `acks the profile request and follows up with the real user profile`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, bytes("30 02"))
+
+        assertThat(setup.transport.writes.single().payload).isEqualTo(bytes("F1 03 30"))
+        advanceTimeBy(PicoocHandler.PROFILE_DELAY_MS)
+        runCurrent()
+
+        assertThat(setup.transport.writes).hasSize(2)
+        assertThat(setup.transport.writes[1].payload).isEqualTo(bytes("31 06 01 01 A0 18"))
+    }
+
+    @Test
+    fun `switches to the A1 prefix once the scale uses the newer opcodes`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, bytes("51 0B 01 02 03 04 05 06 07 08 09"))
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = false))
+
+        // The reply to 0x51 is still a 0x3A time frame, only the prefix changes.
+        assertThat(setup.transport.writes[0].payload.copyOf(3)).isEqualTo(bytes("A1 0A 3A"))
+        assertThat(setup.transport.writes[1].payload).isEqualTo(bytes("A1 03 39"))
+    }
+
+    // --- measurement session ---------------------------------------------------------------
+
+    @Test
+    fun `streams live weight without writing a record`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        repeat(3) { setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = false)) }
+        advanceTimeBy(10_000)
+        runCurrent()
+
+        assertThat(setup.callbacks.published).isEmpty()
+        assertThat(setup.transport.writes.map { it.payload.toList() })
+            .containsExactlyElementsIn(List(3) { bytes("F1 03 39").toList() })
+    }
+
+    @Test
+    fun `publishes once with composition and heart rate after the settle window`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = true))
+        setup.handler.handleNotification(notifyCharacteristic, compositionFrame())
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3C 03 48"))
+
+        assertThat(setup.callbacks.published).isEmpty()
+        advanceTimeBy(PicoocHandler.SETTLE_WAIT_MS - 1)
+        runCurrent()
+        assertThat(setup.callbacks.published).isEmpty()
+        advanceTimeBy(1)
+        runCurrent()
+
+        val measurement = setup.callbacks.published.single()
+        assertThat(measurement.userId).isEqualTo(setup.user.id)
+        assertThat(measurement.weight).isWithin(0.0001f).of(70.0f)
+        assertThat(measurement.fat).isWithin(0.0001f).of(18.5f)
+        assertThat(measurement.water).isWithin(0.0001f).of(55.2f)
+        assertThat(measurement.bone).isWithin(0.0001f).of(3.0f)
+        assertThat(measurement.visceralFat).isWithin(0.0001f).of(8.0f)
+        assertThat(measurement.lbm).isWithin(0.001f).of(57.05f)
+        assertThat(measurement.heartRate).isEqualTo(72)
+        assertThat(measurement.impedance).isWithin(0.0001).of(500.0)
+        // 0x32 carries neither of these, so they come from the impedance estimator.
+        assertThat(measurement.muscle).isGreaterThan(0f)
+        assertThat(measurement.bmr).isGreaterThan(0f)
+    }
+
+    @Test
+    fun `heart rate arriving after the composition frame is still included`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = true))
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3C 03 48"))
+        setup.handler.handleNotification(notifyCharacteristic, compositionFrame())
+        advanceTimeBy(PicoocHandler.SETTLE_WAIT_MS)
+        runCurrent()
+
+        assertThat(setup.callbacks.published.single().heartRate).isEqualTo(72)
+    }
+
+    @Test
+    fun `estimates composition from impedance when the scale sends no 0x32`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = true))
+        advanceTimeBy(PicoocHandler.SETTLE_WAIT_MS)
+        runCurrent()
+
+        val measurement = setup.callbacks.published.single()
+        assertThat(measurement.weight).isWithin(0.0001f).of(70.0f)
+        assertThat(measurement.impedance).isWithin(0.0001).of(500.0)
+        assertThat(measurement.fat).isGreaterThan(0f)
+        assertThat(measurement.water).isGreaterThan(0f)
+        assertThat(measurement.muscle).isGreaterThan(0f)
+        assertThat(measurement.bmr).isGreaterThan(0f)
+    }
+
+    @Test
+    fun `publishes the latched weight when the scale hangs up before completing`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = false))
+        assertThat(setup.callbacks.published).isEmpty()
+
+        setup.handler.handleDisconnected()
+
+        assertThat(setup.callbacks.published).hasSize(1)
+        assertThat(setup.callbacks.published.single().weight).isWithin(0.0001f).of(70.0f)
+    }
+
+    @Test
+    fun `a disconnect after publishing does not add a second record`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, liveFrame(complete = true))
+        advanceTimeBy(PicoocHandler.SETTLE_WAIT_MS)
+        runCurrent()
+        setup.handler.handleDisconnected()
+
+        assertThat(setup.callbacks.published).hasSize(1)
+    }
+
+    /**
+     * Replays a full PICOOC-CQ session frame for frame: handshake, a single already-settled
+     * weight frame, a heart-rate measurement that takes 6.4 s to resolve, then the scale
+     * hanging up. One record carrying both the weight and the heart rate, and nothing published
+     * early — a 1.5 s settle window used to close the record before the heart rate even
+     * started, and without the 0x3C ack the reading never arrived at all.
+     */
+    @Test
+    fun `replays the captured PICOOC-CQ session as a single record`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+
+        setup.handler.handleNotification(notifyCharacteristic, capturedHandshake)
+        advanceTimeBy(2_800)
+        runCurrent()
+
+        setup.handler.handleNotification(
+            notifyCharacteristic,
+            bytes("39 10 6A 7B A5 50 05 A2 13 BA 86 36 00 02 C8 00"),
+        )
+        // 4 s of silence, then the scale reports that it is measuring the heart rate.
+        advanceTimeBy(4_000)
+        runCurrent()
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3C 05 00 00 01"))
+
+        // 6.4 s more before the reading lands — far longer than the old 1.5 s window.
+        advanceTimeBy(6_400)
+        runCurrent()
+        assertThat(setup.callbacks.published).isEmpty()
+
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3C 05 00 44 02"))
+        setup.handler.handleDisconnected()
+
+        val measurement = setup.callbacks.published.single()
+        assertThat(measurement.weight).isWithin(0.0001f).of(72.1f)
+        assertThat(measurement.impedance).isWithin(0.0001).of(505.0)
+        assertThat(measurement.heartRate).isEqualTo(68)
+        assertThat(measurement.fat).isGreaterThan(0f)
+        assertThat(measurement.bmr).isGreaterThan(0f)
+    }
+
+    @Test
+    fun `undocumented opcodes are tolerated without publishing`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3E 08 01 02 03 04 05 06"))
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3F 05 01 02 03"))
+        setup.handler.handleNotification(notifyCharacteristic, bytes("36 04 01 02"))
+        setup.handler.handleNotification(notifyCharacteristic, bytes("37 02"))
+        // Neither of these carries data the scale waits on, so neither is acked.
+        setup.handler.handleNotification(notifyCharacteristic, bytes("3B 03 01"))
+        setup.handler.handleNotification(notifyCharacteristic, bytes("7F 02"))
+
+        assertThat(setup.callbacks.published).isEmpty()
+        assertThat(setup.transport.writes.map { it.payload.toList() }).containsExactly(
+            bytes("F1 03 3E").toList(),
+            bytes("F1 03 3F").toList(),
+            bytes("F1 03 36").toList(),
+            bytes("F1 03 37").toList(),
+        )
+    }
+
+    /**
+     * Without this ack a PICOOC-CQ resends a byte-identical `3C 05 00 00 01` ten times at 1 Hz
+     * and then drops the link, never reaching the reading its own display was showing.
+     */
+    @Test
+    fun `acknowledges every heart rate frame`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        repeat(3) { setup.handler.handleNotification(notifyCharacteristic, bytes("3C 05 00 00 01")) }
+
+        assertThat(setup.transport.writes.map { it.payload.toList() })
+            .containsExactlyElementsIn(List(3) { bytes("F1 03 3C").toList() })
+    }
+
+    @Test
+    fun `acknowledges the body composition frame`() = runTest {
+        val setup = attachedHandler(scope = this)
+        setup.handler.handleConnected(setup.user)
+        setup.transport.clearWrites()
+
+        setup.handler.handleNotification(notifyCharacteristic, compositionFrame())
+
+        assertThat(setup.transport.writes.single().payload).isEqualTo(bytes("F1 03 32"))
+    }
+
+    // --- helpers ---------------------------------------------------------------------------
+
+    /** The 0x3A handshake a PICOOC-CQ actually sent, BOM block and all. */
+    private val capturedHandshake =
+        bytes("3A 12 0A 00 00 00 00 00 00 00 00 10 39 03 A0 46 47 03")
+
+    /**
+     * A 0x39 frame reading 70.00 kg / 500.0 Ω / 154.3 lb / 5.25° phase angle.
+     * Byte 15 is the completion flag: 0 means settled and reportable.
+     */
+    private fun liveFrame(complete: Boolean): ByteArray =
+        bytes("39 10 12 34 56 78 05 78 13 88 06 07 00 02 0D") + byteArrayOf(if (complete) 0 else 1)
+
+    /**
+     * A 0x32 frame reading 70.00 kg / 18.5 % fat / 55.2 % water / 3.00 kg bone /
+     * visceral 8 / body age 27 / 500 Ω, with recognisable filler in the undocumented fields.
+     */
+    private fun compositionFrame(): ByteArray =
+        bytes("32 14 05 78 00 B9 02 28 11 22 00 3C 33 44 08 1B 00 00 01 F4")
+
+    private fun attachedHandler(
+        user: ScaleUser = user(GenderType.MALE, 180f, 24),
+        scope: CoroutineScope = CoroutineScope(EmptyCoroutineContext),
+    ): Setup {
+        val handler = PicoocHandler()
+        val transport = CapturingTransport()
+        val callbacks = CapturingCallbacks()
+        handler.attach(
+            transport = transport,
+            callbacks = callbacks,
+            settings = InMemorySettings(),
+            data = FixedDataProvider(user),
+            scope = scope,
+        )
+        return Setup(handler, transport, callbacks, user)
+    }
+
+    private fun user(gender: GenderType, heightCm: Float, age: Int): ScaleUser {
+        val birthday = Calendar.getInstance().apply { add(Calendar.YEAR, -age) }.time
+        return ScaleUser(id = 7, birthday = birthday, bodyHeight = heightCm, gender = gender)
+    }
+
+    private fun device(name: String) = ScannedDeviceInfo(
+        name = name,
+        address = "00:11:22:33:44:55",
+        rssi = -50,
+        serviceUuids = emptyList(),
+        manufacturerData = null,
+    )
+
+    private fun uuid16(short: Int): UUID =
+        UUID.fromString(String.format("0000%04x-0000-1000-8000-00805f9b34fb", short))
+
+    private fun bytes(hex: String): ByteArray = hex
+        .trim()
+        .split(Regex("\\s+"))
+        .filter(String::isNotEmpty)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+
+    private data class Setup(
+        val handler: PicoocHandler,
+        val transport: CapturingTransport,
+        val callbacks: CapturingCallbacks,
+        val user: ScaleUser,
+    )
+
+    private data class Write(
+        val service: UUID,
+        val characteristic: UUID,
+        val payload: ByteArray,
+        val withResponse: Boolean,
+    )
+
+    private class CapturingTransport : ScaleDeviceHandler.Transport {
+        val notifications = mutableListOf<Pair<UUID, UUID>>()
+        val writes = mutableListOf<Write>()
+        var disconnectCount = 0
+
+        override fun setNotifyOn(service: UUID, characteristic: UUID) {
+            notifications += service to characteristic
+        }
+
+        override fun write(
+            service: UUID,
+            characteristic: UUID,
+            payload: ByteArray,
+            withResponse: Boolean,
+        ) {
+            writes += Write(service, characteristic, payload.copyOf(), withResponse)
+        }
+
+        override fun read(service: UUID, characteristic: UUID) = Unit
+
+        override fun disconnect() {
+            disconnectCount++
+        }
+
+        override fun hasCharacteristic(service: UUID, characteristic: UUID): Boolean = true
+
+        fun clearWrites() = writes.clear()
+    }
+
+    private class CapturingCallbacks : ScaleDeviceHandler.Callbacks {
+        val published = mutableListOf<ScaleMeasurement>()
+
+        override fun onPublish(measurement: ScaleMeasurement) {
+            published += measurement.copy()
+        }
+
+        override fun resolveString(resId: Int, vararg args: Any): String = "res:$resId"
+    }
+
+    private class InMemorySettings : ScaleDeviceHandler.DriverSettings {
+        private val strings = mutableMapOf<String, String>()
+        private val ints = mutableMapOf<String, Int>()
+
+        override fun getInt(key: String, default: Int): Int = ints[key] ?: default
+        override fun putInt(key: String, value: Int) {
+            ints[key] = value
+        }
+
+        override fun getString(key: String, default: String?): String? = strings[key] ?: default
+        override fun putString(key: String, value: String) {
+            strings[key] = value
+        }
+
+        override fun remove(key: String) {
+            strings.remove(key)
+            ints.remove(key)
+        }
+    }
+
+    private class FixedDataProvider(private val user: ScaleUser) : ScaleDeviceHandler.DataProvider {
+        override fun currentUser(): ScaleUser = user
+        override fun usersForDevice(): List<ScaleUser> = listOf(user)
+        override fun lastMeasurementFor(userId: Int): ScaleMeasurement? = null
+    }
+}


### PR DESCRIPTION
Adds a handler for the Picooc scales that speak the 0xFFF0 GATT protocol (PICOOC-C1..CQ, PICOOC-14..25, PICOOC-IS, the S3 Lite V2.0 which advertises as PICOOC-CQ, and the Latin series, which advertises with no vendor prefix).

The scale publishes weight, whole-body impedance and heart rate. It does not report body composition of its own, so fat/water/muscle/bone/LBM/BMR are derived from the impedance via StandardImpedanceLib, as the other impedance-only scales in this package do. The 0x32 composition frame is parsed and preferred when present.

Protocol notes, verified against a PICOOC-CQ capture:

- The scale opens with 0x3A (time request plus a BOM block) and expects a 10-byte reply; the length field counts the 0xF1 prefix.
- It never sends the documented 0x30 profile request, so the sex/height/age frame is pushed unprompted after the handshake. Without it the scale has nothing to run its BIA engine on.
- There is no live weight stream on this model: a single 0x39 arrives with the completion flag already set.
- The pound field in 0x39 is 15 bits wide. 0x862C/10 reads 3434.8 lb, while (0x862C & 0x7FFF)/10 is 158.0 lb, which is exactly the 71.7 kg reported in the same frame. The top bit is a separate flag of unknown meaning.
- 0x3C must be acknowledged. Unacknowledged, the scale resends a byte-identical "3C 05 00 00 01" ten times at 1 Hz and then drops the link, never reaching the reading its own display was showing. Acknowledged, it sends the in-progress frame once and then "3C 05 00 44 02" - 0x44 = 68 bpm, matching the display. Layout is [bpm BE 2B][status], status 1 measuring, 2 final.
- Publication waits for the scale to hang up, which it does on its own once finished; a re-armed quiet period is the fallback. Heart rate lands 10 s after the weight, so publishing on the weight frame loses it.

Opcodes 0x35, 0x36, 0x37, 0x3B, 0x3E and 0x3F are acknowledged and dumped to the log but not decoded: no capture has produced them yet. The metabolic body age in 0x32 and the phase angle in 0x39 are decoded and logged but not stored, as ScaleMeasurement has no field for either.

PICOOC-L (Mini) is deliberately left unclaimed. It is broadcast-only and never accepts a GATT connection, so it needs a separate BROADCAST_ONLY handler.

The handler is registered ahead of ScaleupHandler, which claims any device whose manufacturer data carries a 0xD0/0xE0 key regardless of name.

https://garden.1900.live/22-knowledge/%E5%BC%80%E5%8F%91/picooc%E4%BD%93%E8%84%82%E7%A7%A4ble%E5%8D%8F%E8%AE%AE%E5%88%86%E6%9E%90