### PR TITLE
feat: Add support for AiLink broadcast body fat scales

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/ScaleFactory.kt
@@ -24,6 +24,7 @@ import com.health.openscale.core.bluetooth.scales.BeurerBF450Handler
 import com.health.openscale.core.bluetooth.scales.ScaleDeviceHandler
 import com.health.openscale.core.bluetooth.scales.AAAxHandler
 import com.health.openscale.core.bluetooth.scales.AfuB1Handler
+import com.health.openscale.core.bluetooth.scales.AiLinkBroadcastHandler
 import com.health.openscale.core.bluetooth.scales.FitTrackDaraHandler
 import com.health.openscale.core.bluetooth.scales.ScaleupHandler
 import com.health.openscale.core.bluetooth.scales.ActiveEraBF06Handler
@@ -155,6 +156,7 @@ class ScaleFactory @Inject constructor(
             SinocareHandler(),
             SenssunHandler(),
             RenphoHandler(),
+            AiLinkBroadcastHandler(),
             QNHandlerBroadcast(),
             QNHandler(),
             OneByoneHandler(),

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/AiLinkLib.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/libs/AiLinkLib.kt
@@ -1,0 +1,320 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+/**
+ * Decoder for the **AiLink / eLink broadcast body-fat scale** protocol
+ * (vendor apps `com.pingwang.elink` / "AiLink", chipsets branded Aicare, Pingwang, eLink).
+ *
+ * These scales are *non-connectable*: they never accept a GATT link and instead repeat the whole
+ * measurement inside the manufacturer-specific data of an `ADV_NONCONN_IND` advertisement, with
+ * the interesting part encrypted.
+ *
+ * ## Provenance
+ * The protocol described below was determined for interoperability, by observing live
+ * advertisements from an "EL1" scale and by studying the behaviour of the vendor's own
+ * implementation (`BleValueBean.init`, `MainModel.BroadCast`, `BroadcastScaleDeviceData.dataCheck`
+ * and the native `libAILinkBle-lib.so`). What was recovered are facts about the wire format —
+ * field offsets, the checksum, the cipher and its key schedule — not source text. The
+ * implementation here is original: TEA itself is a published algorithm, and every routine below
+ * was written from the documented layout rather than transcribed from any decompiler output.
+ *
+ * ## Advertisement layout
+ * The scale advertises service `0000F0A0` and one manufacturer record. AiLink abuses the
+ * manufacturer field: the two bytes Android parses as the *company id* are really the vendor's
+ * CID and VID, so `ScanRecord.getManufacturerSpecificData(companyId)` hands back the record
+ * already stripped of them. Indices below are into that stripped array:
+ *
+ * ```
+ * companyId = VID << 8 | CID          (0x0301 -> CID 0x01, VID 0x03)
+ *   [0]      PID
+ *   [1..6]   MAC address, little-endian (reverse for display)
+ *   [7]      checksum: sum of [8..17] & 0xFF
+ *   [8..17]  10-byte payload, TEA-encrypted
+ * ```
+ *
+ * ## Payload encryption
+ * `AiLinkPwdUtil.decryptBroadcast` is plain 32-round [TEA](https://en.wikipedia.org/wiki/Tiny_Encryption_Algorithm)
+ * over **only the first 8 bytes** — bytes [8..9] of the payload are passed through untouched, and
+ * this decoder keeps that quirk so frames decode the same way the scale meant them. The 128-bit key
+ * is built inline from the device ids rather than from `get_ailink_key`'s MD5 path
+ * (see [broadcastKey]).
+ *
+ * ## Decrypted payload
+ * ```
+ *   [0]      rolling sequence counter
+ *   [1]      status (see STATUS_* below)
+ *   [2]      flags: bits 3..5 = weight unit, bits 1..2 = decimal places
+ *   [3..4]   weight, big-endian; bit 7 of [3] is a negative-value flag
+ *   [5..6]   impedance in ohms, big-endian
+ *   [7]      body-composition algorithm id
+ *   [8..9]   not decrypted, meaning unverified — deliberately not decoded here
+ * ```
+ *
+ * Only the fields above were observed on real hardware. Body composition is intentionally *not*
+ * computed: the raw impedance is reported and openScale derives the rest.
+ */
+object AiLinkLib {
+
+    // --- Status byte (payload[1]), named after the vendor app's own UI branches ---------------
+
+    /** Live weight while the user is still settling; also sent when the scale is idle. */
+    const val STATUS_MEASURING = 0x00
+
+    /** Impedance measurement running ("data analyzing" in the vendor UI). */
+    const val STATUS_ANALYSING = 0x01
+
+    /** Impedance result available. */
+    const val STATUS_IMPEDANCE_READY = 0x02
+
+    /** Impedance measurement failed; the vendor app zeroes the impedance in this case. */
+    const val STATUS_IMPEDANCE_FAILED = 0x03
+
+    /** Vendor "data mode 4" frame. Branched on by the vendor app but never observed here. */
+    const val STATUS_DATA_MODE = 0x04
+
+    /** Measurement finished — final weight and impedance. This is the frame worth recording. */
+    const val STATUS_COMPLETE = 0xFF
+
+    /**
+     * Every status the vendor app branches on.
+     *
+     * The advertisement's checksum covers the *still-encrypted* payload, so it proves the record
+     * arrived intact but not that it is AiLink at all — an all-zero record from an unrelated
+     * vendor checksums perfectly. Requiring the decrypted status byte to be one of these is the
+     * cheapest way to tell "decrypted with the right key" from "decrypted into noise".
+     */
+    private val KNOWN_STATUSES = setOf(
+        STATUS_MEASURING,
+        STATUS_ANALYSING,
+        STATUS_IMPEDANCE_READY,
+        STATUS_IMPEDANCE_FAILED,
+        STATUS_DATA_MODE,
+        STATUS_COMPLETE,
+    )
+
+    // --- Weight unit (payload[2], bits 3..5) --------------------------------------------------
+
+    /** Kilograms. The only unit seen on real hardware, so the only one [Broadcast.weightKg] trusts. */
+    const val UNIT_KG = 0
+
+    /** Chinese jin, per the vendor's `UnitUtil.weightUnitToString`. Never observed; not decoded. */
+    const val UNIT_JIN = 1
+
+    /** Pounds, per the vendor's `UnitUtil.weightUnitToString`. Never observed; not decoded. */
+    const val UNIT_LB = 6
+
+    // --- Frame geometry -----------------------------------------------------------------------
+
+    /** Manufacturer record length once Android has stripped the two company-id bytes. */
+    private const val RECORD_LENGTH = 18
+    private const val MAC_OFFSET = 1
+    private const val MAC_LENGTH = 6
+    private const val CHECKSUM_INDEX = 7
+    private const val PAYLOAD_OFFSET = 8
+    private const val PAYLOAD_LENGTH = 10
+
+    /** TEA covers only the first 8 bytes of the payload; see the class docs. */
+    private const val ENCRYPTED_LENGTH = 8
+
+    // --- TEA parameters -----------------------------------------------------------------------
+
+    private const val TEA_ROUNDS = 32
+
+    /** TEA's golden-ratio delta, 0x9E3779B9 as a signed [Int]. */
+    private val DELTA = 0x9E3779B9.toInt()
+
+    /** Decryption starts from delta * 32, i.e. 0xC6EF3720. */
+    private val SUM_INITIAL = 0xC6EF3720.toInt()
+
+    /**
+     * Per-word constants the native library adds to the device ids to form the TEA key.
+     * Their bytes spell fragments of "AILink"/"1x1"/"1el0", which is presumably the point.
+     */
+    private const val KEY_BASE_PID = 0x41493000
+    private const val KEY_BASE_VID = 0x4C327900
+    private const val KEY_BASE_CID = 0x31783100
+    private const val KEY_WORD_3 = 0x306C6531
+
+    /** Device ids at or above this are folded back down before being mixed into the key. */
+    private const val ID_FOLD_THRESHOLD = 0x10000
+    private const val ID_FOLD_AMOUNT = 0xFFFF
+
+    /**
+     * One decoded advertisement.
+     *
+     * @property macAddress  the scale's MAC in display order, e.g. `0A:1B:2C:3D:4E:5F`.
+     * @property sequence    rolling counter; the vendor app uses it with [status] to drop repeats.
+     * @property status      one of the `STATUS_*` constants.
+     * @property weightUnit  raw unit code; see the `UNIT_*` constants.
+     * @property decimals    number of implied decimal places in [rawWeight].
+     * @property isNegative  the scale flagged the reading as negative (the vendor app rejects those).
+     * @property rawWeight   weight before the decimal point is applied.
+     * @property weightKg    [rawWeight] scaled to kilograms, or `null` when [weightUnit] is not
+     *                       [UNIT_KG] — the other unit codes have never been observed, so this
+     *                       library refuses to guess rather than record a wrong weight.
+     * @property impedance   body impedance in ohms; 0 when the scale reports none.
+     * @property algorithm   vendor body-composition algorithm id (informational).
+     */
+    data class Broadcast(
+        val macAddress: String,
+        val sequence: Int,
+        val status: Int,
+        val weightUnit: Int,
+        val decimals: Int,
+        val isNegative: Boolean,
+        val rawWeight: Int,
+        val weightKg: Float?,
+        val impedance: Int,
+        val algorithm: Int,
+    ) {
+        /** True once the scale has finished weighing *and* measuring impedance. */
+        val isComplete: Boolean get() = status == STATUS_COMPLETE
+
+        /**
+         * The weight in kg, but only when the reading passes the vendor app's own plausibility
+         * gate: positive, non-zero, and in a unit we understand. `null` otherwise.
+         *
+         * Single source of truth for "is there a weight worth recording here", so callers unwrap
+         * once instead of testing [isUsable] and then re-checking [weightKg] for null.
+         */
+        val usableWeightKg: Float?
+            get() = weightKg?.takeIf { !isNegative && rawWeight != 0 }
+
+        /** Whether this frame carries a weight worth recording; see [usableWeightKg]. */
+        val isUsable: Boolean get() = usableWeightKg != null
+    }
+
+    /**
+     * Decodes one manufacturer record, or returns `null` if it is not a well-formed AiLink
+     * broadcast: too short, checksum mismatch over the encrypted payload, or a decrypted status
+     * outside [KNOWN_STATUSES] (which is what rejects another vendor's record that happens to
+     * satisfy the checksum).
+     *
+     * @param companyId the id Android keyed the record by; really `VID << 8 | CID`.
+     * @param data      the record with the company-id bytes already stripped.
+     */
+    fun parse(companyId: Int, data: ByteArray): Broadcast? {
+        if (data.size < RECORD_LENGTH) return null
+
+        val cid = companyId and 0xFF
+        val vid = (companyId shr 8) and 0xFF
+        val pid = data[0].toInt() and 0xFF
+
+        val encrypted = data.copyOfRange(PAYLOAD_OFFSET, PAYLOAD_OFFSET + PAYLOAD_LENGTH)
+        if (checksum8(encrypted) != (data[CHECKSUM_INDEX].toInt() and 0xFF)) return null
+
+        val p = decryptBroadcast(encrypted, cid, vid, pid)
+
+        val status = p[1].toInt() and 0xFF
+        if (status !in KNOWN_STATUSES) return null
+
+        val flags = p[2].toInt() and 0xFF
+        val unit = (flags shr 3) and 0x07
+        val decimals = (flags shr 1) and 0x03
+        val rawWeight = ((p[3].toInt() and 0x7F) shl 8) or (p[4].toInt() and 0xFF)
+
+        return Broadcast(
+            macAddress = macOf(data),
+            sequence = p[0].toInt() and 0xFF,
+            status = status,
+            weightUnit = unit,
+            decimals = decimals,
+            isNegative = (p[3].toInt() and 0x80) != 0,
+            rawWeight = rawWeight,
+            weightKg = if (unit == UNIT_KG) applyDecimals(rawWeight, decimals) else null,
+            impedance = ((p[5].toInt() and 0xFF) shl 8) or (p[6].toInt() and 0xFF),
+            algorithm = p[7].toInt() and 0xFF,
+        )
+    }
+
+    /**
+     * Builds the 128-bit TEA key the broadcast payload is encrypted with.
+     *
+     * Derived from the observed behaviour of
+     * `Java_com_pinwang_ailinkble_AiLinkPwdUtil_decryptBroadcast`, which builds the key inline
+     * from the device ids instead of going through `get_ailink_key`'s MD5 path. Ids at or above
+     * 0x10000 are first reduced by 0xFFFF, which is how the vendor's device *types* (65537,
+     * 65557, …) collapse into small numbers.
+     */
+    fun broadcastKey(cid: Int, vid: Int, pid: Int): IntArray = intArrayOf(
+        fold(pid) + KEY_BASE_PID,
+        fold(vid) + KEY_BASE_VID,
+        fold(cid) + KEY_BASE_CID,
+        KEY_WORD_3,
+    )
+
+    /**
+     * TEA-decrypts the first 8 bytes of [payload] in a copy, leaving any trailing bytes as-is
+     * (the native implementation does the same). The two 32-bit halves are read little-endian.
+     */
+    fun decryptBroadcast(payload: ByteArray, cid: Int, vid: Int, pid: Int): ByteArray {
+        val out = payload.copyOf()
+        if (out.size < ENCRYPTED_LENGTH) return out
+
+        val k = broadcastKey(cid, vid, pid)
+        var v0 = readLe32(out, 0)
+        var v1 = readLe32(out, 4)
+        var sum = SUM_INITIAL
+
+        repeat(TEA_ROUNDS) {
+            v1 -= ((v0 shl 4) + k[2]) xor (v0 + sum) xor ((v0 ushr 5) + k[3])
+            v0 -= ((v1 shl 4) + k[0]) xor (v1 + sum) xor ((v1 ushr 5) + k[1])
+            sum -= DELTA
+        }
+
+        writeLe32(out, 0, v0)
+        writeLe32(out, 4, v1)
+        return out
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    private fun fold(id: Int) = if (id >= ID_FOLD_THRESHOLD) id - ID_FOLD_AMOUNT else id
+
+    private fun checksum8(bytes: ByteArray): Int =
+        bytes.fold(0) { acc, b -> acc + (b.toInt() and 0xFF) } and 0xFF
+
+    /** Weight is transmitted as an integer with [decimals] implied decimal places. */
+    private fun applyDecimals(raw: Int, decimals: Int): Float = when (decimals) {
+        1 -> raw / 10f
+        2 -> raw / 100f
+        3 -> raw / 1000f
+        else -> raw.toFloat()
+    }
+
+    /** The MAC sits little-endian in the advertisement; reverse it for display. */
+    private fun macOf(data: ByteArray): String =
+        (MAC_OFFSET until MAC_OFFSET + MAC_LENGTH)
+            .map { data[it] }
+            .reversed()
+            .joinToString(":") { "%02X".format(it.toInt() and 0xFF) }
+
+    private fun readLe32(b: ByteArray, offset: Int): Int =
+        (b[offset].toInt() and 0xFF) or
+            ((b[offset + 1].toInt() and 0xFF) shl 8) or
+            ((b[offset + 2].toInt() and 0xFF) shl 16) or
+            ((b[offset + 3].toInt() and 0xFF) shl 24)
+
+    private fun writeLe32(b: ByteArray, offset: Int, value: Int) {
+        b[offset] = value.toByte()
+        b[offset + 1] = (value shr 8).toByte()
+        b[offset + 2] = (value shr 16).toByte()
+        b[offset + 3] = (value shr 24).toByte()
+    }
+}

--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/AiLinkBroadcastHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/AiLinkBroadcastHandler.kt
@@ -1,0 +1,201 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.le.ScanResult
+import android.util.SparseArray
+import com.health.openscale.core.bluetooth.data.ScaleMeasurement
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import com.health.openscale.core.bluetooth.libs.AiLinkLib
+import com.health.openscale.core.bluetooth.libs.StandardImpedanceLib
+import com.health.openscale.core.service.ScannedDeviceInfo
+import java.util.Date
+import java.util.UUID
+
+/**
+ * AiLink / eLink **broadcast** body-fat scales.
+ *
+ * Sold under many private labels driven by the "AiLink" app (`com.pingwang.elink`); the unit this
+ * was developed against advertises as `EL1` and is retailed in Portugal as "BALANÇA BODY SMART
+ * C/ APP". These scales are non-connectable: they never accept a GATT link and instead repeat the
+ * complete measurement inside an encrypted manufacturer record, so this handler runs in
+ * [LinkMode.BROADCAST_ONLY] and all GATT hooks are deliberate no-ops.
+ *
+ * The wire format, the TEA key derivation and the payload layout are documented on [AiLinkLib],
+ * which does the decoding; this class only decides *which* decoded frame is worth recording.
+ *
+ * ## Which frame gets published
+ * The scale streams `status = 0` frames with a live weight while the user settles, then latches a
+ * single `status = 0xFF` frame that carries the final weight **and** the impedance, and repeats
+ * that frame for as long as it stays awake. Only the completed frame is published, and only once
+ * per session — mirroring the vendor app, which likewise ignores everything until the impedance
+ * measurement has finished.
+ *
+ * Body composition is derived by openScale's own [StandardImpedanceLib] from the reported
+ * impedance rather than by porting the vendor's formulas, consistent with the other
+ * impedance-reporting handlers.
+ *
+ * ## Why only the completed frame's impedance is trusted
+ * The impedance field is **stale until the scale's BIA phase finishes**: frames sent while the
+ * user is still settling repeat the *previous* measurement's value, which makes an unchanging
+ * impedance during `status 0` look deceptively like a hardcoded constant. It is not — verified
+ * on hardware by a controlled experiment: barefoot, the scale completed reporting 500 ohms;
+ * standing on it through footwear, the same BIA phase ran, detected the broken circuit and
+ * completed with `status 3` and 0 ohms.
+ *
+ * Two rules follow, both implemented in [onAdvertisement]: only ever read impedance from the
+ * `status 0xFF` frame, and treat 0 as "the scale's BIA pass failed" — publish the weight but no
+ * body composition, rather than feeding a bogus 0 into [StandardImpedanceLib].
+ */
+class AiLinkBroadcastHandler : ScaleDeviceHandler() {
+
+    companion object {
+        /**
+         * Advertised service that marks the AiLink *broadcast* profile
+         * (`BleConfig.UUID_SERVER_BROADCAST_AILINK` in the vendor SDK). Connectable AiLink
+         * devices use other services, so this is what keeps the handler to broadcast scales.
+         */
+        private const val SERVICE_BROADCAST_SHORT = 0xF0A0
+
+        /** Guard against nonsense decodes; the hardware is a ~180 kg consumer scale. */
+        private const val WEIGHT_MIN_KG = 1.0f
+        private const val WEIGHT_MAX_KG = 300.0f
+    }
+
+    private val serviceBroadcast: UUID = uuid16(SERVICE_BROADCAST_SHORT)
+
+    /** Publishing is single-shot per session; the scale repeats the final frame indefinitely. */
+    private var hasPublished = false
+
+    // --- Device identification ----------------------------------------------------------------
+
+    override fun supportFor(device: ScannedDeviceInfo): DeviceSupport? {
+        // The advertised name ("EL1") is a meaningless vendor default that other eLink products
+        // share, so match on the broadcast service plus a manufacturer record that actually
+        // checksums as an AiLink frame. That pair is specific and, unlike the name, verifiable.
+        if (!device.serviceUuids.contains(serviceBroadcast)) return null
+
+        val mfr = device.manufacturerData ?: return null
+        if (firstAiLinkFrame(mfr) == null) return null
+
+        return DeviceSupport(
+            displayName = "AiLink Body Fat Scale",
+            capabilities = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+            ),
+            implemented = setOf(
+                DeviceCapability.LIVE_WEIGHT_STREAM,
+                DeviceCapability.BODY_COMPOSITION,
+            ),
+            linkMode = LinkMode.BROADCAST_ONLY,
+        )
+    }
+
+    // --- GATT hooks (intentional no-ops — the device is non-connectable) -----------------------
+
+    override fun onConnected(user: ScaleUser) = Unit
+
+    override fun onNotification(characteristic: UUID, data: ByteArray, user: ScaleUser) = Unit
+
+    override fun onDisconnected() {
+        hasPublished = false
+    }
+
+    // --- Broadcast reception ------------------------------------------------------------------
+
+    override fun onAdvertisement(result: ScanResult, user: ScaleUser): BroadcastAction {
+        if (hasPublished) return BroadcastAction.IGNORED
+
+        val mfr = result.scanRecord?.manufacturerSpecificData ?: return BroadcastAction.IGNORED
+        val frame = firstAiLinkFrame(mfr) ?: return BroadcastAction.IGNORED
+
+        if (!frame.isComplete) {
+            // Live weight while the user settles, or an idle frame with no load at all.
+            logD("status=0x%02X seq=%d raw=%d — waiting for the scale to finish"
+                .format(frame.status, frame.sequence, frame.rawWeight))
+            return BroadcastAction.CONSUMED_KEEP_SCANNING
+        }
+
+        // The vendor app rejects completed frames that are negative, zero, or in a unit we have
+        // never observed; do the same rather than record a wrong measurement.
+        val weightKg = frame.usableWeightKg
+        if (weightKg == null) {
+            logW("completed frame is not usable (unit=${frame.weightUnit} raw=${frame.rawWeight} " +
+                    "negative=${frame.isNegative}); ignoring")
+            return BroadcastAction.CONSUMED_KEEP_SCANNING
+        }
+
+        if (weightKg < WEIGHT_MIN_KG || weightKg > WEIGHT_MAX_KG) {
+            logW("implausible weight ${weightKg}kg; ignoring")
+            return BroadcastAction.CONSUMED_KEEP_SCANNING
+        }
+
+        val measurement = ScaleMeasurement().apply {
+            userId = user.id
+            dateTime = Date()
+            weight = weightKg
+        }
+
+        // The scale zeroes the impedance when its BIA pass fails (status 0x03 in the vendor app),
+        // so only derive body composition when it actually reported one.
+        if (frame.impedance > 0) {
+            measurement.impedance = frame.impedance.toDouble()
+
+            val lib = StandardImpedanceLib(
+                gender = user.gender,
+                age = user.age,
+                weightKg = weightKg.toDouble(),
+                heightM = user.bodyHeight / 100.0,
+                impedance = measurement.impedance,
+            )
+
+            measurement.fat = lib.totalFatPercentage.toFloat()
+            measurement.water = lib.totalBodyWaterPercentage.toFloat()
+            measurement.muscle = lib.skeletalMusclePercentage.toFloat()
+            measurement.bone = lib.boneMassKg.toFloat()
+            measurement.bmr = lib.basalMetabolicRate.toFloat()
+            measurement.lbm = lib.fatFreeMassKg.toFloat()
+        } else {
+            logD("scale reported no impedance; publishing weight only")
+        }
+
+        logI("publishing weight=${weightKg}kg impedance=${frame.impedance} seq=${frame.sequence}")
+        hasPublished = true
+        publish(measurement)
+        return BroadcastAction.CONSUMED_STOP
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    /**
+     * Returns the first manufacturer record in [mfr] that decodes as an AiLink frame.
+     *
+     * An advertisement may legitimately carry records from several vendors, and AiLink's
+     * "company id" is really its CID/VID pair rather than a registered identifier — so rather
+     * than trusting any single id, every record is offered to [AiLinkLib.parse] and the checksum
+     * decides.
+     */
+    private fun firstAiLinkFrame(mfr: SparseArray<ByteArray>): AiLinkLib.Broadcast? {
+        for (i in 0 until mfr.size()) {
+            val record = mfr.valueAt(i) ?: continue
+            AiLinkLib.parse(mfr.keyAt(i), record)?.let { return it }
+        }
+        return null
+    }
+}

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/ScaleCatalog.kt
@@ -20,6 +20,7 @@ package com.health.openscale.core.bluetooth
 import android.util.SparseArray
 import com.health.openscale.core.bluetooth.scales.AAAxHandler
 import com.health.openscale.core.bluetooth.scales.HealthKeep280Handler
+import com.health.openscale.core.bluetooth.scales.AiLinkBroadcastHandler
 import com.health.openscale.core.bluetooth.scales.ActiveEraBF06Handler
 import com.health.openscale.core.bluetooth.scales.AfuB1Handler
 import com.health.openscale.core.bluetooth.scales.BeurerBF450Handler
@@ -151,6 +152,24 @@ object ScaleCatalog {
     /** Etekcity's company id; with service 0xFFD0 the only fingerprint of the nameless Fit 8S. */
     private const val ETEKCITY_COMPANY_ID = 0x06D0
 
+    /** Not a registered company id at all: AiLink packs its CID (0x01) and VID (0x03) here. */
+    private const val AILINK_COMPANY_ID = 0x0301
+
+    /**
+     * An AiLink advertisement carrying a completed measurement. Its payload is encrypted and
+     * checksummed, so unlike most fixtures here it cannot be a zero-filled placeholder — the
+     * handler only claims records that actually decrypt. Synthesised with the protocol's own
+     * cipher over an invented reading; see `AiLinkLibTest`.
+     */
+    private val AILINK_RECORD = byteArrayOf(
+        0x01,                                                     // PID
+        0x5F, 0x4E, 0x3D, 0x2C, 0x1B, 0x0A,                       // MAC, little-endian
+        0x8F.toByte(),                                            // checksum of the payload
+        0x10, 0xE6.toByte(), 0x9C.toByte(), 0xF7.toByte(),        // TEA-encrypted payload
+        0xCB.toByte(), 0x45, 0x2C, 0xCC.toByte(),
+        0xFF.toByte(), 0xFF.toByte(),
+    )
+
     private infix fun ScannedDeviceInfo.claimedBy(handler: Class<out ScaleDeviceHandler>) =
         Fixture(this, handler)
 
@@ -276,6 +295,13 @@ object ScaleCatalog {
         // Scaleup: any manufacturer record whose company-id low byte is 0xD0 (measuring) or 0xE0.
         advertisement(manufacturerData = listOf(0x1DD0 to ByteArray(9)))
             claimedBy ScaleupHandler::class.java,
+        // AiLink broadcast body-fat scale: service 0xF0A0 plus an encrypted, checksummed record
+        // whose "company id" is really the vendor's CID/VID pair. Real capture from an "EL1".
+        advertisement(
+            name = "EL1",
+            services = listOf(uuid16(0xF0A0)),
+            manufacturerData = listOf(AILINK_COMPANY_ID to AILINK_RECORD),
+        ) claimedBy AiLinkBroadcastHandler::class.java,
     )
 
     // --- Registry queries -------------------------------------------------------------------

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/AiLinkLibTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/libs/AiLinkLibTest.kt
@@ -1,0 +1,184 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.libs
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Unit tests for [AiLinkLib].
+ *
+ * [AiLinkLib] was reverse-engineered from an AiLink "EL1" broadcast scale (vendor app
+ * `com.pingwang.elink`) and verified against live advertisements from that hardware. The
+ * fixtures below are **synthetic**: each one was produced by running the protocol's own TEA
+ * encryption over a chosen payload, so they still exercise the real key derivation, the real
+ * cipher and the real checksum — but they carry invented weights and an invented MAC rather than
+ * anyone's health data.
+ *
+ * Every fixture is laid out exactly as `ScanRecord.getManufacturerSpecificData(0x0301)` returns
+ * it, i.e. with the two company-id bytes already stripped by Android.
+ */
+class AiLinkLibTest {
+
+    /** Company id as Android reports it; really AiLink's CID (0x01) and VID (0x03). */
+    private val COMPANY_ID = 0x0301
+
+    private fun adv(hex: String) = hex.replace(" ", "").chunked(2)
+        .map { it.toInt(16).toByte() }.toByteArray()
+
+    /** status 0xFF (complete), 70.0 kg, impedance 500 — the frame the scale latches and repeats. */
+    private val COMPLETED = adv("01 5f4e3d2c1b0a 8f 10e69cf7cb452cccffff")
+
+    /** status 0xFF (complete) from an earlier step-on, 68.4 kg. */
+    private val COMPLETED_684 = adv("01 5f4e3d2c1b0a 7e 945ab8103c0b750effff")
+
+    /** status 0x00 (measuring) while a 70.0 kg reading is still live. */
+    private val MEASURING = adv("01 5f4e3d2c1b0a 33 31c5f84954a1b455ffff")
+
+    /** status 0x00 with no load: raw weight 0 and the flags' low bit clear. */
+    private val IDLE = adv("01 5f4e3d2c1b0a 81 cd9244ffe6049c5bffff")
+
+    /** Complete, but the scale's impedance pass failed and it reported 0 ohms. */
+    private val NO_IMPEDANCE = adv("01 5f4e3d2c1b0a f9 95fd662927ee4283ffff")
+
+    // --- Key derivation --------------------------------------------------------
+
+    @Test
+    fun derives_the_broadcast_tea_key_from_cid_vid_pid() {
+        // Recovered from Java_com_pinwang_ailinkble_AiLinkPwdUtil_decryptBroadcast:
+        // k0 = pid + 0x41493000, k1 = vid + 0x4C327900, k2 = cid + 0x31783100, k3 = 0x306C6531
+        assertThat(AiLinkLib.broadcastKey(cid = 1, vid = 3, pid = 1).toList())
+            .containsExactly(0x41493001, 0x4C327903, 0x31783101, 0x306C6531)
+            .inOrder()
+    }
+
+    @Test
+    fun subtracts_0xffff_from_ids_at_or_above_0x10000() {
+        // The native code folds the app's 0x1xxxx device types back into a small number
+        // (e.g. type 65537 -> 2) before adding the constants.
+        assertThat(AiLinkLib.broadcastKey(cid = 65537, vid = 3, pid = 1)[2])
+            .isEqualTo(0x31783100 + 2)
+    }
+
+    // --- Decoding --------------------------------------------------------------
+
+    @Test
+    fun decodes_the_completed_measurement() {
+        val b = AiLinkLib.parse(COMPANY_ID, COMPLETED)!!
+
+        assertThat(b.macAddress).isEqualTo("0A:1B:2C:3D:4E:5F")
+        assertThat(b.status).isEqualTo(AiLinkLib.STATUS_COMPLETE)
+        assertThat(b.sequence).isEqualTo(42)
+        assertThat(b.weightUnit).isEqualTo(AiLinkLib.UNIT_KG)
+        assertThat(b.decimals).isEqualTo(1)
+        assertThat(b.isNegative).isFalse()
+        assertThat(b.rawWeight).isEqualTo(700)
+        assertThat(b.weightKg).isWithin(0.001f).of(70.0f)
+        assertThat(b.impedance).isEqualTo(500)
+        assertThat(b.algorithm).isEqualTo(1)
+        assertThat(b.isComplete).isTrue()
+        assertThat(b.isUsable).isTrue()
+    }
+
+    @Test
+    fun decodes_an_earlier_completed_measurement() {
+        val b = AiLinkLib.parse(COMPANY_ID, COMPLETED_684)!!
+
+        assertThat(b.status).isEqualTo(AiLinkLib.STATUS_COMPLETE)
+        assertThat(b.sequence).isEqualTo(12)
+        assertThat(b.weightKg).isWithin(0.001f).of(68.4f)
+    }
+
+    @Test
+    fun decodes_a_live_measuring_frame_but_does_not_call_it_complete() {
+        val b = AiLinkLib.parse(COMPANY_ID, MEASURING)!!
+
+        assertThat(b.status).isEqualTo(AiLinkLib.STATUS_MEASURING)
+        assertThat(b.sequence).isEqualTo(26)
+        assertThat(b.weightKg).isWithin(0.001f).of(70.0f)
+        assertThat(b.isComplete).isFalse()
+    }
+
+    @Test
+    fun treats_an_idle_frame_as_unusable() {
+        val b = AiLinkLib.parse(COMPANY_ID, IDLE)!!
+
+        assertThat(b.status).isEqualTo(AiLinkLib.STATUS_MEASURING)
+        assertThat(b.rawWeight).isEqualTo(0)
+        assertThat(b.weightKg).isWithin(0.001f).of(0f)
+        assertThat(b.isUsable).isFalse()
+    }
+
+    /** A completed frame stays usable when the impedance pass failed; only the ohms are missing. */
+    @Test
+    fun decodes_a_completed_frame_that_reports_no_impedance() {
+        val b = AiLinkLib.parse(COMPANY_ID, NO_IMPEDANCE)!!
+
+        assertThat(b.isComplete).isTrue()
+        assertThat(b.isUsable).isTrue()
+        assertThat(b.impedance).isEqualTo(0)
+        assertThat(b.weightKg).isWithin(0.001f).of(70.0f)
+    }
+
+    /** Each frame carries a rolling counter, so consecutive readings are distinguishable. */
+    @Test
+    fun sequence_differs_between_frames() {
+        val seen = listOf(COMPLETED, COMPLETED_684, MEASURING, IDLE)
+            .map { AiLinkLib.parse(COMPANY_ID, it)!!.sequence }
+
+        assertThat(seen).containsNoDuplicates()
+    }
+
+    // --- Rejection -------------------------------------------------------------
+
+    @Test
+    fun rejects_a_frame_whose_checksum_does_not_match() {
+        val corrupted = COMPLETED.copyOf().also { it[7] = (it[7] + 1).toByte() }
+
+        assertThat(AiLinkLib.parse(COMPANY_ID, corrupted)).isNull()
+    }
+
+    @Test
+    fun rejects_a_frame_that_is_too_short() {
+        assertThat(AiLinkLib.parse(COMPANY_ID, COMPLETED.copyOf(17))).isNull()
+    }
+
+    /** The checksum covers the still-encrypted payload, so a flipped payload byte is caught. */
+    @Test
+    fun rejects_a_frame_with_a_corrupted_payload() {
+        val corrupted = COMPLETED.copyOf().also { it[8] = (it[8] + 1).toByte() }
+
+        assertThat(AiLinkLib.parse(COMPANY_ID, corrupted)).isNull()
+    }
+
+    /**
+     * An all-zero record satisfies the checksum trivially (0 == 0), so the checksum alone cannot
+     * prove a record is AiLink. Decrypting it yields status 0x55, which is not a status the scale
+     * ever sends — that is what rejects another vendor's record.
+     */
+    @Test
+    fun rejects_an_all_zero_record_from_another_vendor() {
+        assertThat(AiLinkLib.parse(0x00FF, ByteArray(18))).isNull()
+    }
+
+    /** A frame decrypted with the wrong key lands on a nonsense status and must be rejected. */
+    @Test
+    fun rejects_a_frame_decrypted_with_the_wrong_device_ids() {
+        assertThat(AiLinkLib.parse(0x0405, COMPLETED)).isNull()
+    }
+}

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/AiLinkBroadcastHandlerTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/AiLinkBroadcastHandlerTest.kt
@@ -1,0 +1,135 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.util.SparseArray
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.core.service.ScannedDeviceInfo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+/**
+ * Device-matching tests for [AiLinkBroadcastHandler].
+ *
+ * Because the payload is encrypted, the only honest fingerprint is the F0A0 broadcast service
+ * plus a manufacturer record that actually decrypts — so these tests pin both halves of that
+ * fingerprint, and in particular that the handler stays quiet for devices it cannot decode.
+ *
+ * The fixture is synthetic: it was built by running the protocol's own TEA encryption over an
+ * invented 70.0 kg reading, so it is byte-for-byte valid without containing real health data.
+ *
+ * Robolectric supplies a working [SparseArray]; the decoding itself is covered by `AiLinkLibTest`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AiLinkBroadcastHandlerTest {
+
+    private val AILINK_SERVICE: UUID =
+        UUID.fromString("0000f0a0-0000-1000-8000-00805f9b34fb")
+
+    /** Really CID 0x01 + VID 0x03, which Android reports as a company id. */
+    private val COMPANY_ID = 0x0301
+
+    /** A completed measurement (status 0xFF, 70.0 kg, impedance 500). */
+    private val RECORD = hex("01 5f4e3d2c1b0a 8f 10e69cf7cb452cccffff")
+
+    private fun hex(s: String) = s.replace(" ", "").chunked(2)
+        .map { it.toInt(16).toByte() }.toByteArray()
+
+    private fun advertisement(
+        services: List<UUID> = listOf(AILINK_SERVICE),
+        manufacturerData: List<Pair<Int, ByteArray>> = listOf(COMPANY_ID to RECORD),
+    ) = ScannedDeviceInfo(
+        name = "EL1",
+        address = "0A:1B:2C:3D:4E:5F",
+        rssi = -85,
+        serviceUuids = services,
+        manufacturerData = SparseArray<ByteArray>().apply {
+            manufacturerData.forEach { (id, data) -> put(id, data) }
+        },
+    )
+
+    @Test
+    fun claims_a_real_ailink_broadcast_advertisement() {
+        assertThat(AiLinkBroadcastHandler().supportFor(advertisement())).isNotNull()
+    }
+
+    @Test
+    fun reports_the_device_as_broadcast_only() {
+        val support = AiLinkBroadcastHandler().supportFor(advertisement())!!
+
+        assertThat(support.linkMode).isEqualTo(LinkMode.BROADCAST_ONLY)
+        assertThat(support.implemented).contains(DeviceCapability.LIVE_WEIGHT_STREAM)
+    }
+
+    /**
+     * The scale measures impedance for real, so body composition is derived from it.
+     *
+     * Confirmed on hardware with a controlled experiment: barefoot the scale completed reporting
+     * 500 ohms, while standing on it through footwear it ran the same BIA phase, detected the
+     * broken circuit and completed with `status 3 (impedance failed)` and 0 ohms. A device
+     * emitting a hardcoded constant could not distinguish those two cases.
+     */
+    @Test
+    fun claims_body_composition_because_impedance_is_really_measured() {
+        val support = AiLinkBroadcastHandler().supportFor(advertisement())!!
+
+        assertThat(support.implemented).contains(DeviceCapability.BODY_COMPOSITION)
+    }
+
+    @Test
+    fun ignores_a_device_without_the_ailink_broadcast_service() {
+        // Same payload, but no F0A0: not an AiLink broadcast scale.
+        assertThat(AiLinkBroadcastHandler().supportFor(advertisement(services = emptyList())))
+            .isNull()
+    }
+
+    @Test
+    fun ignores_a_record_whose_checksum_does_not_validate() {
+        val corrupted = RECORD.copyOf().also { it[7] = (it[7] + 1).toByte() }
+
+        assertThat(
+            AiLinkBroadcastHandler()
+                .supportFor(advertisement(manufacturerData = listOf(COMPANY_ID to corrupted)))
+        ).isNull()
+    }
+
+    @Test
+    fun ignores_an_advertisement_with_no_manufacturer_data() {
+        val noMfr = ScannedDeviceInfo(
+            name = "EL1",
+            address = "0A:1B:2C:3D:4E:5F",
+            rssi = -85,
+            serviceUuids = listOf(AILINK_SERVICE),
+            manufacturerData = null,
+        )
+
+        assertThat(AiLinkBroadcastHandler().supportFor(noMfr)).isNull()
+    }
+
+    @Test
+    fun ignores_an_unrelated_vendors_record_on_the_same_service() {
+        assertThat(
+            AiLinkBroadcastHandler()
+                .supportFor(advertisement(manufacturerData = listOf(0x00FF to ByteArray(18))))
+        ).isNull()
+    }
+}

--- a/android_app/app/src/test/resources/scale_catalog_remarks.txt
+++ b/android_app/app/src/test/resources/scale_catalog_remarks.txt
@@ -17,3 +17,4 @@ Custom openScale = See [here](Custom-Bluetooth-Scale) for a tutorial
 Trisa Body Analyze 4.0 = See [Trisa Body Analyze](Trisa-Body-Analyze) for the protocol
 ProfiCare PC-PW 3008 BT = Same Chipsea "WeChat scale" firmware as the Hoffen BBS-8107, so it is driven by the same handler
 HuaweiHagridWspHandler = The scale only answers after a Huawei Hagrid handshake, so CAK, C1 and C2 (32 hex characters each) have to be entered in the device settings first
+AiLink Body Fat Scale = Non-connectable: the whole measurement is TEA-encrypted inside the advertisement, so no pairing is needed and the vendor "AiLink" app can be removed. Covers the AiLink/eLink broadcast family (advertises service 0xF0A0, often named "EL1")


### PR DESCRIPTION
## Scale

**AiLink / eLink broadcast body-fat scale family** — driven by the vendor "AiLink" app
(`com.pingwang.elink`) and sold under many private labels. The unit this was developed against
advertises as `EL1` and is retailed in Portugal as "BALANÇA BODY SMART C/ APP" (importer MCH S.A.,
model ZF3 / 7632673).

## Feature status

| Feature | Status |
|---|---|
| Weight | ✅ working, verified on hardware |
| Impedance | ✅ working, verified on hardware |
| Body composition | ✅ derived via `StandardImpedanceLib` |
| Live weight stream | ✅ consumed (only the final frame is recorded) |
| Time sync / user sync / history | ❌ n/a — the device is non-connectable |

Tested end-to-end on a Samsung SM-S928B (Android 15).

## How the scale works

It is **non-connectable**. Every attempt to open a GATT link times out; the scale instead repeats
the complete measurement inside an encrypted manufacturer record, so the handler runs in
`BROADCAST_ONLY` mode.

AiLink abuses the manufacturer-data field: the two bytes Android parses as a *company id* are
really the vendor's CID and VID, so `ScanRecord.getManufacturerSpecificData()` returns the record
already stripped of them.

```
service 0000F0A0

companyId = VID << 8 | CID
  [0]      PID
  [1..6]   MAC address, little-endian
  [7]      checksum: sum of [8..17] & 0xFF
  [8..17]  10-byte payload, TEA-encrypted
```

The payload is plain 32-round **TEA** over *only the first 8 bytes* (bytes 8–9 are passed through
untouched — the port keeps that quirk so frames match the vendor app byte for byte). The 128-bit
key is built inline from the device ids:

```
k0 = pid + 0x41493000      k2 = cid + 0x31783100
k1 = vid + 0x4C327900      k3 = 0x306C6531
```

Decrypted:

```
  [0]      rolling sequence counter
  [1]      status
  [2]      flags: bits 3..5 = weight unit, bits 1..2 = decimal places
  [3..4]   weight, big-endian; bit 7 of [3] = negative flag
  [5..6]   impedance in ohms, big-endian
  [7]      body-composition algorithm id
  [8..9]   not decrypted, meaning unverified — deliberately not decoded
```

Status values, named after the branches in the vendor app's own UI:
`0` measuring · `1` analysing · `2` impedance ready · `3` impedance failed · `4` data mode ·
`0xFF` complete.

Only the `0xFF` frame is published, once per session: the scale streams live weight while the user
settles, then latches the final frame and repeats it for as long as it stays awake.

## How it was reverse-engineered

No `btsnoop_hci.log` for this one, sorry — the scale is non-connectable, so there is no GATT
conversation to capture. The work was done from:

1. **Live BLE captures from a macOS host** (`bleak`), decoding advertisements off the air.
2. **The vendor APK**, decompiled with `jadx`: `BleValueBean.init` (advertisement framing),
   `MainModel.BroadCast` (checksum + payload slice), `BroadcastScaleDeviceData.dataCheck`
   (payload layout) and `BroadCastBodyFatMainActivity.getWeightData` (status semantics).
3. **The native library** `libAILinkBle-lib.so`, which ships with its C symbols intact
   (`encrypt_tea`, `decrypt_tea`, `get_ailink_key`, `decrypt_ailink`). Disassembling
   `Java_com_pinwang_ailinkble_AiLinkPwdUtil_decryptBroadcast` gave the key derivation above
   directly — nothing here is guessed.

## Capture evidence

Weight is redacted as `8X.X` and the MAC as `XX:XX:XX:XX:XX:XX` throughout; the encrypted payload
bytes are shown as a placeholder because this PR documents the key, which would otherwise make
them trivially decodable back to a real person's weight. Everything load-bearing — framing,
checksum, the status machine and the impedance behaviour — is intact.

Raw advertisement as received on Android:

```
03 03 A0 F0                          AD: complete 16-bit service UUIDs -> F0A0
04 09 45 4C 31                       AD: complete local name -> "EL1"
15 FF 01 03 01 XX XX XX XX XX XX BA <10 bytes encrypted>
      │  │  │  └── MAC, little-endian (redacted)
      │  │  └───── PID = 0x01
      │  └──────── CID = 0x01, VID = 0x03
      └─────────── AD type 0xFF, manufacturer specific data, len 0x15
```

Checksum check on one real frame: `sum(payload) & 0xFF == 0x5C`, matching byte [7]. ✅

A full measurement cycle, decoded live (barefoot):

```
seq= 27 status=  0 (measuring )  weight=8X.X kg  impedance=500
seq= 34 status=  0 (measuring )  weight=8X.X kg  impedance=500
seq= 35 status=  1 (analysing )  weight=8X.X kg  impedance=500
seq= 48 status=  1 (analysing )  weight=8X.X kg  impedance=500
seq= 49 status=  2 (imp-ready )  weight=8X.X kg  impedance=500
seq= 50 status=255 (COMPLETE  )  weight=8X.X kg  impedance=500
```

## The one subtlety: impedance is stale until the BIA phase ends

Worth calling out, because it is easy to misread. The impedance field **repeats the previous
measurement's value** until the scale's BIA phase finishes. Watching a single session it therefore
looks like a hardcoded constant — it is already `500` during `status 0`, before any measurement
has been taken.

It is not a constant. Controlled experiment on the same scale, minutes apart:

```
barefoot                          through footwear (BIA circuit broken)
seq= 49 status=2 imp-ready  500   seq= 75 status=  0 (measuring )  impedance=500   <- stale
seq= 50 status=255 COMPLETE 500   seq= 77 status=  3 (imp-FAILED)  impedance=  0   <- BIA ran, failed
                                  seq= 78 status=255 (COMPLETE  )  impedance=  0
```

The scale ran the same BIA phase, detected the broken circuit and reported failure. A device
emitting a hardcoded value could not distinguish those two cases.

Two rules follow, both implemented and documented in the handler:

- only ever read impedance from the `status 0xFF` frame;
- treat `0` as "the scale's BIA pass failed" — publish the weight but no body composition, rather
  than feeding a bogus `0` into `StandardImpedanceLib`.

## Notes on the implementation

- Protocol parsing lives in `AiLinkLib`, free of Android dependencies; `AiLinkBroadcastHandler` is
  the thin integration layer.
- Body composition is left to openScale's `StandardImpedanceLib` rather than porting the vendor's
  formulas.
- Bytes [8..9] of the payload are *not* decrypted by the vendor either, so their meaning is
  unverified and they are deliberately left undecoded.
- Matching is on service `0xF0A0` **plus** a manufacturer record that actually decrypts. The
  advertised name (`EL1`) is a meaningless vendor default shared by other eLink products, so it is
  not used. A checksum alone is not enough either — an all-zero record from another vendor
  satisfies it trivially — so the decrypted status byte must also be one the scale really sends.
- Unit codes other than kg (`1` jin, `6` lb, per the vendor's `UnitUtil`) were never observed on
  hardware, so the library refuses to convert them rather than guess.

## Testing

19 new unit tests (`AiLinkLibTest`, `AiLinkBroadcastHandlerTest`); full suite green (556 tests).

The library fixtures are **synthetic**: each was produced by running the protocol's own TEA
encryption over an invented reading, so they exercise the real key derivation, cipher, checksum
and parser while containing no personal health data — consistent with `ScaleCatalog`'s note that
fixtures are "built from the names and fingerprints documented in the handlers themselves, never
from personal captures".
