### PR TITLE
feat: Add support for Afu B1

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -22,6 +22,7 @@ import androidx.annotation.VisibleForTesting
 import com.health.openscale.core.bluetooth.scales.BeurerBF450Handler
 import com.health.openscale.core.bluetooth.scales.ScaleDeviceHandler
 import com.health.openscale.core.bluetooth.scales.AAAxHandler
+import com.health.openscale.core.bluetooth.scales.AfuB1Handler
 import com.health.openscale.core.bluetooth.scales.FitTrackDaraHandler
 import com.health.openscale.core.bluetooth.scales.ScaleupHandler
 import com.health.openscale.core.bluetooth.scales.ActiveEraBF06Handler
@@ -131,6 +132,7 @@ class ScaleFactory @Inject constructor(
         internal fun createHandlers(): List<ScaleDeviceHandler> = listOf(
             // Exact-name match must precede generic LeFu/0xFFF0 handlers (first match wins).
             ActiveEraBF06Handler(),
+            AfuB1Handler(),
             KeepS3Handler(),
             OmronWlcHandler(),
             BeurerBF450Handler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/AfuB1Lib.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/AfuB1Lib.kt
@@ -1,0 +1,620 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+/**
+ * Wire protocol of the scale AFU-BH-TZ-B1,
+ * reverse-engineered from the official AFU Android app
+ *
+ * Every frame is exactly 20 bytes, in both directions:
+ *
+ *     [0xAF][0x45][sub-cmd @2][body @3..17][wire type @18][crc @19]
+ *
+ * crc = sum(raw[2..18]) & 0x1F — every captured frame validates against it.
+ *
+ * The 18th byte ("wire type") says what the frame IS, the 2nd byte ("sub-command")
+ * disambiguates within that type:
+ *
+ *   wire type 0x54  stored / history record        (scale -> phone)
+ *   wire type 0x51  live weight                    (scale -> phone)
+ *   wire type 0x52  single-impedance result        (scale -> phone)
+ *   wire type 0x5f  control frames                 (both directions):
+ *                     sub-cmd 0x12 = ACK, 0x14 = chunk request/report chunk,
+ *                     0x15 = close report, 0x16 = time-sync
+ *   wire type 0x62  sync-request                   (phone -> scale only)
+ *   wire type 0x61  user profile                   (phone -> scale only)
+ *
+ * A typical session (verified against btsnoop_hci_260817_140338.log timestamps):
+ *
+ *   1. Handshake:  time-sync -> 2x sync-request. The profile must NOT be sent yet —
+ *      sending it early switches the scale into weighing mode and blocks history.
+ *   2. Idle:       with nobody standing on it the scale starts pushing its stored
+ *      measurements (0x54), but on its own it repeats the same record forever, no
+ *      matter how often it is ACKed. A history-dump request (0x8e) switches it
+ *      into export mode: every stored record is sent once, each ACKed before the
+ *      next one arrives (the correlation index echoes the record sequence).
+ *   3. First weigh: live weight streams (0x51) until the weight is marked final
+ *      (state bit) and the phone ACKs. Only after the scale goes idle again
+ *      (user stepped off) does the phone
+ *      re-sync and send profile 0x4b + a chunk request (0x14) to PULL the fresh committed
+ *      record (0x54), followed by 7 report chunks and a closing sub-cmd 0x15 request.
+ *      The report payload is [per-session bytes]["AFU-BH-TZ-B1"+MAC in plaintext][zeros];
+ *      it is not needed — body composition comes from weight + impedance of the 0x54.
+ *   4. Arming:     profile 0x5b tags the NEXT weigh-in for an impedance measurement and
+ *      profile 0x68 closes the session. Both are optional: the scale commits and serves
+ *      every weigh with plain weight + resistance even when no profiles are sent at all.
+ *   5. Second weigh (same connection, armed by 0x5b): once its weight is marked
+ *      final and is ACKed the scale replies with 0x52 (single impedance result)
+ *      instead of a stored record.
+ *      A 0x52 therefore never occurs in a single-weigh session — its absence is normal.
+ *
+ * Profile bodies carry a per-variant "open byte" pair (`af XX` between <user> and
+ * the 0x17 byte), copied from the official captures.
+ *
+ * Timestamps are Unix epoch seconds: LE32 in stored records, `ConvertIntEndian(now)`
+ * bytes big-endian in time-sync/profile frames.
+ */
+object AfuB1Lib {
+
+    const val FRAME_SIZE = 20
+
+    // ---- Wire types (raw[18]) --------------------------------------------------
+
+    const val WIRE_STORED_RECORD = 0x54     // scale -> phone
+    const val WIRE_IMPEDANCE_RESULT = 0x52  // scale -> phone
+    const val WIRE_LIVE_WEIGHT = 0x51       // scale -> phone
+    const val WIRE_CONTROL = 0x5F           // both directions
+    const val WIRE_SYNC_REQUEST = 0x62      // phone -> scale
+    const val WIRE_USER_PROFILE = 0x61      // phone -> scale
+
+    // ---- Sub-commands (raw[2]) -------------------------------------------------
+
+    const val CMD_TIME_SYNC = 0x16
+    const val CMD_SYNC_REQUEST = 0x04
+    const val CMD_ACK = 0x12
+    const val CMD_BODY_COMP_CHUNK = 0x14    // scale: chunk payload / phone: chunk request
+    const val CMD_HISTORY_DUMP = 0x8E       // profile variant: dump the full history queue
+
+    /**
+     * Purpose of a user-profile frame (raw[2] of wire type 0x61). The scale treats each
+     * code differently, so they are an enum, not free ints. [openByte] is the `af XX`
+     * pair in the body, copied from the official captures per variant.
+     */
+    enum class ProfileVariant(val code: Int, val openByte: Int) {
+        /** First contact once live weighing has started. */
+        INITIAL(0x3F, 0xB6),
+
+        /** Re-measure: makes the scale commit the weigh and push the fresh record. */
+        GET_WEIGH_AGAIN_1(0x4B, 0xB6),
+        GET_WEIGH_AGAIN_2(0x5B, 0xD9),
+
+        /** Finalize the session and arm the next weigh. */
+        FINAL(0x68, 0xD9)
+    }
+
+    /** The two sync-requests of the handshake, in captured order. */
+    enum class SyncRequestVariant { FIRST, SECOND }
+
+    // Weight is stored in the low 18 bits of the (endian-swapped) flags word.
+    const val WEIGHT_G_MASK = 0x3FFFF
+
+    // Body-composition table constants.
+    private const val BAND_LOW = 4.0
+    private const val BAND_HIGH = 75.0
+    private const val BMI_SCALE = 10000.0
+    private const val VFAL_DIV = 10000.0
+
+    // --- Endian helpers ----------------------------------------------------
+    // Faithful port of the j3/j3.c byte-swap functions the app uses: values are stored
+    // little-endian but read back byte-swapped.
+
+    /** Byte-reverses a 32-bit word (the app's ConvertIntEndian). */
+    fun convertIntEndian(v: Int): Int =
+        ((v and 0xFF) shl 24) or ((v and 0xFF00) shl 8) or
+                ((v ushr 8) and 0xFF00) or ((v ushr 24) and 0xFF)
+
+    // --- Commands (phone -> scale) -----------------------------------------
+
+    /** af45 16 <time4> 20 00...00 5f <crc> — syncs the scale's clock to the phone's. */
+    fun buildTimeSync(nowEpochSeconds: Long): ByteArray =
+        buildFrame(CMD_TIME_SYNC, WIRE_CONTROL, time4(nowEpochSeconds) + byteArrayOf(0x20) + ByteArray(10))
+
+    /**
+     * af45 04 <body> 62 <crc> — one of the two sync-requests of the handshake.
+     *
+     * Some body bytes (the 0xb6/0xf8/0x11 "open byte", the 0x17 constant, the counter
+     * bytes 0x1d/0x56/0x02/0x04) were captured verbatim from one session of the official
+     * app and may be session-dependent — tweak if the scale rejects pairing.
+     */
+    fun buildSyncRequest(variant: SyncRequestVariant): ByteArray {
+        val body = if (variant == SyncRequestVariant.FIRST) {
+            byteArrayOf(
+                0x00, 0x01, 0xAF.toByte(), 0xB6.toByte(), 0x17, 0x1D, 0x01,
+                0x00, 0x02, 0xB4.toByte(), 0xC6.toByte(), 0x1B, 0x56, 0x01, 0x00
+            )
+        } else {
+            byteArrayOf(
+                0x01, 0x03, 0xA5.toByte(), 0xF8.toByte(), 0x11, 0x1D, 0x02,
+                0x00, 0x04, 0xB4.toByte(), 0xC6.toByte(), 0x1B, 0x1D, 0x01, 0x00
+            )
+        }
+        return buildFrame(CMD_SYNC_REQUEST, WIRE_SYNC_REQUEST, body)
+    }
+
+    /**
+     * af45 <variant> <time4> 00 <user> af b6 17 <age> <sex> <tgt*100 LE> 03 00 61 <crc>.
+     * Sends the user's age/sex/target weight to the scale. [variant] picks the purpose
+     * (see [ProfileVariant]). [sex] 1 = male, 0 = female.
+     */
+    fun buildUserProfile(
+        variant: ProfileVariant,
+        nowEpochSeconds: Long,
+        user: Int,
+        age: Int,
+        sex: Int,
+        targetKg: Float
+    ): ByteArray {
+        val targetX100 = Math.round(targetKg * 100f) and 0xFFFF
+        val body = time4(nowEpochSeconds) + byteArrayOf(
+            0x00, (user and 0xFF).toByte(),
+            0xAF.toByte(), variant.openByte.toByte(), 0x17,
+            (age and 0xFF).toByte(), (sex and 0xFF).toByte(),
+            (targetX100 and 0xFF).toByte(), ((targetX100 ushr 8) and 0xFF).toByte(),
+            0x03, 0x00
+        )
+        return buildFrame(variant.code, WIRE_USER_PROFILE, body)
+    }
+
+    /**
+     * af45 8e <time4> 00 <user> af de 17 <age> <sex> <tgt*100 LE> 03 00 61 <crc>.
+     * Tells the scale to export its ENTIRE history queue. Without this request the
+     * scale just repeats the same stored record forever.
+     */
+    fun buildHistoryDumpRequest(
+        nowEpochSeconds: Long,
+        user: Int,
+        age: Int,
+        sex: Int,
+        targetKg: Float
+    ): ByteArray {
+        val targetX100 = Math.round(targetKg * 100f) and 0xFFFF
+        val body = time4(nowEpochSeconds) + byteArrayOf(
+            0x00, (user and 0xFF).toByte(),
+            0xAF.toByte(), 0xDE.toByte(), 0x17,
+            (age and 0xFF).toByte(), (sex and 0xFF).toByte(),
+            (targetX100 and 0xFF).toByte(), ((targetX100 ushr 8) and 0xFF).toByte(),
+            0x03, 0x00
+        )
+        return buildFrame(CMD_HISTORY_DUMP, WIRE_USER_PROFILE, body)
+    }
+
+    /**
+     * af45 12 <reply_wire_type> 00 <correlation> 00...00 5f <crc>.
+     * Acknowledges a received frame. `replyWireType` is the wire type of the frame being
+     * acknowledged (0x54/0x51/0x52, or 0x14 for body-comp chunks) and `correlationIndex`
+     * the record sequence for history records (0 otherwise).
+     */
+    fun buildAck(replyWireType: Int, correlationIndex: Int): ByteArray =
+        buildFrame(
+            CMD_ACK, WIRE_CONTROL,
+            byteArrayOf((replyWireType and 0xFF).toByte(), 0x00, (correlationIndex and 0xFF).toByte()) + ByteArray(12)
+        )
+
+    /** Asks the scale to stream the (encrypted, undecodable) report chunks of the last weigh. */
+    fun buildChunkRequest(): ByteArray = buildFrame(CMD_BODY_COMP_CHUNK, WIRE_CONTROL, ByteArray(15))
+
+    // --- Incoming frames (scale -> phone) ----------------------------------
+
+    sealed class ScaleFrame {
+        /** The wire type byte (raw[18]) this frame arrived as. */
+        abstract val wireType: Int
+
+        /** What an ACK for this frame must echo (its wire type, 0x14 for chunks). */
+        abstract val ackReplyByte: Int
+
+        /** Stored / history record (wire type 0x54). */
+        data class StoredRecord(
+            val historyType: Int,
+            val sequence: Int,
+            val timestampEpochSeconds: Long,
+            val weightGrams: Int,
+            val hasElectrode: Boolean,
+            val hasHeartRate: Boolean,
+            val hasPhaseAngle: Boolean,
+            val hasZx: Boolean,          // vendor flag, purpose unknown
+            val hasTemperature: Boolean,
+            val locked: Boolean,         // scale considers this weight final
+            val resistanceOhms: Int
+        ) : ScaleFrame() {
+            override val wireType = WIRE_STORED_RECORD
+            override val ackReplyByte = WIRE_STORED_RECORD
+        }
+
+        /** Live weight while someone stands on the scale (wire type 0x51). */
+        data class LiveWeight(
+            val weightGrams: Int,
+            val mode: Int,               // 0x02 = live-weight subtype
+            val locked: Boolean          // scale signals the weight is final
+        ) : ScaleFrame() {
+            override val wireType = WIRE_LIVE_WEIGHT
+            override val ackReplyByte = WIRE_LIVE_WEIGHT
+        }
+
+        /** Single-impedance measurement result (wire type 0x52). */
+        data class ImpedanceResult(
+            val valid: Boolean,          // sub-cmd 0x01 marks a valid result
+            val adcOhms: Int             // resistance in Ohm
+        ) : ScaleFrame() {
+            override val wireType = WIRE_IMPEDANCE_RESULT
+            override val ackReplyByte = WIRE_IMPEDANCE_RESULT
+        }
+
+        /** One 14-byte chunk of the scale's encrypted report (0x5f/0x14). Purpose unknown. */
+        data class BodyCompChunk(
+            val chunkIndex: Int,
+            val payload: ByteArray
+        ) : ScaleFrame() {
+            override val wireType = WIRE_CONTROL
+            override val ackReplyByte = CMD_BODY_COMP_CHUNK
+        }
+
+        /** Inbound acknowledgment (0x5f/0x12). */
+        data class Acknowledgement(
+            val replyCmd: Int,
+            val replyOp: Int
+        ) : ScaleFrame() {
+            override val wireType = WIRE_CONTROL
+            override val ackReplyByte = 0 // ACKs are not acknowledged
+        }
+
+        /** Other control frame, e.g. an echoed time-sync (0x5f). */
+        data class ControlFrame(val cmd: Int) : ScaleFrame() {
+            override val wireType = WIRE_CONTROL
+            override val ackReplyByte = 0
+        }
+    }
+
+    /**
+     * Decode one 20-byte frame. Returns null for anything that is not a valid AFU frame
+     * (wrong length, wrong header, bad CRC, or a phone->scale frame the scale never sends).
+     */
+    fun parse(raw: ByteArray): ScaleFrame? {
+        if (raw.size != FRAME_SIZE ||
+            (raw[0].toInt() and 0xFF) != 0xAF ||
+            (raw[1].toInt() and 0xFF) != 0x45
+        ) return null
+        if (!crcValid(raw)) return null
+
+        val cmd = raw[2].toInt() and 0xFF
+        return when (raw[18].toInt() and 0xFF) {
+            WIRE_STORED_RECORD -> parseStoredRecord(cmd, raw)
+            WIRE_IMPEDANCE_RESULT -> parseImpedanceResult(cmd, raw)
+            WIRE_LIVE_WEIGHT -> parseLiveWeight(raw)
+            WIRE_CONTROL -> when (cmd) {
+                CMD_BODY_COMP_CHUNK -> ScaleFrame.BodyCompChunk(
+                    chunkIndex = raw[3].toInt() and 0xFF,
+                    payload = raw.copyOfRange(4, 18)
+                )
+
+                CMD_ACK -> ScaleFrame.Acknowledgement(
+                    replyCmd = raw[3].toInt() and 0xFF,
+                    replyOp = raw[4].toInt() and 0xFF
+                )
+
+                else -> ScaleFrame.ControlFrame(cmd)
+            }
+
+            WIRE_SYNC_REQUEST, WIRE_USER_PROFILE -> null // phone -> scale only
+            else -> null
+        }
+    }
+
+    private fun parseStoredRecord(cmd: Int, raw: ByteArray): ScaleFrame.StoredRecord {
+        // j3.e() case 84: first byte = history_type(bits 0-1) + sequence(bits 2-7)
+        val timestamp = (raw[3].toLong() and 0xFF) or ((raw[4].toLong() and 0xFF) shl 8) or
+                ((raw[5].toLong() and 0xFF) shl 16) or ((raw[6].toLong() and 0xFF) shl 24)
+        val weightFlags = convertIntEndian(be32(raw, 7))
+        return ScaleFrame.StoredRecord(
+            historyType = cmd and 0x03,
+            sequence = (cmd ushr 2) and 0x3F,
+            timestampEpochSeconds = timestamp,
+            weightGrams = weightFlags and WEIGHT_G_MASK,
+            hasElectrode = weightFlags.bit(24),
+            hasHeartRate = weightFlags.bit(25),
+            hasPhaseAngle = weightFlags.bit(26),
+            hasZx = weightFlags.bit(27),
+            hasTemperature = weightFlags.bit(28),
+            locked = weightFlags.bit(31),
+            // resistance always present in 0x54 frames, LE16 at raw[13..14]
+            resistanceOhms = le16(raw, 13)
+        )
+    }
+
+    private fun parseLiveWeight(raw: ByteArray): ScaleFrame.LiveWeight {
+        val weightFlags = convertIntEndian(be32(raw, 2))
+        return ScaleFrame.LiveWeight(
+            weightGrams = weightFlags and WEIGHT_G_MASK,
+            mode = raw[6].toInt() and 0xFF,
+            locked = weightFlags.bit(31)
+        )
+    }
+
+    private fun parseImpedanceResult(cmd: Int, raw: ByteArray): ScaleFrame.ImpedanceResult =
+        ScaleFrame.ImpedanceResult(
+            valid = cmd == 0x01,
+            adcOhms = le16(raw, 4)
+        )
+
+    // ----------------------------------------------------------------------------
+    // Body composition from weight + impedance. The arithmetic deliberately mixes
+    // single/double precision: every .toFloat() boundary below is load-bearing.
+    // ----------------------------------------------------------------------------
+
+    /**
+     * Body-fat percentage. Sex-aware (1 = male, 0 = female); impedance 0 -> null.
+     * Clamped to [5, 80] and rounded half-even to one decimal.
+     */
+    fun bodyFatPercent(
+        weightKg: Double,
+        heightCm: Double,
+        age: Int,
+        sex: Int,
+        impedanceOhm: Double,
+    ): Float? {
+        if (impedanceOhm == 0.0) return null
+        val h = (heightCm / 100.0).toFloat()
+        val hd = h.toDouble()
+        val h2 = hd * hd
+        var r: Double
+        if (sex == 1) {
+            val h2f = (h * (h * -486583.0f)).toDouble()
+            r = 1625303.0 / impedanceOhm / impedanceOhm
+            r += 9.146 * weightKg / h2 / impedanceOhm
+            r += h2f / weightKg / impedanceOhm + 61.8
+            r += -251.193 * h2 / weightKg / age
+            r += impedanceOhm * -0.0139
+            r += age * 0.05975
+        } else {
+            val h2f = (h * (h * -382280.0f)).toDouble()
+            r = -186.422 * h2 / weightKg + 58.82
+            r += h2f / weightKg / impedanceOhm
+            r += 128.005 * weightKg / hd / impedanceOhm
+            r += -0.0728 * weightKg / hd
+            r += 7816.359 / hd / impedanceOhm
+            r += -3.333 * weightKg / h2 / age
+        }
+        val clamped = r.toFloat().coerceIn(5f, 80f)
+        return (Math.rint(clamped * 10.0) / 10.0).toFloat()
+    }
+
+    /** The composition fields openScale publishes for one measurement. */
+    data class BodyComposition(
+        val waterPercent: Double,
+        val skeletalMusclePercent: Double,
+        val boneMassKg: Float,
+        val visceralFatIndex: Int,
+        val proteinPercent: Double,
+        val fatFreeMassKg: Float,
+    )
+
+    /**
+     * Derives water %, skeletal muscle %, bone mass, the visceral fat index,
+     * protein % and fat-free mass from weight and [bodyFatPercent]. Returns null
+     * outside the validated input ranges.
+     */
+    fun bodyComposition(
+        sex: Int,
+        age: Int,
+        heightCm: Float,
+        weightKg: Float,
+        bodyFatPercent: Float,
+    ): BodyComposition? {
+        if (sex > 1 || age !in 10..99) return null
+        if (heightCm < 90f || heightCm > 240f || weightKg < 10f || weightKg > 200f) return null
+
+        val bf = bodyFatPercent.toDouble()
+        val w = weightKg.toDouble()
+        val h = heightCm.toDouble()
+
+        // _classify: fat % bands below 4 / above 75 swap fixed values in; degenerate
+        // f64 edge windows are rejected outright by the reference implementation.
+        if ((bf <= BAND_LOW && bf <= 3.999) || (bf >= BAND_HIGH && (bf <= 74.999 || bf > 75.001))) {
+            return null
+        }
+        val bandLow = bf <= BAND_LOW
+        val bandHigh = bf >= BAND_HIGH
+
+        val bmi = (w * BMI_SCALE / (heightCm * heightCm).toDouble()).toFloat()
+
+        // _recompute_bf: back-solve the internal fat rate from BMI + measured fat %.
+        val recomputedBf: Float = run {
+            val num: Double
+            val denom: Double
+            if (sex == 0) {
+                if (age <= 15) {
+                    num = ((-556421.0 / bmi).toFloat() + 17387.0).toFloat().toDouble()
+                    denom = bf - 44.19
+                } else {
+                    num = ((-518695.0 / bmi).toFloat() + 15802.0).toFloat().toDouble()
+                    denom = bf - 42.86 + age * -0.057
+                }
+            } else {
+                if (age <= 15) {
+                    num = ((-506791.0 / bmi).toFloat() + 12009.0).toFloat().toDouble()
+                    denom = bf - 63.25 + age * 1.121
+                } else {
+                    num = ((-460857.0 / bmi).toFloat() + 10645.0).toFloat().toDouble()
+                    denom = bf - 37.74 + age * -0.0511
+                }
+            }
+            (num / denom).toFloat()
+        }
+
+        // _body_rate (c0), with band replacements.
+        val c0: Float = when {
+            bandLow -> (if (sex == 0) 66.5 else 66.0).toFloat()
+            bandHigh -> (if (sex == 0) 18.0 else 15.0).toFloat()
+            sex == 0 -> {
+                var s2 = (3752.4 * heightCm).toFloat(); s2 *= heightCm
+                var s3 = (444.93 + (556707.0 / recomputedBf).toFloat()).toFloat()
+                s2 /= recomputedBf
+                s3 /= weightKg
+                s2 = (s2 / 10000.0).toFloat()
+                val sa = (10276.0 / recomputedBf).toFloat()
+                s2 = s3 + s2
+                (24.305 + (s2 - sa)).toFloat()
+            }
+            else -> {
+                var s2 = (3705.3 * heightCm).toFloat(); s2 *= heightCm
+                var s3 = (299.43 + (696819.0 / recomputedBf).toFloat()).toFloat()
+                s2 /= recomputedBf
+                s3 /= weightKg
+                s2 = (s2 / 10000.0).toFloat()
+                val sa = (10770.0 / recomputedBf).toFloat()
+                s2 = s3 + s2
+                (29.61 + (s2 - sa)).toFloat()
+            }
+        }
+        val c4 = (c0.toDouble() * w / 100.0).toFloat()
+
+        // Bone mass.
+        val boneMassKg: Float = if (bandLow || bandHigh) {
+            val fac = if (bandLow) (if (sex == 0) 5.8 else 5.0) else (if (sex == 0) 1.6 else 1.3)
+            ((w * fac).toFloat() / 100.0).toFloat()
+        } else {
+            val fac = if (sex == 0) 0.061 else 0.052
+            val p1 = (w * fac).toFloat()
+            val p2 = (100.0 - bf).toFloat()
+            (p1.toDouble() * p2.toDouble() / 100.0).toFloat()
+        }
+
+        // Skeletal muscle rate (s1) and total muscle rate (s4).
+        val s1: Float
+        val s4: Float
+        if (bandLow) {
+            s1 = (if (sex == 0) 56.6 else 59.0).toFloat()
+            s4 = (if (sex == 0) 90.2 else 91.0).toFloat()
+        } else if (bandHigh) {
+            s1 = (if (sex == 0) 15.1 else 17.9).toFloat()
+            s4 = (if (sex == 0) 23.4 else 23.7).toFloat()
+        } else {
+            s1 = if (sex == 0) c0 * 0.857f - 0.36f else c0 * 0.895f
+            val mf = if (sex == 0) 0.939f else 0.948f
+            s4 = mf * (100f - bf.toFloat())
+        }
+        val skeletalMusclePercent = ((s1 * w).toFloat() / 100.0).toFloat() * 100.0 / w
+
+        // Protein rate feeds the water derivation.
+        val muscleKg = ((s4 * w).toFloat() / 100.0).toFloat()
+        val proteinRate = ((muscleKg - c4) * 100.0 / w).toFloat()
+
+        // Visceral fat index (VFAL).
+        val vfal: Int = when {
+            bandLow -> 1
+            bandHigh -> 30
+            sex == 1 -> {
+                val bf64 = recomputedBf.toDouble()
+                var acc = 77.216 / bf64 + 0.068
+                acc *= w
+                val d17 = acc + 0.5
+                var d5 = (-5489.0 / recomputedBf).toFloat().toDouble() + 2.8
+                d5 *= h; d5 *= h
+                var d6 = d17 + d5 / VFAL_DIV
+                d6 += 6096.3 / bf64
+                val raw = (-1.22 + (d6 + 0.1668 * age)).toInt()
+                if (raw <= 0) 1 else if (raw > 30) 30 else raw
+            }
+            else -> {
+                val bf64 = recomputedBf.toDouble()
+                var acc = 71.92 / bf64 + 0.0876
+                acc *= w
+                val d17 = acc + 0.5
+                var d5 = (-1261.7 / bf64).toFloat().toDouble() - 2.88
+                d5 *= h; d5 *= h
+                var d6 = d17 + d5 / VFAL_DIV
+                d6 += -1545.6 / bf64
+                val raw = (5.9 + (d6 + 0.068 * age)).toInt()
+                if (raw <= 0) 1 else if (raw > 30) 30 else raw
+            }
+        }
+
+        val bonePct = boneMassKg * 100.0 / w
+
+        // Fat-free mass: w + w*bf/(-100).
+        val fatMassKg = (w * bf).toFloat()
+        val fatFreeMassKg = (w + (fatMassKg / -100.0).toFloat()).toFloat()
+
+        return BodyComposition(
+            waterPercent = 100.0 - bf - bonePct - proteinRate,
+            skeletalMusclePercent = skeletalMusclePercent,
+            boneMassKg = boneMassKg,
+            visceralFatIndex = vfal,
+            proteinPercent = proteinRate.toDouble(),
+            fatFreeMassKg = fatFreeMassKg,
+        )
+    }
+
+
+    // --- Helpers -----------------------------------------------------------
+
+    /** Build a frame: AF 45 [sub-cmd@2][body@3..17][wire type@18][crc@19]. */
+    private fun buildFrame(cmd: Int, wireType: Int, body: ByteArray): ByteArray {
+        require(body.size == 15) { "AFU frame body must be 15 bytes, got ${body.size}" }
+        val b = ByteArray(FRAME_SIZE)
+        b[0] = 0xAF.toByte()
+        b[1] = 0x45.toByte()
+        b[2] = (cmd and 0xFF).toByte()
+        body.copyInto(b, 3)
+        b[18] = (wireType and 0xFF).toByte()
+        b[19] = crc(b).toByte()
+        return b
+    }
+
+    /** Timestamp slot: ConvertIntEndian(now) stored as raw big-endian bytes. */
+    private fun time4(nowEpochSeconds: Long): ByteArray {
+        val v = convertIntEndian((nowEpochSeconds and 0xFFFFFFFFL).toInt())
+        return byteArrayOf(
+            ((v ushr 24) and 0xFF).toByte(),
+            ((v ushr 16) and 0xFF).toByte(),
+            ((v ushr 8) and 0xFF).toByte(),
+            (v and 0xFF).toByte()
+        )
+    }
+
+    /** Checksum over raw[2..18]: byte sum, transmitted in the lower 5 bits. */
+    private fun crc(raw: ByteArray): Int {
+        var sum = 0
+        for (i in 2 until 19) sum += raw[i].toInt() and 0xFF
+        return sum and 0x1F
+    }
+
+    private fun crcValid(raw: ByteArray): Boolean =
+        crc(raw) == (raw[19].toInt() and 0x1F)
+
+    /** Little-endian 16-bit word at [off]. */
+    private fun le16(raw: ByteArray, off: Int): Int =
+        (raw[off].toInt() and 0xFF) or ((raw[off + 1].toInt() and 0xFF) shl 8)
+
+    /** True if bit [n] of the flags word is set. */
+    private fun Int.bit(n: Int): Boolean = ((this ushr n) and 1) == 1
+
+    /** Big-endian 32-bit word at [start]. */
+    private fun be32(raw: ByteArray, start: Int): Int =
+        ((raw[start].toInt() and 0xFF) shl 24) or ((raw[start + 1].toInt() and 0xFF) shl 16) or
+                ((raw[start + 2].toInt() and 0xFF) shl 8) or (raw[start + 3].toInt() and 0xFF)
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/AfuB1Handler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/AfuB1Handler.kt
@@ -1,0 +1,551 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.BluetoothGattCharacteristic
+import com.health.openscale.R
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.AfuB1Lib
+import com.health.openscale.core.bluetooth.libs.AfuB1Lib.ScaleFrame
+import com.health.openscale.core.data.GenderType
+import com.health.openscale.core.service.ScannedDeviceInfo
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+import kotlin.math.abs
+import kotlin.time.Duration.Companion.milliseconds
+
+class AfuB1Handler : ScaleDeviceHandler() {
+
+    companion object {
+        // Service advertised by the scale (and the GATT service carrying the vendor data channel).
+        val SERVICE_UUID = UUID.fromString("0000fc50-0000-1000-8000-00805f9b34fb")
+
+        // The frame write channel of the AFU app (service af000000-9f2d-4c8a-8d6f-6a7b45f90000).
+        val WRITE_SERVICE = UUID.fromString("af000000-9f2d-4c8a-8d6f-6a7b45f90000")
+        val WRITE_CHARACTERISTIC = UUID.fromString("af000002-9f2d-4c8a-8d6f-6a7b45f90000")
+
+        // The app always talks to scale user slot 1.
+        private const val SCALE_USER_SLOT = 1
+
+        // Timing of the commit flow after the weight is marked final:
+        // IDLE_DELAY_MS  — scale is considered idle (user stepped off) after this long
+        //                  without a single frame; only then may the weigh be committed.
+        // IDLE_POLL_MS   — how often the commit coroutine re-checks the idle condition.
+        // COMMIT_TIMEOUT — give the scale this long to push the fresh record after the
+        //                  re-sync + getWeighAgain, then fall back to the live weight.
+        private const val IDLE_DELAY_MS = 2_000L
+        private const val IDLE_POLL_MS = 250L
+        private const val COMMIT_TIMEOUT_MS = 15_000L
+
+        // Match tolerances of a "fresh committed" record — full rule on isFreshCommitted().
+        private const val FRESH_RECORD_WINDOW_S = 600L
+        private const val FRESH_WEIGHT_TOLERANCE_G = 1_000
+    }
+
+    // ---- User profile cached from the app ---------------------------------------
+
+    private var age = 30
+    private var sex = 1          // 1 = male, 0 = female (AFU convention)
+    private var targetKg = 60.0f
+
+    // ---- Session state ------------------------------------------------------------
+    // Cross-thread state (GATT callback vs commit coroutine), hence @Volatile.
+
+    @Volatile
+    private var handshakeComplete = false
+
+    @Volatile
+    private var liveWeighInProgress = false
+
+    @Volatile
+    private var profileSent = false
+
+    @Volatile
+    private var historyDumpRequested = false
+
+    @Volatile
+    private var weightIsFinal = false
+
+    @Volatile
+    private var commitInProgress = false
+
+    @Volatile
+    private var committedRecordSeen = false
+
+    @Volatile
+    private var lastLiveWeightG: Int? = null
+
+    @Volatile
+    private var lastFrameAt = 0L
+
+    @Volatile
+    private var weighStartedAt = 0L
+    private var commitJob: Job? = null
+
+    // --- Device discovery --------------------------------------------------
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        val name = device.name.uppercase()
+        val hasService = device.serviceUuids.contains(SERVICE_UUID)
+        val nameMatches = name.contains("AFU")
+        if (!hasService || !nameMatches) return null
+
+        val caps = setOf(
+            DeviceCapability.BODY_COMPOSITION,
+            DeviceCapability.HISTORY_READ,
+            DeviceCapability.LIVE_WEIGHT_STREAM,
+            DeviceCapability.TIME_SYNC,
+            DeviceCapability.USER_SYNC
+        )
+        return DeviceSupport(
+            displayName = "AFU-BH-TZ-B1",
+            capabilities = caps,
+            implemented = caps,
+            linkMode = LinkMode.CONNECT_GATT
+        )
+    }
+
+    // --- Connection --------------------------------------------------------
+
+    override fun onConnected(user: ScaleUser) {
+        resetSession()
+
+        age = user.age
+        sex = if (user.gender == GenderType.MALE) 1 else 0
+        targetKg = when {
+            user.goalWeight > 0f -> user.goalWeight
+            user.initialWeight > 0f -> user.initialWeight
+            else -> 60.0f
+        }
+
+        subscribeToAllCharacteristics()
+        lastFrameAt = System.currentTimeMillis()
+        sendHandshake()
+        // Drain the stored history right away; if the scale ignores an early 0x8e,
+        // onStoredRecord re-sends it once the first record arrives.
+        sendHistoryDumpRequest()
+        logI("history-dump request (0x8e) sent right after handshake")
+        userInfo(R.string.bt_info_step_on_scale)
+    }
+
+    override fun onDisconnected() {
+        commitJob?.cancel()
+        commitJob = null
+    }
+
+    /** Forget everything from a previous connection — the handler instance is shared. */
+    private fun resetSession() {
+        commitJob?.cancel()
+        commitJob = null
+        handshakeComplete = false
+        liveWeighInProgress = false
+        profileSent = false
+        historyDumpRequested = false
+        weightIsFinal = false
+        commitInProgress = false
+        committedRecordSeen = false
+        lastLiveWeightG = null
+        lastFrameAt = 0L
+        weighStartedAt = 0L
+    }
+
+    /** Subscribe to every notify/indicate characteristic (the scale reports on one of them). */
+    private fun subscribeToAllCharacteristics() {
+        val peripheral = getPeripheral() ?: return
+        for (service in peripheral.services) {
+            for (char in service.characteristics ?: continue) {
+                if ((char.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) != 0 ||
+                    (char.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0
+                ) {
+                    setNotifyOn(service.uuid, char.uuid)
+                }
+            }
+        }
+    }
+
+    // --- Commands (phone -> scale) -----------------------------------------
+
+    /** The service actually hosting the write characteristic, resolved from the GATT tree. */
+    private fun writeService(): UUID {
+        val peripheral = getPeripheral()
+        if (peripheral != null) {
+            for (service in peripheral.services) {
+                if (service.characteristics?.any { it.uuid == WRITE_CHARACTERISTIC } == true) {
+                    return service.uuid
+                }
+            }
+            logW("write characteristic not found in GATT tree, using default service")
+        }
+        return WRITE_SERVICE
+    }
+
+    /** Handshake: time-sync + 2x sync-request. No profile — a profile 0x3f sent too
+     *  early switches the scale into weighing mode and blocks the stored-history dump. */
+    private fun sendHandshake() {
+        sendTimeSync()
+        sendSyncRequestPair()
+        handshakeComplete = true
+        logI("handshake sent (time-sync + 2x sync-request)")
+    }
+
+    private fun sendTimeSync() {
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC,
+            AfuB1Lib.buildTimeSync(System.currentTimeMillis() / 1000L)
+        )
+    }
+
+    private fun sendSyncRequestPair() {
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC,
+            AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.FIRST)
+        )
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC,
+            AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.SECOND)
+        )
+    }
+
+    /** The user profile (age/sex/target weight) with one of the profile variants. */
+    private fun sendUserProfile(variant: AfuB1Lib.ProfileVariant) {
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC, AfuB1Lib.buildUserProfile(
+                variant = variant,
+                nowEpochSeconds = System.currentTimeMillis() / 1000L,
+                user = SCALE_USER_SLOT,
+                age = age,
+                sex = sex,
+                targetKg = targetKg
+            )
+        )
+    }
+
+    /** Tells the scale to dump its full history queue. */
+    private fun sendHistoryDumpRequest() {
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC, AfuB1Lib.buildHistoryDumpRequest(
+                nowEpochSeconds = System.currentTimeMillis() / 1000L,
+                user = SCALE_USER_SLOT,
+                age = age,
+                sex = sex,
+                targetKg = targetKg
+            )
+        )
+    }
+
+    /** Acknowledge a received frame; history records carry their sequence as correlation. */
+    private fun sendAck(frame: ScaleFrame) {
+        val correlation = (frame as? ScaleFrame.StoredRecord)?.sequence ?: 0
+        writeTo(
+            writeService(), WRITE_CHARACTERISTIC,
+            AfuB1Lib.buildAck(frame.ackReplyByte, correlation)
+        )
+    }
+
+    /** GetWeighAgain profiles (0x4b/0x5b) + chunk request — pulls the fresh committed weigh. */
+    private fun sendGetWeighAgain() {
+        sendUserProfile(AfuB1Lib.ProfileVariant.GET_WEIGH_AGAIN_1)
+        sendUserProfile(AfuB1Lib.ProfileVariant.GET_WEIGH_AGAIN_2)
+        writeTo(writeService(), WRITE_CHARACTERISTIC, AfuB1Lib.buildChunkRequest())
+    }
+
+    /** Finalize a weigh and arm the scale for the next one (mirrors the app's ending). */
+    private fun sendFinalize() {
+        sendUserProfile(AfuB1Lib.ProfileVariant.FINAL)
+        sendTimeSync()
+        sendSyncRequestPair()
+    }
+
+    // --- Incoming frames (scale -> phone) ----------------------------------
+
+    override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) {
+        lastFrameAt = System.currentTimeMillis()
+        val frame = AfuB1Lib.parse(data)
+        if (frame == null) {
+            logD("not an AFU frame (len=${data.size}) ${data.toHexPreview(20)}")
+            return
+        }
+        when (frame) {
+            is ScaleFrame.StoredRecord -> onStoredRecord(frame, user)
+            is ScaleFrame.LiveWeight -> onLiveWeight(frame)
+            is ScaleFrame.ImpedanceResult -> onImpedanceResult(frame)
+            is ScaleFrame.BodyCompChunk -> onBodyCompChunk(frame)
+            is ScaleFrame.Acknowledgement ->
+                logD("RX ACK reply_cmd=0x${frame.replyCmd.toString(16)} op=0x${frame.replyOp.toString(16)}")
+
+            is ScaleFrame.ControlFrame ->
+                logD("RX control cmd=0x${frame.cmd.toString(16)}")
+        }
+    }
+
+    /**
+     * A stored record (0x54). On its own the scale repeats the same stored record
+     * forever, so the first idle record triggers a history-dump request (0x8e)
+     * that switches it to export mode; in export mode every record must be ACKed
+     * before the next one arrives. After a weigh commit, the pushed record is the
+     * fresh measurement.
+     */
+    private fun onStoredRecord(record: ScaleFrame.StoredRecord, user: ScaleUser) {
+        logStoredRecord(record)
+        sendAck(record)
+
+        // Idle: answer the first record with a history-dump request to drain the FULL
+        // queue. During a live weigh the scale ignores it, so gate it on no live frames.
+        if (!liveWeighInProgress && !historyDumpRequested) {
+            historyDumpRequested = true
+            sendHistoryDumpRequest()
+            logI("idle: history-dump request (0x8e) sent to drain the full queue")
+        }
+
+        publishMeasurement(
+            user = user,
+            weightKg = record.weightGrams / 1000.0f,
+            impedanceOhms = record.resistanceOhms.toFloat(),
+            timestamp = record.timestampEpochSeconds
+        )
+
+        if (isFreshCommitted(record) && !committedRecordSeen) {
+            committedRecordSeen = true
+            commitJob?.cancel()
+            logI("committed weigh received — draining any remaining history")
+            startPostWeighDrain()
+        } else {
+            logI("stored history imported (not the fresh weigh) — continuing session")
+        }
+    }
+
+    /** Live weight streaming (0x51) while someone stands on the scale. */
+    private fun onLiveWeight(weight: ScaleFrame.LiveWeight) {
+        liveWeighInProgress = true
+        if (weighStartedAt == 0L) weighStartedAt = System.currentTimeMillis()
+        lastLiveWeightG = weight.weightGrams
+        logI(
+            "RX 0x51 live ${weight.weightGrams / 1000.0f}kg mode=${weight.mode} " +
+                    "state=${if (weight.locked) 1 else 0}"
+        )
+
+        // Live weighing has started: now (and only now) send the user profile.
+        if (!profileSent && handshakeComplete) {
+            profileSent = true
+            sendUserProfile(AfuB1Lib.ProfileVariant.INITIAL)
+            logI("live: user profile (0x3f) sent")
+        }
+
+        // The scale signals the weight is final — ACK and start the commit flow.
+        if (weight.locked && !weightIsFinal && handshakeComplete) {
+            weightIsFinal = true
+            sendAck(weight)
+            logI("state=1 final, ACKed 0x51 — commit fires once the scale goes idle")
+            startCommitFlow()
+        }
+    }
+
+    /**
+     * Single-impedance result (0x52). The scale only sends it after a second weigh-in
+     * armed by profile 0x5b, which openScale does not do — so this is normally never
+     * reached; every stored record already carries its resistance.
+     */
+    private fun onImpedanceResult(result: ScaleFrame.ImpedanceResult) {
+        logI("RX 0x52 RESULT adc=${result.adcOhms} (impedance, valid=${result.valid})")
+        sendAck(result)
+
+        // After it the app sends the final profile + a re-sync to arm the next weigh.
+        // If the fresh record was already received, the post-weigh drain is in charge
+        // of ending the session. If not (abnormal ordering), arm the scale and let the
+        // commit flow's timeout fall back to the stable live weight.
+        if (handshakeComplete && commitInProgress && !committedRecordSeen) {
+            logI("weigh complete — sending finalize to arm the next weigh")
+            sendFinalize()
+        }
+    }
+
+    /**
+     * One 14-byte chunk of the scale's encrypted report (0x5f/0x14). Purpose unknown and
+     * the payload is undecodable — body composition comes from weight + impedance, so the
+     * data is discarded. The ACK still matters: un-ACKed frames get re-served by the
+     * scale, so acknowledging keeps the flow moving towards the impedance frames.
+     */
+    private fun onBodyCompChunk(chunk: ScaleFrame.BodyCompChunk) {
+        logI("RX 0x14 chunk ${chunk.chunkIndex} (encrypted report, discarded)")
+        sendAck(chunk)
+    }
+
+    // --- Commit flow -------------------------------------------------------
+
+    /**
+     * After the weight is marked final the user must step off and the scale go idle. Only then can
+     * the fresh committed record be pulled (re-sync + getWeighAgain). Waiting for the
+     * scale to go quiet (rather than a fixed delay after the weight is marked final)
+     * matters: the scale keeps
+     * streaming 0x51 while someone stands on it, and a commit sent mid-weigh is ignored —
+     * afterwards the scale replays its stored history instead of the fresh weight.
+     */
+    private fun startCommitFlow() {
+        commitJob = scope.launch {
+            while (!scaleIsIdle()) {
+                if (committedRecordSeen) return@launch
+                delay(IDLE_POLL_MS.milliseconds)
+            }
+
+            if (!commitInProgress) {
+                commitInProgress = true
+                logI("scale idle — re-sync + getWeighAgain to pull the fresh record")
+                sendTimeSync()
+                sendSyncRequestPair()
+                sendGetWeighAgain()
+            }
+
+            // Phase 2: give the scale time to push the fresh record + impedance.
+            val deadline = System.currentTimeMillis() + COMMIT_TIMEOUT_MS
+            while (!committedRecordSeen && System.currentTimeMillis() < deadline) {
+                delay(IDLE_POLL_MS.milliseconds)
+            }
+
+            val stableWeightG = lastLiveWeightG
+            if (!committedRecordSeen && stableWeightG != null) {
+                committedRecordSeen = true
+                logW("commit timeout — publishing stable live weight")
+                publishMeasurement(
+                    user = currentAppUser(),
+                    weightKg = stableWeightG / 1000.0f,
+                    impedanceOhms = null,
+                    timestamp = null
+                )
+                requestDisconnect()
+            }
+        }
+    }
+
+    /** True once the scale has been silent for [IDLE_DELAY_MS] — the user is off it. */
+    private fun scaleIsIdle(): Boolean =
+        System.currentTimeMillis() - lastFrameAt > IDLE_DELAY_MS
+
+    /**
+     * After the fresh weigh record: re-sync + 0x8e once more and wait until the queue
+     * goes quiet, so any history the scale still holds is imported before disconnecting.
+     * The scale only serves stored records while idle, and it re-serves the oldest
+     * un-ACKed record until ACKed — draining to silence means everything is read.
+     */
+    private fun startPostWeighDrain() {
+        commitJob = scope.launch {
+            logI("post-weigh drain: re-sync + 0x8e to catch remaining history")
+            sendTimeSync()
+            sendSyncRequestPair()
+            sendHistoryDumpRequest()
+            val deadline = System.currentTimeMillis() + COMMIT_TIMEOUT_MS
+            while (!scaleIsIdle() && System.currentTimeMillis() < deadline) {
+                delay(IDLE_POLL_MS.milliseconds)
+            }
+            requestDisconnect()
+        }
+    }
+
+    /**
+     * A stored record is the fresh committed weigh only if it was recorded during this
+     * weigh (timestamp near now, after the weigh started) and matches the final weight.
+     * Everything else is old stored history and must not finish the session.
+     */
+    private fun isFreshCommitted(record: ScaleFrame.StoredRecord): Boolean {
+        if (!commitInProgress || weighStartedAt == 0L) return false
+        val nowSecs = System.currentTimeMillis() / 1000L
+        val ts = record.timestampEpochSeconds
+        if (ts < weighStartedAt / 1000L - 60L) return false
+        if (abs(nowSecs - ts) > FRESH_RECORD_WINDOW_S) return false
+        val live = lastLiveWeightG ?: return false
+        return abs(record.weightGrams - live) <= FRESH_WEIGHT_TOLERANCE_G
+    }
+
+    // --- Measurement publishing --------------------------------------------
+
+    private fun publishMeasurement(
+        user: ScaleUser,
+        weightKg: Float,
+        impedanceOhms: Float?,
+        timestamp: Long?
+    ) {
+        if (weightKg <= 0f) return
+        val measurement = ScaleMeasurement().apply {
+            userId = user.id
+            dateTime = timestamp?.let { plausibleDate(it) } ?: Date()
+            this.weight = weightKg
+            // Composition chain: resistance -> body-fat % -> report. Nothing derived is
+            // published outside the reference implementation's validated input ranges.
+            if (impedanceOhms != null && impedanceOhms > 0f) {
+                val sexFlag = if (user.gender == GenderType.MALE) 1 else 0
+                val bodyFat = AfuB1Lib.bodyFatPercent(
+                    weightKg.toDouble(), user.bodyHeight.toDouble(), user.age,
+                    sexFlag, impedanceOhms.toDouble(),
+                )
+                if (bodyFat != null) {
+                    val comp = AfuB1Lib.bodyComposition(sexFlag, user.age, user.bodyHeight, weightKg, bodyFat)
+                    if (comp != null) {
+                        this.impedance = impedanceOhms.toDouble()
+                        fat = bodyFat
+                        water = comp.waterPercent.toFloat()
+                        muscle = comp.skeletalMusclePercent.toFloat()
+                        bone = comp.boneMassKg
+                        visceralFat = comp.visceralFatIndex.toFloat()
+                        protein = comp.proteinPercent.toFloat()
+                        lbm = comp.fatFreeMassKg
+                    }
+                }
+            }
+        }
+        logI(
+            "publishing measurement: ${weightKg}kg" +
+                    (impedanceOhms?.let { ", impedance=${it}Ohm" } ?: "")
+        )
+        publish(measurement)
+    }
+
+    /** History timestamps are Unix seconds; guard against a wildly wrong scale clock. */
+    private fun plausibleDate(timestampEpochSeconds: Long): Date {
+        val millis = timestampEpochSeconds * 1000L
+        return if (millis in 946_684_800_000L..(System.currentTimeMillis() + 86_400_000L)) Date(millis)
+        else Date()
+    }
+
+    private fun logStoredRecord(record: ScaleFrame.StoredRecord) {
+        logI(
+            "RX 0x54 stored seq=${record.sequence} type=${record.historyType} " +
+                    iso(record.timestampEpochSeconds) + " ${record.weightGrams / 1000.0f}kg " +
+                    "res=${record.resistanceOhms}Ohm" +
+                    (if (record.locked) " FINAL" else "") +
+                    (if (record.hasElectrode) " E" else "") +
+                    (if (record.hasHeartRate) " HR" else "")
+        )
+    }
+
+    // --- Helpers -----------------------------------------------------------
+
+    private fun iso(epochSeconds: Long): String {
+        val cal = Calendar.getInstance().apply { timeInMillis = epochSeconds * 1000L }
+        return String.format(
+            Locale.US,
+            "%04d-%02d-%02d %02d:%02d:%02d",
+            cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
+            cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND)
+        )
+    }
+}

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
@@ -20,6 +20,7 @@ package com.health.openscale.core.bluetooth
 import android.util.SparseArray
 import com.health.openscale.core.bluetooth.scales.AAAxHandler
 import com.health.openscale.core.bluetooth.scales.ActiveEraBF06Handler
