### PR TITLE
Fix misleading plateau and volatility insights

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementInsightsUseCase.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/usecase/MeasurementInsightsUseCase.kt
@@ -54,6 +54,8 @@ class MeasurementInsightsUseCase @Inject constructor() {
         private const val SHORT_TERM_TREND_DAYS = 30L
         private const val VOLATILITY_STABLE_THRESHOLD   = 0.01f
         private const val VOLATILITY_MODERATE_THRESHOLD = 0.03f
+        private const val PLATEAU_TOTAL_CHANGE_THRESHOLD = 0.0025f
+        private const val MIN_RELATIVE_DENOMINATOR = 1e-6f
         const val CORRELATION_WINDOW_DAYS = 90L
         const val CORRELATION_MIN_MEASUREMENTS = 4
         const val PATTERN_HISTORY_WINDOWS = 5
@@ -138,11 +140,11 @@ class MeasurementInsightsUseCase @Inject constructor() {
         val minPoint = dataPoints.minBy { it.second }
         val maxPoint = dataPoints.maxBy { it.second }
 
-        // Volatility via standard deviation relative to the mean
+        // Volatility via detrended residual standard deviation relative to the mean
         val rawValues  = dataPoints.map { it.second }
         val mean       = rawValues.average().toFloat()
-        val stdDev     = stdDev(rawValues, mean)
-        val relStdDev  = if (mean != 0f) stdDev / mean else 0f
+        val stdDev     = detrendedStdDev(dataPoints)
+        val relStdDev  = if (abs(mean) > MIN_RELATIVE_DENOMINATOR) stdDev / abs(mean) else 0f
         val volatility = when {
             relStdDev < VOLATILITY_STABLE_THRESHOLD   -> Volatility.STABLE
             relStdDev < VOLATILITY_MODERATE_THRESHOLD -> Volatility.MODERATE
@@ -174,14 +176,18 @@ class MeasurementInsightsUseCase @Inject constructor() {
         ) / 30.44f
         val ratePerMonth = if (totalMonths > 0f) deltaAbs / totalMonths else 0f
 
-        // Plateau detection at the tail of the series using half the stdDev as threshold
+        // Plateau detection at the tail of the series using total change within the window.
         val (plateauDays, plateauStartDate) = run {
             if (dataPoints.size < 3) return@run null to null
-            val threshold = stdDev * 0.5f
+            val threshold = abs(mean) * PLATEAU_TOTAL_CHANGE_THRESHOLD
             if (threshold < 1e-6f) return@run null to null
             var plateauStartIndex = dataPoints.size - 1
+            var windowMin = dataPoints.last().second
+            var windowMax = dataPoints.last().second
             for (i in dataPoints.indices.reversed().drop(1)) {
-                if (abs(dataPoints[i + 1].second - dataPoints[i].second) > threshold) break
+                windowMin = minOf(windowMin, dataPoints[i].second)
+                windowMax = maxOf(windowMax, dataPoints[i].second)
+                if (windowMax - windowMin > threshold) break
                 plateauStartIndex = i
             }
             if (plateauStartIndex == dataPoints.size - 1) return@run null to null
@@ -552,5 +558,32 @@ class MeasurementInsightsUseCase @Inject constructor() {
         if (values.size < 2) return 0f
         val variance = values.sumOf { ((it - mean) * (it - mean)).toDouble() } / values.size
         return sqrt(variance).toFloat()
+    }
+
+    private fun detrendedStdDev(dataPoints: List<Pair<LocalDate, Float>>): Float {
+        if (dataPoints.size < 2) return 0f
+
+        val firstDate = dataPoints.first().first
+        val xs = dataPoints.map {
+            ChronoUnit.DAYS.between(firstDate, it.first).toFloat()
+        }
+        val xMean = xs.average().toFloat()
+        val yMean = dataPoints.map { it.second }.average().toFloat()
+        val denominator = xs.sumOf { ((it - xMean) * (it - xMean)).toDouble() }.toFloat()
+
+        if (denominator < MIN_RELATIVE_DENOMINATOR) {
+            return stdDev(dataPoints.map { it.second }, yMean)
+        }
+
+        val numerator = dataPoints.indices.sumOf { i ->
+            ((xs[i] - xMean) * (dataPoints[i].second - yMean)).toDouble()
+        }.toFloat()
+        val slope = numerator / denominator
+        val intercept = yMean - slope * xMean
+        val residuals = dataPoints.indices.map { i ->
+            dataPoints[i].second - (intercept + slope * xs[i])
+        }
+        val residualMean = residuals.average().toFloat()
+        return stdDev(residuals, residualMean)
     }
 }

--- a/android_app/app/src/main/java/com/health/openscale/ui/screen/insights/InsightsScreen.kt
+++ b/android_app/app/src/main/java/com/health/openscale/ui/screen/insights/InsightsScreen.kt
@@ -442,10 +442,8 @@ private fun MeasurementAnalysisCard(analysis: MeasurementAnalysis) {
 
         // ── Summary ───────────────────────────────────────────────────
         val summary: String? = when {
-            analysis.plateauDays != null &&
-                    analysis.plateauDays > 14 &&
-                    java.time.temporal.ChronoUnit.DAYS.between(analysis.lastMeasuredOn, LocalDate.now()) <= 7 ->
-                stringResource(R.string.insights_summary_plateau, analysis.plateauDays)
+            analysis.shouldShowPlateauSummary() ->
+                stringResource(R.string.insights_summary_plateau, analysis.plateauDays ?: 0)
 
             analysis.shortTermTrend != analysis.longTermTrend && analysis.longTermTrend != TrendDirection.STABLE -> when (analysis.shortTermTrend) {
                 TrendDirection.DOWN   -> stringResource(R.string.insights_summary_trend_change_down)
@@ -465,6 +463,12 @@ private fun MeasurementAnalysisCard(analysis: MeasurementAnalysis) {
         summary?.let { InsightSummaryText(it) }
     }
 }
+
+internal fun MeasurementAnalysis.shouldShowPlateauSummary(today: LocalDate = LocalDate.now()): Boolean =
+    plateauDays != null &&
+            plateauDays > 14 &&
+            longTermTrend == TrendDirection.STABLE &&
+            java.time.temporal.ChronoUnit.DAYS.between(lastMeasuredOn, today) <= 7
 
 // ---------------------------------------------------------------------------
 // ShiftStatTile

--- a/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementInsightsUseCaseTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/usecase/MeasurementInsightsUseCaseTest.kt
@@ -21,7 +21,10 @@ import com.google.common.truth.Truth.assertThat
 import com.health.openscale.core.data.MeasurementType
 import com.health.openscale.core.model.MeasurementWithValues
 import com.health.openscale.core.model.TrendDirection
+import com.health.openscale.core.model.Volatility
 import com.health.openscale.testutil.Fixtures
+import java.time.LocalDate
+import java.time.ZoneId
 import org.junit.Test
 
 /**
@@ -43,6 +46,25 @@ class MeasurementInsightsUseCaseTest {
 
     private fun risingSeries(): List<MeasurementWithValues> =
         listOf(m(1, 70f), m(2, 71f), m(3, 72f), m(4, 73f), m(5, 74f), m(6, 75f))
+
+    private fun m(date: LocalDate, measurementId: Int, value: Float): MeasurementWithValues =
+        Fixtures.mwv(
+            measurementId = measurementId,
+            timestamp = date.atTime(12, 0).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            values = listOf(Fixtures.valueWithType(weight, value, measurementId)),
+        )
+
+    private fun dailySeries(
+        start: LocalDate,
+        count: Int,
+        valueForDay: (Int) -> Float,
+    ): List<MeasurementWithValues> =
+        (0 until count).map { day ->
+            m(start.plusDays(day.toLong()), day + 1, valueForDay(day))
+        }
+
+    private fun analysisFor(measurements: List<MeasurementWithValues>) =
+        useCase.compute(measurements, primaryTypeId = weight.id).measurementAnalysis!!
 
     @Test
     fun compute_emptyInput_returnsEmptyInsight() {
@@ -94,5 +116,114 @@ class MeasurementInsightsUseCaseTest {
 
         assertThat(insight.basedOnCount).isEqualTo(series.size)
         assertThat(insight.measurementAnalysis).isNotNull()
+    }
+
+    @Test
+    fun compute_smoothStrongDownwardTrend_doesNotReportLongPlateauOrHighVolatility() {
+        val start = LocalDate.of(2025, 1, 1)
+        val measurements = dailySeries(start, count = 181) { day ->
+            100f - 22f * day / 180f
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.DOWN)
+        assertThat(analysis.plateauDays ?: 0).isLessThan(14)
+        assertThat(analysis.volatility).isEqualTo(Volatility.STABLE)
+    }
+
+    @Test
+    fun compute_smoothStrongUpwardTrend_doesNotReportHighVolatilityFromTrendSpan() {
+        val start = LocalDate.of(2025, 1, 1)
+        val measurements = dailySeries(start, count = 181) { day ->
+            78f + 22f * day / 180f
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.UP)
+        assertThat(analysis.plateauDays ?: 0).isLessThan(14)
+        assertThat(analysis.volatility).isEqualTo(Volatility.STABLE)
+    }
+
+    @Test
+    fun compute_stableSeries_stillDetectsPlateau() {
+        val start = LocalDate.of(2025, 2, 1)
+        val measurements = dailySeries(start, count = 30) { day ->
+            if (day % 2 == 0) 80f else 80.05f
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.STABLE)
+        assertThat(analysis.plateauDays).isAtLeast(28)
+        assertThat(analysis.plateauStartDate).isEqualTo(start)
+    }
+
+    @Test
+    fun compute_flatNoisySeries_reportsHighVolatility() {
+        val start = LocalDate.of(2025, 3, 1)
+        val measurements = dailySeries(start, count = 40) { day ->
+            if (day % 2 == 0) 77f else 83f
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.STABLE)
+        assertThat(analysis.volatility).isEqualTo(Volatility.HIGH)
+    }
+
+    @Test
+    fun compute_trendingNoisySeries_reportsResidualVolatilityFromScatter() {
+        val start = LocalDate.of(2025, 3, 1)
+        val measurements = dailySeries(start, count = 60) { day ->
+            100f - 0.1f * day + if (day % 2 == 0) -1.5f else 1.5f
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.DOWN)
+        assertThat(analysis.volatility).isEqualTo(Volatility.MODERATE)
+    }
+
+    @Test
+    fun compute_slowPersistentDrift_doesNotBecomeLongPlateau() {
+        val measurements = dailySeries(LocalDate.of(2025, 4, 1), count = 60) { day ->
+            80f - 0.02f * day
+        }
+
+        val analysis = analysisFor(measurements)
+
+        assertThat(analysis.longTermTrend).isEqualTo(TrendDirection.DOWN)
+        assertThat(analysis.plateauDays ?: 0).isLessThan(14)
+    }
+
+    @Test
+    fun compute_plateauWindowUsesTotalChangeThresholdBoundary() {
+        val start = LocalDate.of(2025, 5, 1)
+        val withinThreshold = dailySeries(start, count = 20) { day ->
+            if (day == 0) 100f else 100.24f
+        }
+        val outsideThreshold = dailySeries(start, count = 20) { day ->
+            if (day == 0) 99.7f else 100f
+        }
+
+        val inside = analysisFor(withinThreshold)
+        val outside = analysisFor(outsideThreshold)
+
+        assertThat(inside.plateauStartDate).isEqualTo(start)
+        assertThat(outside.plateauStartDate).isEqualTo(start.plusDays(1))
+    }
+
+    @Test
+    fun compute_shortDatasetReturnsEmptyAnalysis() {
+        val measurements = dailySeries(LocalDate.of(2025, 6, 1), count = 2) { day ->
+            80f + day
+        }
+
+        val insight = useCase.compute(measurements, primaryTypeId = weight.id)
+
+        assertThat(insight.measurementAnalysis).isNull()
+        assertThat(insight.basedOnCount).isEqualTo(2)
     }
 }

--- a/android_app/app/src/test/java/com/health/openscale/ui/screen/insights/InsightsScreenTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/ui/screen/insights/InsightsScreenTest.kt
@@ -1,0 +1,75 @@
+/*
+ * openScale
+ * Copyright (C) 2025 olie.xdev <olie.xdeveloper@googlemail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.ui.screen.insights
+
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.core.data.MeasurementType
+import com.health.openscale.core.model.InsightConfidence
+import com.health.openscale.core.model.MeasurementAnalysis
+import com.health.openscale.core.model.TrendDirection
+import com.health.openscale.core.model.Volatility
+import com.health.openscale.testutil.Fixtures
+import java.time.LocalDate
+import org.junit.Test
+
+class InsightsScreenTest {
+
+    private val weight = Fixtures.type(id = 1, identity = MeasurementType.WEIGHT.identity)
+
+    private fun analysis(
+        longTermTrend: TrendDirection,
+        plateauDays: Int? = 21,
+        lastMeasuredOn: LocalDate = LocalDate.of(2025, 6, 30),
+    ) = MeasurementAnalysis(
+        type = weight,
+        firstValue = 80f,
+        lastValue = 80f,
+        deltaAbsolute = 0f,
+        deltaPercent = 0f,
+        minValue = 80f,
+        minValueDate = lastMeasuredOn.minusDays(plateauDays?.toLong() ?: 0L),
+        maxValue = 80f,
+        maxValueDate = lastMeasuredOn,
+        volatility = Volatility.STABLE,
+        shortTermTrend = TrendDirection.STABLE,
+        longTermTrend = longTermTrend,
+        ratePerMonth = 0f,
+        plateauDays = plateauDays,
+        plateauStartDate = plateauDays?.let { lastMeasuredOn.minusDays(it.toLong()) },
+        bestPeriodStart = null,
+        bestPeriodDelta = null,
+        firstMeasuredOn = lastMeasuredOn.minusDays(plateauDays?.toLong() ?: 0L),
+        lastMeasuredOn = lastMeasuredOn,
+        confidence = InsightConfidence.HIGH,
+    )
+
+    @Test
+    fun shouldShowPlateauSummary_suppressesWhenLongTermTrendIsNotStable() {
+        val today = LocalDate.of(2025, 7, 1)
+
+        assertThat(analysis(TrendDirection.DOWN).shouldShowPlateauSummary(today)).isFalse()
+        assertThat(analysis(TrendDirection.UP).shouldShowPlateauSummary(today)).isFalse()
+    }
+
+    @Test
+    fun shouldShowPlateauSummary_allowsRecentStablePlateau() {
+        val today = LocalDate.of(2025, 7, 1)
+
+        assertThat(analysis(TrendDirection.STABLE).shouldShowPlateauSummary(today)).isTrue()
+    }
+}


### PR DESCRIPTION
Fixes #1453

## Problem

The Insights card can describe a smooth long-term weight trend as both volatile and a long plateau because plateau and volatility are derived from spread across a trending series.

## Implementation

- Detect plateaus using a trailing window-based total-change criterion.
- Measure volatility from residuals after removing a linear trend.
- Suppress the plateau summary unless the long-term trend is stable.

## Scope

This intentionally includes only the maintainer-approved plateau, residual-volatility, and summary-guard changes.

The related findings around weekday patterns, anomaly detection, short-term trend windows, best-month normalization, rate-per-month minimum span, plateauStartDate null consistency, and Turkish chip truncation are intentionally left out to keep the diff minimal.

## Tests

Added focused regressions for smooth upward/downward trends, true plateaus, noisy flat and trending data, slow drift, threshold boundaries, short datasets, and the plateau-summary guard.

## Validation

- `./gradlew testDebugUnitTest` — PASS
- `./gradlew compileDebugAndroidTestKotlin` — PASS
- `./gradlew assembleDebug` — PASS
- `git diff --check` — PASS