### PR TITLE
Fix ISO week aggregation consistency

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/data/Enums.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/data/Enums.kt
@@ -508,7 +508,7 @@ enum class AggregationLevel(@param:StringRes val displayNameResId: Int) {
             NONE,
             DAY   -> date.toString()
             WEEK  -> {
-                val wf = WeekFields.of(Locale.getDefault())
+                val wf = WeekFields.ISO
                 "${date.get(wf.weekBasedYear())}-W${date.get(wf.weekOfWeekBasedYear())}"
             }
             MONTH -> "${date.year}-${date.monthValue}"
@@ -517,10 +517,10 @@ enum class AggregationLevel(@param:StringRes val displayNameResId: Int) {
     }
 
     /**
-     * Returns a human-readable, locale-sensitive label for the period containing [timestamp].
+     * Returns a human-readable label for the period containing [timestamp].
      *
-     * Intentionally separate from [periodKey] — labels are locale-dependent and must
-     * not be used as stable identifiers.
+     * Intentionally separate from [periodKey] — labels may use locale-sensitive
+     * presentation, but [WEEK] period identity remains ISO/device-independent.
      *
      * @param calendarWeekAbbrev Localised abbreviation for "calendar week" (e.g. "CW" / "KW").
      *                           Only used for [WEEK].
@@ -538,7 +538,7 @@ enum class AggregationLevel(@param:StringRes val displayNameResId: Int) {
                 DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
             )
             WEEK  -> {
-                val wf = WeekFields.of(locale)
+                val wf = WeekFields.ISO
                 "${date.get(wf.weekBasedYear())} – $calendarWeekAbbrev ${date.get(wf.weekOfWeekBasedYear())}"
             }
             MONTH -> date.format(DateTimeFormatter.ofPattern("MMMM yyyy", locale))

--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementAggregationUseCase.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementAggregationUseCase.kt
@@ -29,7 +29,6 @@ import com.health.openscale.core.model.ValueWithDifference
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.WeekFields
-import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
@@ -83,8 +82,7 @@ class MeasurementAggregationUseCase @Inject constructor() {
             }
         }
 
-        // Hoist WeekFields outside the groupBy lambda (locale lookup is not free)
-        val weekFields = if (level == AggregationLevel.WEEK) WeekFields.of(Locale.getDefault()) else null
+        val weekFields = if (level == AggregationLevel.WEEK) WeekFields.ISO else null
 
         // Group by period key — reuses the same logic as periodKey() extension
         val grouped: Map<String, List<EnrichedMeasurement>> = measurements

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/table/TableScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/table/TableScreen.kt
@@ -406,7 +406,7 @@ fun TableScreen(
                     AggregationLevel.NONE  -> ""
                     AggregationLevel.DAY   -> dateFormatterDate.format(Date(timestamp))
                     AggregationLevel.WEEK  -> {
-                        val wf = WeekFields.of(locale)
+                        val wf = WeekFields.ISO
                         "${date.get(wf.weekBasedYear())} – $calendarWeekAbbrev ${date.get(wf.weekOfWeekBasedYear())}"
                     }
                     AggregationLevel.MONTH ->
@@ -583,7 +583,7 @@ fun TableScreen(
         val label = when {
             spanDays <= 1  -> dateFormatterDate.format(Date(drillDownStartMillis))
             spanDays <= 8  -> {
-                val wf = WeekFields.of(locale)
+                val wf = WeekFields.ISO
                 "${date.get(wf.weekBasedYear())} – $calendarWeekAbbrev ${date.get(wf.weekOfWeekBasedYear())}"
             }
             spanDays <= 32 -> date.format(DateTimeFormatter.ofPattern("MMMM yyyy", locale))

--- a/android_app/app/src/test/java/com/health/openscale/core/data/AggregationLevelTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/data/AggregationLevelTest.kt
@@ -21,12 +21,31 @@ import com.google.common.truth.Truth.assertThat
 import com.health.openscale.testutil.Fixtures.ts
 import org.junit.Test
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
+import java.util.Locale
 
 /** Tests the date-bucketing that drives day/week/month/year aggregation grouping. */
 class AggregationLevelTest {
 
     private val zone: ZoneId = ZoneId.systemDefault()
+    private val utc: ZoneId = ZoneId.of("UTC")
+
+    private fun tsUtc(year: Int, month: Int, day: Int): Long =
+        LocalDate.of(year, month, day).atStartOfDay(utc).toInstant().toEpochMilli()
+
+    private fun weekLabel(timestamp: Long, abbreviation: String, locale: Locale): String =
+        AggregationLevel.WEEK.periodLabel(timestamp, abbreviation, locale, utc)
+
+    private fun <T> withDefaultLocale(locale: Locale, block: () -> T): T {
+        val previous = Locale.getDefault()
+        Locale.setDefault(locale)
+        return try {
+            block()
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
 
     @Test
     fun periodKey_day_isIsoDate() {
@@ -41,6 +60,94 @@ class AggregationLevelTest {
     @Test
     fun periodKey_year_isYear() {
         assertThat(AggregationLevel.YEAR.periodKey(ts(2025, 4, 7), zone)).isEqualTo("2025")
+    }
+
+    @Test
+    fun periodKey_week_isLocaleIndependent() {
+        val sunday = tsUtc(2025, 4, 6)
+        val monday = tsUtc(2025, 4, 7)
+
+        val usKeys = withDefaultLocale(Locale.US) {
+            listOf(
+                AggregationLevel.WEEK.periodKey(sunday, utc),
+                AggregationLevel.WEEK.periodKey(monday, utc),
+            )
+        }
+        val germanyKeys = withDefaultLocale(Locale.GERMANY) {
+            listOf(
+                AggregationLevel.WEEK.periodKey(sunday, utc),
+                AggregationLevel.WEEK.periodKey(monday, utc),
+            )
+        }
+
+        assertThat(usKeys).containsExactly("2025-W14", "2025-W15").inOrder()
+        assertThat(germanyKeys).isEqualTo(usKeys)
+    }
+
+    @Test
+    fun periodKey_week_usesIsoWeekBasedYearAtYearBoundary() {
+        withDefaultLocale(Locale.US) {
+            assertThat(AggregationLevel.WEEK.periodKey(tsUtc(2021, 1, 1), utc))
+                .isEqualTo("2020-W53")
+        }
+    }
+
+    @Test
+    fun periodLabel_week_underUsLocale_usesIsoWeekIdentity() {
+        val sunday = tsUtc(2025, 4, 6)
+        val label = weekLabel(sunday, "CW", Locale.US)
+
+        assertThat(AggregationLevel.WEEK.periodKey(sunday, utc)).isEqualTo("2025-W14")
+        assertThat(label).contains("2025")
+        assertThat(label).contains("CW 14")
+        assertThat(label).doesNotContain("CW 15")
+    }
+
+    @Test
+    fun periodLabel_week_identityIsLocaleIndependent() {
+        val sunday = tsUtc(2025, 4, 6)
+
+        val usLabel = weekLabel(sunday, "CW", Locale.US)
+        val germanyLabel = weekLabel(sunday, "KW", Locale.GERMANY)
+
+        assertThat(usLabel).contains("2025")
+        assertThat(usLabel).contains("CW 14")
+        assertThat(germanyLabel).contains("2025")
+        assertThat(germanyLabel).contains("KW 14")
+    }
+
+    @Test
+    fun periodLabel_week_usesIsoWeekBasedYearAtYearBoundary() {
+        val monday = tsUtc(2019, 12, 30)
+        val wednesday = tsUtc(2020, 1, 1)
+
+        assertThat(AggregationLevel.WEEK.periodKey(monday, utc)).isEqualTo("2020-W1")
+        assertThat(AggregationLevel.WEEK.periodKey(wednesday, utc)).isEqualTo("2020-W1")
+        assertThat(weekLabel(monday, "CW", Locale.US)).contains("2020")
+        assertThat(weekLabel(monday, "CW", Locale.US)).contains("CW 1")
+        assertThat(weekLabel(wednesday, "CW", Locale.US)).contains("2020")
+        assertThat(weekLabel(wednesday, "CW", Locale.US)).contains("CW 1")
+    }
+
+    @Test
+    fun periodLabel_week_matchesKeyAndBounds() {
+        val cases = listOf(
+            tsUtc(2025, 4, 6) to "2025-W14",
+            tsUtc(2025, 4, 7) to "2025-W15",
+            tsUtc(2020, 1, 1) to "2020-W1",
+        )
+
+        for ((timestamp, expectedKey) in cases) {
+            val expectedWeek = expectedKey.substringAfter("-W")
+            val label = weekLabel(timestamp, "CW", Locale.US)
+            val (start, end) = AggregationLevel.WEEK.periodBounds(timestamp, utc)
+
+            assertThat(AggregationLevel.WEEK.periodKey(timestamp, utc)).isEqualTo(expectedKey)
+            assertThat(label).contains(expectedKey.substringBefore("-W"))
+            assertThat(label).contains("CW $expectedWeek")
+            assertThat(timestamp).isAtLeast(start)
+            assertThat(timestamp).isLessThan(end)
+        }
     }
 
     @Test
@@ -72,5 +179,15 @@ class AggregationLevelTest {
         assertThat(startDate.dayOfMonth).isEqualTo(1)
         assertThat(startDate.monthValue).isEqualTo(4)
         assertThat(start).isLessThan(end)
+    }
+
+    @Test
+    fun periodBounds_week_startsOnMonday() {
+        val (start, end) = AggregationLevel.WEEK.periodBounds(tsUtc(2025, 4, 6), utc)
+
+        assertThat(Instant.ofEpochMilli(start).atZone(utc).toLocalDate())
+            .isEqualTo(LocalDate.of(2025, 3, 31))
+        assertThat(Instant.ofEpochMilli(end).atZone(utc).toLocalDate())
+            .isEqualTo(LocalDate.of(2025, 4, 7))
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementAggregationUseCaseTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementAggregationUseCaseTest.kt
@@ -21,14 +21,20 @@ import com.google.common.truth.Truth.assertThat
 import com.health.openscale.core.data.AggregationLevel
 import com.health.openscale.core.data.InputFieldType
 import com.health.openscale.core.data.MeasurementTypeKey
+import com.health.openscale.core.model.AggregatedMeasurement
 import com.health.openscale.core.model.EnrichedMeasurement
 import com.health.openscale.testutil.Fixtures
 import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
 
 class MeasurementAggregationUseCaseTest {
 
     private val useCase = MeasurementAggregationUseCase()
     private val weight = Fixtures.type(id = 1, key = MeasurementTypeKey.WEIGHT)
+    private val utc: ZoneId = ZoneId.of("UTC")
 
     private fun em(measurementId: Int, timestamp: Long, weightValue: Float): EnrichedMeasurement =
         Fixtures.enriched(
@@ -38,6 +44,20 @@ class MeasurementAggregationUseCaseTest {
                 values = listOf(Fixtures.valueWithType(weight, weightValue, measurementId)),
             )
         )
+
+    private fun tsUtc(year: Int, month: Int, day: Int, hour: Int = 12): Long =
+        LocalDate.of(year, month, day).atTime(hour, 0)
+            .atZone(utc).toInstant().toEpochMilli()
+
+    private fun <T> withDefaultLocale(locale: Locale, block: () -> T): T {
+        val previous = Locale.getDefault()
+        Locale.setDefault(locale)
+        return try {
+            block()
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
 
     @Test
     fun aggregate_empty_returnsEmpty() {
@@ -80,6 +100,113 @@ class MeasurementAggregationUseCaseTest {
         val out = useCase.aggregate(input, AggregationLevel.DAY)
         assertThat(out).hasSize(2)
         assertThat(out.map { it.aggregatedFromCount }).containsExactly(1, 1)
+    }
+
+    @Test
+    fun aggregate_week_underUsLocale_separatesIsoSundayAndMonday() {
+        withDefaultLocale(Locale.US) {
+            val sunday = tsUtc(2025, 4, 6)
+            val monday = tsUtc(2025, 4, 7)
+            val input = listOf(
+                em(2, monday, 82f),
+                em(1, sunday, 80f),
+            )
+
+            val out = useCase.aggregate(input, AggregationLevel.WEEK, utc)
+
+            assertThat(out).hasSize(2)
+            assertThat(out.map { it.periodKey }).containsExactly("2025-W15", "2025-W14").inOrder()
+            assertThat(out.map { it.aggregatedFromCount }).containsExactly(1, 1).inOrder()
+            assertWeeklyBoundsContainGroupedMembers(out, input)
+        }
+    }
+
+    @Test
+    fun aggregate_week_isLocaleIndependent() {
+        val input = listOf(
+            em(3, tsUtc(2025, 4, 14), 84f),
+            em(2, tsUtc(2025, 4, 7), 82f),
+            em(1, tsUtc(2025, 4, 6), 80f),
+        )
+
+        val usPeriods = withDefaultLocale(Locale.US) {
+            useCase.aggregate(input, AggregationLevel.WEEK, utc).map { periodSnapshot(it) }
+        }
+        val germanyPeriods = withDefaultLocale(Locale.GERMANY) {
+            useCase.aggregate(input, AggregationLevel.WEEK, utc).map { periodSnapshot(it) }
+        }
+
+        assertThat(usPeriods).containsExactly(
+            PeriodSnapshot("2025-W16", 1, "2025-04-14", "2025-04-21"),
+            PeriodSnapshot("2025-W15", 1, "2025-04-07", "2025-04-14"),
+            PeriodSnapshot("2025-W14", 1, "2025-03-31", "2025-04-07"),
+        ).inOrder()
+        assertThat(germanyPeriods).isEqualTo(usPeriods)
+    }
+
+    @Test
+    fun aggregate_week_usesIsoWeekBasedYearAtYearBoundary() {
+        withDefaultLocale(Locale.US) {
+            val input = listOf(
+                em(2, tsUtc(2021, 1, 4), 82f),
+                em(1, tsUtc(2021, 1, 1), 80f),
+            )
+
+            val out = useCase.aggregate(input, AggregationLevel.WEEK, utc)
+
+            assertThat(out.map { it.periodKey }).containsExactly("2021-W1", "2020-W53").inOrder()
+            assertThat(out.map { it.aggregatedFromCount }).containsExactly(1, 1).inOrder()
+            assertWeeklyBoundsContainGroupedMembers(out, input)
+        }
+    }
+
+    @Test
+    fun aggregate_monthAndYear_groupWithoutChangingNonWeekBehaviour() {
+        val input = listOf(
+            em(3, tsUtc(2026, 1, 1), 84f),
+            em(2, tsUtc(2025, 4, 8), 82f),
+            em(1, tsUtc(2025, 4, 7), 80f),
+        )
+
+        val monthly = useCase.aggregate(input, AggregationLevel.MONTH, utc)
+        val yearly = useCase.aggregate(input, AggregationLevel.YEAR, utc)
+
+        assertThat(monthly.map { it.periodKey }).containsExactly("2026-1", "2025-4").inOrder()
+        assertThat(monthly.map { it.aggregatedFromCount }).containsExactly(1, 2).inOrder()
+        assertThat(yearly.map { it.periodKey }).containsExactly("2026", "2025").inOrder()
+        assertThat(yearly.map { it.aggregatedFromCount }).containsExactly(1, 2).inOrder()
+    }
+
+    private data class PeriodSnapshot(
+        val key: String,
+        val count: Int,
+        val startDate: String,
+        val endDate: String,
+    )
+
+    private fun periodSnapshot(period: AggregatedMeasurement): PeriodSnapshot =
+        PeriodSnapshot(
+            key = period.periodKey,
+            count = period.aggregatedFromCount,
+            startDate = Instant.ofEpochMilli(period.periodStartMillis).atZone(utc).toLocalDate().toString(),
+            endDate = Instant.ofEpochMilli(period.periodEndMillis).atZone(utc).toLocalDate().toString(),
+        )
+
+    private fun assertWeeklyBoundsContainGroupedMembers(
+        periods: List<AggregatedMeasurement>,
+        members: List<EnrichedMeasurement>,
+    ) {
+        val membersByKey = members.groupBy {
+            AggregationLevel.WEEK.periodKey(it.measurementWithValues.measurement.timestamp, utc)
+        }
+
+        for (period in periods) {
+            for (member in membersByKey.getValue(period.periodKey)) {
+                val timestamp = member.measurementWithValues.measurement.timestamp
+                assertThat(timestamp).isAtLeast(period.periodStartMillis)
+                assertThat(timestamp).isLessThan(period.periodEndMillis)
+            }
+        }
     }
 
     // --- INT-typed measurements ------------------------------------------------


### PR DESCRIPTION
Fixes #1454.

## Summary
- use `WeekFields.ISO` for WEEK aggregation and `periodKey`
- keep WEEK bounds aligned to Monday-based ISO periods
- make WEEK labels use the same ISO week identity while retaining localised presentation
- keep aggregate table WEEK labels consistent with their stored period

## Tests
- US Sunday/Monday ISO boundary regression
- US/Germany locale-independence
- ISO week-based year boundary
- key/label/bounds consistency
- aggregate member/bounds consistency

## Validation
- `./gradlew testDebugUnitTest --tests '*AggregationLevelTest'` - passed
- `./gradlew testDebugUnitTest --tests '*MeasurementAggregationUseCaseTest'` - passed
- `./gradlew testDebugUnitTest` - passed
- `./gradlew compileDebugAndroidTestKotlin` - passed
- `./gradlew assembleDebug` - passed
- `git diff --check` - passed
- `git show --check HEAD` - passed