+import com.health.openscale.core.bluetooth.scales.AfuB1Handler
 import com.health.openscale.core.bluetooth.scales.BeurerBF450Handler
 import com.health.openscale.core.bluetooth.scales.BeurerSanitasHandler
 import com.health.openscale.core.bluetooth.scales.BodyConnectHandler
@@ -158,6 +159,7 @@ object ScaleCatalog {
     val fixtures: List<Fixture> = listOf(
         // --- Matched by advertised name ---
         device("AE BS-06") claimedBy ActiveEraBF06Handler::class.java,
+        device("AFU-BH-TZ-B1", uuid16(0xFC50)) claimedBy AfuB1Handler::class.java,
         device("Keep_S3") claimedBy KeepS3Handler::class.java,
         device("Beurer BF450") claimedBy BeurerBF450Handler::class.java,
         device("BIA SCALE", SERVICE_FFB0) claimedBy TaylorBIAHandler::class.java,

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/AfuB1LibTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/AfuB1LibTest.kt
@@ -1,0 +1,362 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [AfuB1Lib] — the wire protocol of the "AFU B1" scale.
+ *
+ * All byte fixtures were captured with the official AFU app (btsnoop HCI logs) while
+ * reverse-engineering the protocol.
+ */
+class AfuB1LibTest {
+
+    private fun hex(s: String) = s.replace(" ", "")
+        .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    /** Independent CRC reimplementation — cross-checks the lib's checksum. */
+    private fun expectedCrc(raw: ByteArray): Int {
+        var sum = 0
+        for (i in 2 until 19) sum += raw[i].toInt() and 0xFF
+        return sum and 0x1F
+    }
+
+    /** Assembles a valid 20-byte AFU frame around the 16 middle bytes (index 2..17). */
+    private fun frame(middle: ByteArray, wireType: Int): ByteArray {
+        require(middle.size == 16) { "middle must be 16 bytes, got ${middle.size}" }
+        val f = ByteArray(AfuB1Lib.FRAME_SIZE)
+        f[0] = 0xAF.toByte(); f[1] = 0x45.toByte()
+        middle.copyInto(f, 2)
+        f[18] = wireType.toByte()
+        f[19] = expectedCrc(f).toByte()
+        return f
+    }
+
+    /** Blanks the timestamp slot (raw[3..6]) and the CRC covering it for comparisons. */
+    private fun maskTime(f: ByteArray): ByteArray = f.copyOf().also {
+        for (i in 3..6) it[i] = 0
+        it[19] = 0
+    }
+
+    // --- Frame builders (phone -> scale) --------------------------------------
+
+    @Test
+    fun buildTimeSync_matchesCapture() {
+        // af4516ba90806a20000000000000000000005f09
+        assertThat(AfuB1Lib.buildTimeSync(1786810554L))
+            .isEqualTo(hex("af4516ba90806a20000000000000000000005f09"))
+    }
+
+    @Test
+    fun buildSyncRequest_first_matchesCapture() {
+        // af45040001afb6171d010002b4c61b560100620f  (frame 1381 of the capture)
+        assertThat(AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.FIRST))
+            .isEqualTo(hex("af45040001afb6171d010002b4c61b560100620f"))
+    }
+
+    @Test
+    fun buildSyncRequest_second_matchesCapture() {
+        // af45040103a5f8111d020004b4c61b1d0100620e
+        assertThat(AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.SECOND))
+            .isEqualTo(hex("af45040103a5f8111d020004b4c61b1d0100620e"))
+    }
+
+    @Test
+    fun buildSyncRequest_first_hasType62() {
+        val f = AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.FIRST)
+        assertThat(f.size).isEqualTo(20)
+        assertThat(f[18].toInt() and 0xFF).isEqualTo(AfuB1Lib.WIRE_SYNC_REQUEST)
+        assertThat(f[2].toInt() and 0xFF).isEqualTo(AfuB1Lib.CMD_SYNC_REQUEST)
+    }
+
+    @Test
+    fun buildUserProfile_matchesCapture() {
+        // af453fd490806a0001afb6171d01881303006107
+        val f = AfuB1Lib.buildUserProfile(
+            variant = AfuB1Lib.ProfileVariant.INITIAL,
+            nowEpochSeconds = 1786810580L,
+            user = 1,
+            age = 29,
+            sex = 1,
+            targetKg = 50.0f
+        )
+        assertThat(f).isEqualTo(hex("af453fd490806a0001afb6171d01881303006107"))
+    }
+
+    @Test
+    fun buildUserProfile_getWeighAgainVariants_matchCapture() {
+        // Frames 3367 / 5604 / 7980 of btsnoop_hci_260817_140338.log. Only the
+        // timestamp slot (raw[3..6]) is masked — it differs per capture moment.
+        val cases = listOf(
+            AfuB1Lib.ProfileVariant.GET_WEIGH_AGAIN_1 to
+                    "af454ba4826a200001afb6171d01881303006115",
+            AfuB1Lib.ProfileVariant.GET_WEIGH_AGAIN_2 to
+                    "af455ba4826a200001afd9171d01881303006108",
+            AfuB1Lib.ProfileVariant.FINAL to
+                    "af4568a4826a200001afd9171d01881303006115",
+        )
+        for ((variant, captured) in cases) {
+            val built = AfuB1Lib.buildUserProfile(
+                variant = variant,
+                nowEpochSeconds = 0L,
+                user = 1,
+                age = 29,
+                sex = 1,
+                targetKg = 50.0f
+            )
+            assertThat(maskTime(built)).isEqualTo(maskTime(hex(captured)))
+        }
+    }
+
+    @Test
+    fun buildHistoryDumpRequest_matchesCapture() {
+        // af458e4090806a0001afde171d0188130300610a
+        val f = AfuB1Lib.buildHistoryDumpRequest(
+            nowEpochSeconds = 1786810432L,
+            user = 1,
+            age = 29,
+            sex = 1,
+            targetKg = 50.0f
+        )
+        assertThat(f).isEqualTo(hex("af458e4090806a0001afde171d0188130300610a"))
+    }
+
+    @Test
+    fun buildChunkRequest_matchesCapture() {
+        // af45140000000000000000000000000000005f13  (frame 3395 of the capture)
+        assertThat(AfuB1Lib.buildChunkRequest())
+            .isEqualTo(hex("af45140000000000000000000000000000005f13"))
+    }
+
+    @Test
+    fun buildAck_matchesCaptures() {
+        // af45125400050000000000000000000000005f0a  (ack 0x54, correlation=5)
+        assertThat(AfuB1Lib.buildAck(AfuB1Lib.WIRE_STORED_RECORD, 5))
+            .isEqualTo(hex("af45125400050000000000000000000000005f0a"))
+        // af45125100000000000000000000000000005f02  (ack 0x51)
+        assertThat(AfuB1Lib.buildAck(AfuB1Lib.WIRE_LIVE_WEIGHT, 0))
+            .isEqualTo(hex("af45125100000000000000000000000000005f02"))
+        // af45125200000000000000000000000000005f03  (ack 0x52)
+        assertThat(AfuB1Lib.buildAck(AfuB1Lib.WIRE_IMPEDANCE_RESULT, 0))
+            .isEqualTo(hex("af45125200000000000000000000000000005f03"))
+    }
+
+    @Test
+    fun buildFrame_computesCrcCorrectly() {
+        val f = AfuB1Lib.buildTimeSync(1786810554L)
+        assertThat(f[19].toInt() and 0x1F).isEqualTo(expectedCrc(f))
+    }
+
+    // --- Frame decoder (scale -> phone) ---------------------------------------
+
+    @Test
+    fun parse_liveWeightFrame() {
+        // af45b2ed080002800188384b0000000000005106
+        // live 0x51: weight 60850 g (60.85 kg), mode 0x02, not locked
+        val f = AfuB1Lib.parse(hex("af45b2ed080002800188384b0000000000005106"))
+        assertThat(f).isInstanceOf(AfuB1Lib.ScaleFrame.LiveWeight::class.java)
+        val live = f as AfuB1Lib.ScaleFrame.LiveWeight
+        assertThat(live.weightGrams).isEqualTo(60850)
+        assertThat(live.mode).isEqualTo(0x02)
+        assertThat(live.locked).isFalse()
+    }
+
+    @Test
+    fun parse_lockedLiveWeight_setsStateBit() {
+        // Same live frame as above but with bit 31 of the flags word set (state/locked = 1).
+        val vt = AfuB1Lib.convertIntEndian(0x8000EDB2.toInt()) // weight 60850 g + locked bit
+        val middle = ByteArray(16)
+        middle[0] = ((vt ushr 24) and 0xFF).toByte()
+        middle[1] = ((vt ushr 16) and 0xFF).toByte()
+        middle[2] = ((vt ushr 8) and 0xFF).toByte()
+        middle[3] = (vt and 0xFF).toByte()
+        middle[4] = 0x02 // mode
+
+        val live = AfuB1Lib.parse(frame(middle, AfuB1Lib.WIRE_LIVE_WEIGHT))
+        assertThat(live).isEqualTo(
+            AfuB1Lib.ScaleFrame.LiveWeight(weightGrams = 60850, mode = 0x02, locked = true)
+        )
+    }
+
+    @Test
+    fun parse_historyFrame() {
+        // af450046a4826a7aee0880000127020000005404
+        // stored 0x54 record: time 1786946630, weight 61050 g (61.05 kg), resistance 551 Ohm
+        val f = AfuB1Lib.parse(hex("af450046a4826a7aee0880000127020000005404"))
+        assertThat(f).isInstanceOf(AfuB1Lib.ScaleFrame.StoredRecord::class.java)
+        val h = f as AfuB1Lib.ScaleFrame.StoredRecord
+        assertThat(h.historyType).isEqualTo(0)
+        assertThat(h.sequence).isEqualTo(0)
+        assertThat(h.timestampEpochSeconds).isEqualTo(1786946630L)
+        assertThat(h.weightGrams).isEqualTo(61050)
+        assertThat(h.resistanceOhms).isEqualTo(551)
+        // seq=0 is the current LOCKED weight — the scale re-serves it until ACKed.
+        assertThat(h.locked).isTrue()
+    }
+
+    @Test
+    fun parse_historyFrame_encodedSeqInHeader() {
+        // Header byte 0x14 = history_type 0 + history_seq 5 (bits 2..7).
+        val middle = ByteArray(16)
+        middle[0] = 0x14
+
+        val h = AfuB1Lib.parse(frame(middle, AfuB1Lib.WIRE_STORED_RECORD))
+        assertThat(h).isEqualTo(
+            AfuB1Lib.ScaleFrame.StoredRecord(
+                historyType = 0,
+                sequence = 5,
+                timestampEpochSeconds = 0L,
+                weightGrams = 0,
+                hasElectrode = false,
+                hasHeartRate = false,
+                hasPhaseAngle = false,
+                hasZx = false,
+                hasTemperature = false,
+                locked = false,
+                resistanceOhms = 0
+            )
+        )
+    }
+
+    @Test
+    fun parse_impedanceFrame() {
+        // af4501002702000000000000000000000000521c
+        // 0x52 single-impedance result: valid=1, adc=551
+        val f = AfuB1Lib.parse(hex("af4501002702000000000000000000000000521c"))
+        assertThat(f).isInstanceOf(AfuB1Lib.ScaleFrame.ImpedanceResult::class.java)
+        val i = f as AfuB1Lib.ScaleFrame.ImpedanceResult
+        assertThat(i.valid).isTrue()
+        assertThat(i.adcOhms).isEqualTo(551)
+    }
+
+    @Test
+    fun parse_chunkFrame() {
+        // af4514001058a2e6e8296fe2d7799037224c5f0a
+        // 0x5f/0x14 body-comp chunk index 0, 14-byte payload
+        val f = AfuB1Lib.parse(hex("af4514001058a2e6e8296fe2d7799037224c5f0a"))
+        assertThat(f).isInstanceOf(AfuB1Lib.ScaleFrame.BodyCompChunk::class.java)
+        val c = f as AfuB1Lib.ScaleFrame.BodyCompChunk
+        assertThat(c.chunkIndex).isEqualTo(0)
+        assertThat(c.payload.size).isEqualTo(14)
+    }
+
+    @Test
+    fun parse_ackFrame() {
+        // af45125f16000000000000000000000000005f06
+        // 0x5f/0x12 ack: reply_cmd=0x5f
+        val f = AfuB1Lib.parse(hex("af45125f16000000000000000000000000005f06"))
+        assertThat(f).isInstanceOf(AfuB1Lib.ScaleFrame.Acknowledgement::class.java)
+        val a = f as AfuB1Lib.ScaleFrame.Acknowledgement
+        assertThat(a.replyCmd).isEqualTo(0x5F)
+        assertThat(a.replyOp).isEqualTo(0x16)
+    }
+
+    @Test
+    fun parse_phoneToScaleTypes_rejected() {
+        // Type 0x61 (profile) / 0x62 (sync-request) never arrive from the scale.
+        val f = AfuB1Lib.buildUserProfile(
+            variant = AfuB1Lib.ProfileVariant.INITIAL,
+            nowEpochSeconds = 1786810580L,
+            user = 1,
+            age = 29,
+            sex = 1,
+            targetKg = 50.0f
+        )
+        assertThat(AfuB1Lib.parse(f)).isNull()
+        assertThat(AfuB1Lib.parse(AfuB1Lib.buildSyncRequest(AfuB1Lib.SyncRequestVariant.FIRST))).isNull()
+    }
+
+    // --- Robustness ------------------------------------------------------------
+
+    @Test
+    fun parse_wrongLength_rejected() {
+        assertThat(AfuB1Lib.parse(byteArrayOf(0xAF.toByte()))).isNull()
+        assertThat(AfuB1Lib.parse(ByteArray(19))).isNull()
+        assertThat(AfuB1Lib.parse(ByteArray(21))).isNull()
+    }
+
+    @Test
+    fun parse_badHeader_rejected() {
+        val f = AfuB1Lib.buildTimeSync(1786810554L)
+        f[0] = 0x00 // not 0xAF
+        assertThat(AfuB1Lib.parse(f)).isNull()
+    }
+
+    @Test
+    fun parse_badCrc_rejected() {
+        val f = AfuB1Lib.buildTimeSync(1786810554L)
+        f[19] = ((f[19].toInt() + 1) and 0xFF).toByte()
+        assertThat(AfuB1Lib.parse(f)).isNull()
+    }
+
+    // --- Body composition from impedance ----------------------------------------
+
+    @Test
+    fun bodyFatPercent_referenceValues() {
+        // Reference outputs of the python reference implementation:
+        // male, 29y, 175cm, 61.0kg @ 550 Ohm -> 16.7 %; 61.1kg @ 545 Ohm -> 16.6 %
+        assertThat(AfuB1Lib.bodyFatPercent(61.0, 175.0, 29, 1, 550.0)).isEqualTo(16.7f)
+        assertThat(AfuB1Lib.bodyFatPercent(61.1, 175.0, 29, 1, 545.0)).isEqualTo(16.6f)
+        assertThat(AfuB1Lib.bodyFatPercent(61.0, 175.0, 29, 1, 0.0)).isNull()
+    }
+
+    @Test
+    fun bodyComposition_referenceValues() {
+        val c = AfuB1Lib.bodyComposition(1, 29, 175f, 61f, 16.7f)!!
+        assertThat(c.waterPercent).isWithin(1e-9).of(56.15439616656694)
+        assertThat(c.skeletalMusclePercent).isWithin(1e-9).of(50.25818621525999)
+        assertThat(c.boneMassKg.toDouble()).isWithin(1e-9).of(2.6422760486602783)
+        assertThat(c.visceralFatIndex).isEqualTo(6)
+        assertThat(c.proteinPercent).isWithin(1e-9).of(22.814002990722656)
+        assertThat(c.fatFreeMassKg.toDouble()).isWithin(1e-9).of(50.8129997253418)
+
+        val c2 = AfuB1Lib.bodyComposition(1, 29, 175f, 61.1f, 16.6f)!!
+        assertThat(c2.waterPercent).isWithin(1e-9).of(56.27454136258639)
+        assertThat(c2.skeletalMusclePercent).isWithin(1e-9).of(50.36572084232014)
+        assertThat(c2.boneMassKg.toDouble()).isWithin(1e-9).of(2.649784803390503)
+        assertThat(c2.visceralFatIndex).isEqualTo(5)
+        assertThat(c2.proteinPercent).isWithin(1e-9).of(22.788658142089844)
+        assertThat(c2.fatFreeMassKg.toDouble()).isWithin(1e-9).of(50.9573974609375)
+    }
+
+    @Test
+    fun bodyComposition_rejectsOutOfRange() {
+        assertThat(AfuB1Lib.bodyComposition(1, 29, 175f, 61f, 3.9f)).isNull()
+        assertThat(AfuB1Lib.bodyComposition(1, 29, 175f, 61f, 75.5f)).isNull()
+        assertThat(AfuB1Lib.bodyComposition(1, 9, 175f, 61f, 20f)).isNull()
+        assertThat(AfuB1Lib.bodyComposition(1, 29, 80f, 61f, 20f)).isNull()
+        assertThat(AfuB1Lib.bodyComposition(1, 29, 175f, 250f, 20f)).isNull()
+    }
+
+    @Test
+    fun buildThenParse_roundtrip() {
+        val f = AfuB1Lib.buildUserProfile(
+            variant = AfuB1Lib.ProfileVariant.INITIAL,
+            nowEpochSeconds = 1786810580L,
+            user = 1,
+            age = 29,
+            sex = 1,
+            targetKg = 50.0f
+        )
+        // A phone->scale frame is not something the scale would echo, but the CRC must
+        // still be self-consistent so the scale can validate it.
+        assertThat(f[19].toInt() and 0x1F).isEqualTo(expectedCrc(f))
+    }
+}


