### PR TITLE
fix(beurer): mask bit 31 when decoding measurement timestamps

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BeurerSanitasHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/BeurerSanitasHandler.kt
@@ -637,8 +637,8 @@ class BeurerSanitasHandler : ScaleDeviceHandler() {
             // If we had deferred data and it matches the same timestamp/user, drop it
             storedMeasurement.measurementData?.let { pending ->
                 if (ru.remoteUserId == storedMeasurement.storedUid) {
-                    val tsA = ConverterUtils.fromUnsignedInt32Be(merged, 0)
-                    val tsB = ConverterUtils.fromUnsignedInt32Be(pending, 0)
+                    val tsA = decodeTimestampSeconds(merged, 0)
+                    val tsB = decodeTimestampSeconds(pending, 0)
                     if (tsA == tsB) {
                         logD("Dropping deferred data (duplicate of saved data)")
                         storedMeasurement.measurementData = null
@@ -660,7 +660,7 @@ class BeurerSanitasHandler : ScaleDeviceHandler() {
     }
 
     private fun addMeasurement(buf: ByteArray, userId: Int) {
-        val timestampMs = ConverterUtils.fromUnsignedInt32Be(buf, 0) * 1000L
+        val timestampMs = decodeTimestampSeconds(buf, 0) * 1000L
         val weight = getKiloGram(buf, 4)
         val impedance = ConverterUtils.fromUnsignedInt16Be(buf, 6)
         val fat = getPercent(buf, 8)
@@ -682,6 +682,19 @@ class BeurerSanitasHandler : ScaleDeviceHandler() {
         }
         publish(m)
     }
+
+    /**
+     * Decode a 4-byte big-endian unix timestamp from a measurement payload.
+     *
+     * Some firmwares set bit 31 of the timestamp in live [CMD_MEASUREMENT] frames while
+     * sending the same field with the bit cleared in [CMD_SAVED_MEASUREMENT] frames.
+     * Observed on a Beurer BF800-W (issue #1500): SET_TIME wrote 0x6A9290AD and the live
+     * measurement 21 s later carried 0xEA9290C2 = (0x6A9290AD + 21) or 0x80000000.
+     * Decoded unmasked, such a measurement lands ~68 years in the future (year 2094).
+     * Unix timestamps do not need bit 31 until 2038, so the flag bit is safe to mask off.
+     */
+    private fun decodeTimestampSeconds(data: ByteArray, offset: Int): Long =
+        ConverterUtils.fromUnsignedInt32Be(data, offset) and 0x7FFF_FFFFL
 
     private fun getKiloGram(data: ByteArray, offset: Int): Float {
         // Unit is 50 g


### PR DESCRIPTION
Fixes #1500

**What happens**

On my reading of the debug log in #1500 (Beurer BF800-W), the scale sets bit 31
of the timestamp in live `CMD_MEASUREMENT` frames, while `CMD_SAVED_MEASUREMENT`
frames carry the same field with the bit clear. In the reporter's session the
app wrote SET_TIME `6A 92 90 AD`, and the live measurement 21 seconds later came
back with timestamp bytes `EA 92 90 C2` — exactly `(SET_TIME + 21) | 0x80000000`.
`addMeasurement()` decodes that unmasked, so the measurement lands ~68 years in
the future ("Sep 16 2094"). The saved-measurement copy of the same session
(`6A 91 45 2A`) decodes fine, which is why the bug looks intermittent and
path-dependent. The identical "tail bytes" the reporter noticed are the second
half of the merged 22-byte record (water/muscle/bone/…), not the timestamp.

The legacy Java driver had the same unmasked decode, so this predates the
Kotlin migration; it only shows up when a measurement is delivered over the
live path.

**The change**

- `BeurerSanitasHandler`: new `decodeTimestampSeconds()` helper that masks bit
  31 of the 4-byte big-endian timestamp, with a comment documenting the observed
  firmware behaviour. Unix time doesn't need bit 31 until 2038, so this is a
  no-op for frames that don't set the flag (saved path unchanged).
- `addMeasurement()` and the duplicate-suppression timestamp comparison in
  `processMeasurementData()` use the helper.

**Testing**

New `BeurerSanitasHandlerTest` replays the session from the issue log
byte-for-byte through `handleNotification()` (same pattern as
`BodyConnectHandlerTest`): INIT-ACK → status → user list/info → saved
measurement (asserts 2026-08-28, 82.4 kg, impedance 436) → live measurement
(asserts 2026-08-29, 82.35 kg, impedance 442). The live-path test reproduces
the 2094 date on master and passes with this change. I don't own one of these
scales, so this is verified against the reporter's log rather than on hardware.
