### PR TITLE
Add scoped Beurer BF1000 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Monitor and track your weight, BMI, body fat, body water, muscle and other body 
 openScale has built-in support for a number of Bluetooth (BLE or "smart") scales from  many manufacturers, e.g. Beurer, Sanitas, Yunmai, Xiaomi, etc. (see model list below). Together with our users we constantly improve and extend the set of supported scales and in many cases pick up where the original app falls short.
 
 - Custom made Bluetooth scale
-- Beurer BF105, BF500, BF600, BF700, BF710, BF720, BF800, BF850 and BF950
+- Beurer BF105, BF500, BF600, BF700, BF710, BF720, BF800, BF850, BF950 and BF1000
 - Digoo DG-S038H
 - Excelvan CF369BLE
 - Exingtech Y1

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/BeurerBf1000Lib.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/BeurerBf1000Lib.kt
@@ -1,0 +1,83 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+/**
+ * Parser for the Beurer BF1000 Super Precision private measurement packets.
+ *
+ * Standard Weight Scale (2A9D) and Body Composition (2A9C) packets are handled
+ * by StandardWeightProfileHandler. The BF1000 also sends Beurer-private packets
+ * on service FFFF: characteristic 0009 for visceral/segmental fat and 000A for
+ * segmental muscle. These functions intentionally stay free of Android
+ * dependencies so captured packets can be asserted in JVM tests.
+ */
+object BeurerBf1000Lib {
+    data class SegmentalFatMeasurement(
+        val visceralFat: Float,
+        val leftArm: Float,
+        val rightArm: Float,
+        val torso: Float,
+        val leftLeg: Float,
+        val rightLeg: Float
+    )
+
+    data class SegmentalMuscleMeasurement(
+        val leftArm: Float,
+        val rightArm: Float,
+        val torso: Float,
+        val leftLeg: Float,
+        val rightLeg: Float
+    )
+
+    fun parseSegmentalFatMeasurement(value: ByteArray): SegmentalFatMeasurement? {
+        if (!hasBytes(value, 0, 12) || u8(value, 0) != 0x7E) return null
+        val fat = readTenths(value, offset = 2, count = 5)
+        return SegmentalFatMeasurement(
+            visceralFat = u8(value, 1) * 0.1f,
+            leftArm = fat[0],
+            rightArm = fat[1],
+            torso = fat[2],
+            leftLeg = fat[3],
+            rightLeg = fat[4]
+        )
+    }
+
+    fun parseSegmentalMuscleMeasurement(value: ByteArray): SegmentalMuscleMeasurement? {
+        if (!hasBytes(value, 0, 11) || u8(value, 0) != 0x3E) return null
+        val muscle = readTenths(value, offset = 1, count = 5)
+        return SegmentalMuscleMeasurement(
+            leftArm = muscle[0],
+            rightArm = muscle[1],
+            torso = muscle[2],
+            leftLeg = muscle[3],
+            rightLeg = muscle[4]
+        )
+    }
+
+    private fun readTenths(data: ByteArray, offset: Int, count: Int): List<Float> =
+        List(count) { index -> u16le(data, offset + index * 2) * 0.1f }
+
+    private fun hasBytes(data: ByteArray, offset: Int, count: Int): Boolean =
+        offset >= 0 && count >= 0 && offset + count <= data.size
+
+    private fun u8(data: ByteArray, offset: Int): Int =
+        data[offset].toInt() and 0xFF
+
+    private fun u16le(data: ByteArray, offset: Int): Int =
+        (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardBeurerSanitasHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/StandardBeurerSanitasHandler.kt
@@ -18,6 +18,7 @@
 package com.health.openscale.core.bluetooth.scales
 
 import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.BeurerBf1000Lib
 import com.health.openscale.core.data.ActivityLevel
 import com.health.openscale.core.data.GenderType
 import com.health.openscale.core.service.ScannedDeviceInfo
@@ -32,8 +33,9 @@ import java.util.UUID
  */
 class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
 
-    private enum class Model { BEURER_BF105, BEURER_BF950, BEURER_BF500, BEURER_BF600 }
+    private enum class Model { BEURER_BF105, BEURER_BF1000, BEURER_BF950, BEURER_BF500, BEURER_BF600 }
     private val scaleUserList = mutableListOf<ScaleUser>()
+    private val bf1000AmbiguousScaleUserList = mutableListOf<ScaleUser>()
 
     private data class Profile(
         val service: UUID,
@@ -44,12 +46,31 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
         val chrTargetWeight: UUID?
     )
 
+    private data class ParsedBf1000ScaleUser(
+        val scaleUser: ScaleUser,
+        val authoritativeSlot: Boolean
+    )
+
     private var activeModel: Model? = null
     private var friendlyName: String? = null
     private var profile: Profile? = null
 
+    // BF1000 private measurement characteristics on the Beurer FFFF service:
+    // 0006 reports measurement-complete status, 0009 carries visceral/segmental
+    // fat, and 000A carries segmental muscle. Segmental values are decoded and
+    // logged only until openScale has a generic/custom BLE measurement path.
+    private val bf1000MeasurementStatus = uuid16(0x0006)
+    private val bf1000SegmentalFatMeasurement = uuid16(0x0009)
+    private val bf1000SegmentalMuscleMeasurement = uuid16(0x000A)
+    private val bf1000CustomMeasurementChars = listOf(
+        bf1000MeasurementStatus,
+        bf1000SegmentalFatMeasurement,
+        bf1000SegmentalMuscleMeasurement
+    )
+
     private fun pFor(m: Model) = when (m) {
-        Model.BEURER_BF105 -> Profile(
+        Model.BEURER_BF105,
+        Model.BEURER_BF1000 -> Profile(
             service = uuid16(0xFFFF),
             chrUserList = uuid16(0x0001),
             chrActivity = uuid16(0x0004),
@@ -85,6 +106,7 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
 
     private fun nameFor(m: Model) = when (m) {
         Model.BEURER_BF105 -> "Beurer BF105/720"
+        Model.BEURER_BF1000 -> "Beurer BF1000"
         Model.BEURER_BF950 -> "Beurer BF950"
         Model.BEURER_BF500 -> "Beurer BF500"
         Model.BEURER_BF600 -> "Beurer BF600"
@@ -98,6 +120,7 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
 
         val model = when {
             "bf105" in name || "bf720" in name -> Model.BEURER_BF105
+            "bf1000" in name                   -> Model.BEURER_BF1000
             "bf950" in name || "sbf77" in name || "sbf76" in name -> Model.BEURER_BF950
             "bf500" in name                    -> Model.BEURER_BF500
             "bf600" in name || "bf850" in name -> Model.BEURER_BF600
@@ -140,10 +163,18 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
                 profile?.service?.let { svc ->
                     logD("Setting custom user list notifications on service=${svc} for chrUserList=${chr}")
 
+                    if (activeModel == Model.BEURER_BF1000) {
+                        scaleUserList.clear()
+                        bf1000AmbiguousScaleUserList.clear()
+                    }
                     setNotifyOn(svc, chr)
                     writeTo(svc, chr, byteArrayOf(0x00.toByte()))
                 }
             }
+        }
+
+        if (activeModel == Model.BEURER_BF1000) {
+            enableBf1000CustomMeasurements()
         }
     }
 
@@ -176,9 +207,16 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
             return
         }
 
-        when (characteristic) {
-            p.chrUserList       -> {
-                handleUserList(data, user)
+        when {
+            characteristic == p.chrUserList -> {
+                if (activeModel == Model.BEURER_BF1000) {
+                    handleBf1000UserList(data, user)
+                } else {
+                    handleUserList(data, user)
+                }
+            }
+            activeModel == Model.BEURER_BF1000 && isBf1000CustomMeasurementCharacteristic(characteristic) -> {
+                handleBf1000CustomMeasurementData(characteristic, data)
             }
             else ->
                 super.onNotification(characteristic, data, user)
@@ -193,6 +231,57 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
     }
 
     // ---- Vendor write helpers -------------------------------------------------
+
+    private fun enableBf1000CustomMeasurements() {
+        val p = profile ?: return
+
+        logD("Enabling BF1000 custom measurement characteristics")
+        bf1000CustomMeasurementChars.forEach { chr ->
+            setNotifyOn(p.service, chr)
+        }
+    }
+
+    private fun handleBf1000CustomMeasurementData(characteristic: UUID, data: ByteArray) {
+        logD("BF1000 custom chr=${characteristic.shortId()} len=${data.size} ${data.toHexPreview(64)}")
+
+        when {
+            characteristic == bf1000SegmentalFatMeasurement -> {
+                val decoded = BeurerBf1000Lib.parseSegmentalFatMeasurement(data)
+                if (decoded == null) {
+                    logW("BF1000 segmental fat packet could not be decoded")
+                    return
+                }
+
+                logD(
+                    "BF1000 segmental fat decoded, not persisted: visceral=${decoded.visceralFat} " +
+                        "leftArm=${decoded.leftArm}% rightArm=${decoded.rightArm}% " +
+                        "torso=${decoded.torso}% leftLeg=${decoded.leftLeg}% " +
+                        "rightLeg=${decoded.rightLeg}%"
+                )
+            }
+            characteristic == bf1000SegmentalMuscleMeasurement -> {
+                val decoded = BeurerBf1000Lib.parseSegmentalMuscleMeasurement(data)
+                if (decoded == null) {
+                    logW("BF1000 segmental muscle packet could not be decoded")
+                    return
+                }
+
+                logD(
+                    "BF1000 segmental muscle decoded, not persisted: leftArm=${decoded.leftArm}% " +
+                        "rightArm=${decoded.rightArm}% torso=${decoded.torso}% " +
+                        "leftLeg=${decoded.leftLeg}% rightLeg=${decoded.rightLeg}%"
+                )
+            }
+        }
+
+        if (characteristic == bf1000MeasurementStatus &&
+            data.firstOrNull()?.toInt()?.and(0xFF) == 0x01) {
+            logD("BF1000 measurement-complete status received")
+        }
+    }
+
+    private fun isBf1000CustomMeasurementCharacteristic(characteristic: UUID): Boolean =
+        characteristic in bf1000CustomMeasurementChars
 
     private fun handleUserList(data: ByteArray, user : ScaleUser) {
         val parser = BluetoothBytesParser(data)
@@ -261,6 +350,160 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
         }
     }
 
+    private fun handleBf1000UserList(data: ByteArray, user : ScaleUser) {
+        if (data.isEmpty()) {
+            logW("Empty user-list packet")
+            return
+        }
+
+        if (data.size == 1) {
+            when (u8(data, 0)) {
+                2 -> {
+                    if (scaleUserList.isEmpty() && bf1000AmbiguousScaleUserList.isEmpty()) {
+                        // Status=2 -> no user on scale; clear any stale mapping and offer registration
+                        logD("No users on scale, presenting create-only choice")
+                        val appId = user.id
+                        findKnownScaleIndexForAppUser(appId)?.let { idx ->
+                            saveUserIdForScaleIndex(idx, -1)
+                            saveConsentForScaleIndex(idx, -1)
+                            logD("Cleared stale mapping for appUserId=$appId at scaleIndex=$idx")
+                        }
+                        presentCreateOnlyChoice()
+                    } else {
+                        logD("User-list received")
+                        presentBf1000UserListIfConsentMissing(user)
+                    }
+                    return
+                }
+
+                1 -> {
+                    // Status=1 -> user list complete
+                    logD("User-list received")
+                    presentBf1000UserListIfConsentMissing(user)
+                    return
+                }
+
+                else -> {
+                    logW("Unknown user-list status packet: ${data.toHexPreview(16)}")
+                    return
+                }
+            }
+        }
+
+        parseBf1000ScaleUser(data)?.let { parsed ->
+            if (parsed.authoritativeSlot) {
+                upsertScaleUser(parsed.scaleUser)
+            } else {
+                bf1000AmbiguousScaleUserList += parsed.scaleUser
+                logD("ScaleUser deferred: $parsed")
+            }
+        } ?: logW("User-list entry could not be decoded: ${data.toHexPreview(32)}")
+    }
+
+    private fun presentBf1000UserListIfConsentMissing(user: ScaleUser) {
+        resolveBf1000AmbiguousScaleUsers()
+        val scaleIndex = findKnownScaleIndexForAppUser(user.id) ?: -1
+        if (loadConsentForScaleIndex(scaleIndex) == -1) {
+            presentChooseFromUsers(scaleUserList.sortedBy { it.id })
+        }
+    }
+
+    private fun resolveBf1000AmbiguousScaleUsers() {
+        if (bf1000AmbiguousScaleUserList.isEmpty()) {
+            return
+        }
+
+        bf1000AmbiguousScaleUserList.forEach { candidate ->
+            if (scaleUserList.any { it.hasSameUserProfileAs(candidate) }) {
+                logD("ScaleUser deferred duplicate ignored: $candidate")
+                return@forEach
+            }
+
+            val targetIndex = listOf(candidate.id, candidate.id + 1)
+                .filter { it in 1..255 }
+                .distinct()
+                .firstOrNull { slot -> scaleUserList.none { it.id == slot } }
+
+            if (targetIndex != null) {
+                upsertScaleUser(candidate.copy(id = targetIndex))
+            } else {
+                logW("ScaleUser deferred entry could not be assigned to a free slot: $candidate")
+            }
+        }
+
+        bf1000AmbiguousScaleUserList.clear()
+    }
+
+    private fun parseBf1000ScaleUser(data: ByteArray): ParsedBf1000ScaleUser? {
+        if (data.size < 12) {
+            logW("User-list entry too short: len=${data.size} ${data.toHexPreview(32)}")
+            return null
+        }
+
+        val authoritativeSlot = u8(data, 1) > 0
+        val index = when {
+            // Existing Beurer/Sanitas records use [kind, slot, initials...].
+            authoritativeSlot -> u8(data, 1)
+            // BF1000 captures also show [slot-like, 00, initials...] records.
+            // They duplicate profile data, but their slot byte is not always
+            // authoritative, so they are resolved after the list is complete.
+            u8(data, 0) > 0 && u8(data, 1) == 0 -> u8(data, 0)
+            else -> {
+                logW("User-list entry has unknown slot layout: ${data.toHexPreview(32)}")
+                return null
+            }
+        }
+
+        val rawInitials = data.copyOfRange(2, 5)
+        val initials = if (rawInitials.all { it == 0xFF.toByte() }) {
+            "unknown"
+        } else {
+            String(rawInitials, Charsets.US_ASCII)
+                .filter { it.isLetterOrDigit() }
+                .take(3)
+                .ifEmpty { "unknown" }
+        }
+
+        val year = u16le(data, 5)
+        val month = u8(data, 7)
+        val day = u8(data, 8)
+        val height = u8(data, 9)
+        val gender = u8(data, 10)
+        val activityLevel = u8(data, 11)
+
+        val calendar = GregorianCalendar(year, month - 1, day)
+        val scaleUser = ScaleUser().apply {
+            this.userName = initials
+            this.birthday = calendar.time
+            this.bodyHeight = height.toFloat()
+            this.gender = if (gender == 0) GenderType.MALE else GenderType.FEMALE
+            this.activityLevel = ActivityLevel.fromInt(activityLevel - 1)
+            this.id = index
+        }
+
+        return ParsedBf1000ScaleUser(
+            scaleUser = scaleUser,
+            authoritativeSlot = authoritativeSlot
+        )
+    }
+
+    private fun upsertScaleUser(scaleUser: ScaleUser) {
+        val existingIndex = scaleUserList.indexOfFirst { it.id == scaleUser.id }
+        if (existingIndex >= 0) {
+            scaleUserList[existingIndex] = scaleUser
+            logD("ScaleUser updated: $scaleUser")
+        } else {
+            scaleUserList.add(scaleUser)
+            logD("ScaleUser added: $scaleUser")
+        }
+    }
+
+    private fun ScaleUser.hasSameUserProfileAs(other: ScaleUser): Boolean =
+        birthday == other.birthday &&
+            bodyHeight == other.bodyHeight &&
+            gender == other.gender &&
+            activityLevel == other.activityLevel
+
     private fun writeActivityLevel(user: ScaleUser) {
         val lvl = (user.activityLevel.toInt() + 1).coerceIn(1, 5)
         profile?.chrActivity?.let { chr ->
@@ -294,4 +537,13 @@ class StandardBeurerSanitasHandler : StandardWeightProfileHandler() {
             }
         }
     }
+
+    private fun UUID.shortId(): String =
+        String.format("0x%04x", (mostSignificantBits shr 32) and 0xFFFF)
+
+    private fun u8(data: ByteArray, offset: Int): Int =
+        data[offset].toInt() and 0xFF
+
+    private fun u16le(data: ByteArray, offset: Int): Int =
+        (data[offset].toInt() and 0xFF) or ((data[offset + 1].toInt() and 0xFF) shl 8)
 }

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
@@ -171,6 +171,7 @@ object ScaleCatalog {
         device("SANITAS SBF73") claimedBy SanitasSbf72Handler::class.java,
         device("Beurer BF915") claimedBy SanitasSbf72Handler::class.java,
         device("Beurer BF105") claimedBy StandardBeurerSanitasHandler::class.java,
+        device("Beurer BF1000") claimedBy StandardBeurerSanitasHandler::class.java,
         device("Beurer BF500") claimedBy StandardBeurerSanitasHandler::class.java,
         device("Beurer BF600") claimedBy StandardBeurerSanitasHandler::class.java,
         device("Beurer BF950") claimedBy StandardBeurerSanitasHandler::class.java,

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/BeurerBf1000LibTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/BeurerBf1000LibTest.kt
@@ -1,0 +1,80 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Tests for the Beurer BF1000 Super Precision private segmental decoder.
+ *
+ * The vectors are from an openScale file-log capture taken against a BF1000:
+ * Beurer-private FFFF/0009 segmental fat and FFFF/000A segmental muscle
+ * notifications. Standard 2A9D and 2A9C packets are handled by the existing
+ * StandardWeightProfileHandler.
+ */
+class BeurerBf1000LibTest {
+    private fun hex(s: String): ByteArray =
+        s.filterNot { it.isWhitespace() }.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    fun `decodes private segmental fat measurement`() {
+        val decoded = BeurerBf1000Lib.parseSegmentalFatMeasurement(
+            hex("7E 32 8E 00 8F 00 63 00 81 00 7C 00")
+        )
+
+        assertThat(decoded).isNotNull()
+        with(decoded!!) {
+            assertThat(visceralFat).isWithin(1e-4f).of(5.0f)
+            assertThat(leftArm).isWithin(1e-4f).of(14.2f)
+            assertThat(rightArm).isWithin(1e-4f).of(14.3f)
+            assertThat(torso).isWithin(1e-4f).of(9.9f)
+            assertThat(leftLeg).isWithin(1e-4f).of(12.9f)
+            assertThat(rightLeg).isWithin(1e-4f).of(12.4f)
+        }
+    }
+
+    @Test
+    fun `decodes private segmental muscle measurement`() {
+        val decoded = BeurerBf1000Lib.parseSegmentalMuscleMeasurement(
+            hex("3E EA 01 E9 01 E8 01 F2 01 F5 01")
+        )
+
+        assertThat(decoded).isNotNull()
+        with(decoded!!) {
+            assertThat(leftArm).isWithin(1e-4f).of(49.0f)
+            assertThat(rightArm).isWithin(1e-4f).of(48.9f)
+            assertThat(torso).isWithin(1e-4f).of(48.8f)
+            assertThat(leftLeg).isWithin(1e-4f).of(49.8f)
+            assertThat(rightLeg).isWithin(1e-4f).of(50.1f)
+        }
+    }
+
+    @Test
+    fun `rejects short or unexpected private packets`() {
+        assertThat(BeurerBf1000Lib.parseSegmentalFatMeasurement(ByteArray(11))).isNull()
+        assertThat(BeurerBf1000Lib.parseSegmentalMuscleMeasurement(ByteArray(10))).isNull()
+
+        assertThat(BeurerBf1000Lib.parseSegmentalFatMeasurement(
+            hex("00 32 8E 00 8F 00 63 00 81 00 7C 00")
+        )).isNull()
+        assertThat(BeurerBf1000Lib.parseSegmentalMuscleMeasurement(
+            hex("00 EA 01 E9 01 E8 01 F2 01 F5 01")
+        )).isNull()
+    }
+}


### PR DESCRIPTION
Claim the BF1000 in the standard Beurer/Sanitas handler and keep persisted measurements limited to the existing openScale fields.

Decode the BF1000 private segmental packets for logging/documentation only, with JVM test vectors from captured data.

Guard the BF1000-specific mixed user-list handling behind the BF1000 model path so existing Beurer/Sanitas models keep their previous parser behavior.