### PR DESCRIPTION
**AFU B1** body fat scale (an AFU × Boohee Health co-brand) — shows up on Bluetooth as `AFU-BH-TZ-B1`. But I guess this is a scale made by ICOMON.

## Summary

This PR adds a dedicated `AfuB1Handler` plus its library `AfuB1Lib`.

**What works:** weighing, history import, time sync, user profile sync, and body composition derived.

Everything was reverse-engineered from HCI snoop captures of the official app and Boohee app.

## Protocol (reverse-engineered)

Every frame is exactly 20 bytes, in both directions:

```
[AF][45][cmd @2][body @3..17][wire type @18][crc @19]    crc = sum(raw[2..18]) & 0x1F
```

Wire types: `0x51` live weight, `0x54` stored/history record, `0x52` single impedance result, `0x5f` control (sub-cmds `0x12` ACK, `0x14` chunk request / report chunk, `0x16` time-sync), `0x61` user profile and `0x62` sync-request (phone → scale only).

The session flow that mirrors the official app:

1. **Handshake** — time-sync + 2× sync-request.
2. **Idle history** — while idle, the scale keeps pushing its stored measurement (0x54) until it gets an ACK. A history-dump request (0x8e) then makes it send every stored record once.
3. **Weigh-in** — live weight streams until the scale marks the reading as final (a state bit inside the frame); the phone ACKs and waits for the scale to go idle (user stepped off). Re-sync + getWeighAgain profiles (0x4b/0x5b) then make the scale push the freshly committed 0x54 record.

- The history queue must be drained before a weigh can be pulled — otherwise the commit flow returns the *old* queued record instead of the fresh measurement.

The full annotated frame layout lives in the `AfuB1Lib` header comment.

## Body composition

The scale itself only ever sends weight + raw impedance. The official app computes body fat in the cloud, therefore, I cannot obtain the actual algorithm.

- Body-fat % comes from a formula ported from the Boohee app's algorithm library. Its constants fitted to the official app's results.
- Water %, skeletal muscle %, bone mass and visceral fat index are derived from that body-fat value with formulas also reverse-engineered from the Boohee app. With identical inputs they match the official app exactly.

## Testing

- All AfuB1 unit tests pass: `/gradlew test`.
- Tested on a physical device.

## AI disclaimer

I used generative AI to help write this solution.
