### PR TITLE
fix: support alternate manufacturer ID for Sinocare CW286

### DIFF
--- a/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SinocareHandler.kt
+++ b/android_app/app/src/main/java/com/health/openscale/core/bluetooth/scales/SinocareHandler.kt
@@ -34,7 +34,7 @@ import com.health.openscale.core.data.Kg
  * in manufacturer data advertisements. No GATT connection is used.
  *
  * Frame notes (derived from legacy implementation):
- * - Manufacturer ID: 0xFF64
+ * - Manufacturer ID observerd: 0xFF64 and 0x0000
  * - Manufacturer data length must be > 16
  * - Checksum: XOR of bytes [6..15] (inclusive) must equal data[16]
  * - Weight: 16-bit: MSB at index 10, LSB at index 9; unit = kg/100
@@ -49,6 +49,7 @@ class SinocareHandler : ScaleDeviceHandler() {
         private const val TAG = "SinocareHandler"
 
         private const val MANUFACTURER_DATA_ID = 0xFF64
+        private const val MANUFACTURER_DATA_ID_ALT = 0x0000
         private const val WEIGHT_MSB = 10
         private const val WEIGHT_LSB = 9
         private const val CHECKSUM_INDEX = 16
@@ -80,7 +81,7 @@ class SinocareHandler : ScaleDeviceHandler() {
      */
     override fun onAdvertisement(result: ScanResult, user: ScaleUser): BroadcastAction {
         val msd: SparseArray<ByteArray> = result.scanRecord?.manufacturerSpecificData ?: return BroadcastAction.IGNORED
-        val data = msd.get(MANUFACTURER_DATA_ID) ?: return BroadcastAction.IGNORED
+        val data = msd.get(MANUFACTURER_DATA_ID) ?: msd.get(MANUFACTURER_DATA_ID_ALT) ?: return BroadcastAction.IGNORED
 
         // Sanity: need at least up to checksum index
         if (data.size <= CHECKSUM_INDEX) return BroadcastAction.IGNORED

--- a/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/SinocareHandlerTest.kt
+++ b/android_app/app/src/test/java/com/health/openscale/core/bluetooth/scales/SinocareHandlerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * openScale
+ * Copyright (C) 2026 openScale contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.health.openscale.core.bluetooth.scales
+
+import android.bluetooth.le.ScanRecord
+import android.bluetooth.le.ScanResult
+import com.google.common.truth.Truth.assertThat
+import com.health.openscale.core.bluetooth.data.ScaleUser
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowBluetoothDevice
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SinocareHandlerTest {
+    @Test
+    @Suppress("DEPRECATION")
+    fun `accepts CW286 advertisement using alternate manufacturer id`() {
+        // Captured CW286 manufacturer payload, wrapped in an AD structure (14 FF 00 00).
+        // Payload bytes 0..5: address zeroed, outside the checksum range.
+        // Bytes 9..10: 06 1D -> 7430 -> 74.30 kg; XOR of bytes 6..15: D4 (byte 16).
+        val advertisement = "14FF0000000000000000CE0000061D0000000001D4"
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        // Android's parser is hidden from the public SDK.
+        val parseMethod = ScanRecord::class.java.getDeclaredMethod("parseFromBytes", ByteArray::class.java)
+        parseMethod.isAccessible = true
+        val record = parseMethod.invoke(null, advertisement) as ScanRecord
+        val result = ScanResult(ShadowBluetoothDevice.newInstance("00:11:22:33:44:55"), record, -50, 0L)
+        val handler = SinocareHandler()
+        val user = ScaleUser()
+
+        // Nine identical readings are required for a stable measurement.
+        repeat(8) {
+            assertThat(handler.onAdvertisement(result, user))
+                .isEqualTo(BroadcastAction.CONSUMED_KEEP_SCANNING)
+        }
+        assertThat(handler.onAdvertisement(result, user)).isEqualTo(BroadcastAction.CONSUMED_STOP)
+    }
+}


### PR DESCRIPTION
## Summary

Fix Sinocare CW286 broadcast handling for devices that expose the Sinocare
manufacturer payload under manufacturer ID `0x0000` instead of `0xFF64`.

The device is already identified by the advertised name `Weight Scale`, but
`SinocareHandler.onAdvertisement()` previously only looked up manufacturer
data under `0xFF64`, causing these advertisements to be ignored.

The handler now tries `0xFF64` first and falls back to `0x0000`.

Device detection is intentionally unchanged, so `0x0000` alone is not used as
a Sinocare fingerprint.

## Testing

- Added a regression test using a sanitized advertisement captured from a
  physical Sinocare CW286.
- The captured frame decodes as 74.30 kg and reaches the existing stability
  threshold.
- Verified successfully on a physical CW286 using the debug APK.
- `assembleDebug` succeeds.